### PR TITLE
Protocol fee switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "factory"
+version = "0.1.0"
+dependencies = [
+ "amm",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "contracts/amm",
   "contracts/token",
+  "contracts/factory",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ A constant-product Automated Market Maker (AMM) built as a Soroban smart contrac
 - [Contracts](#contracts)
   - [AMM Pool Contract](#amm-pool-contract)
   - [LP Token Contract](#lp-token-contract)
+  - [Factory Contract](#factory-contract)
 - [Math & Formulas](#math--formulas)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Build](#build)
   - [Test](#test)
 - [Usage](#usage)
-  - [Deploy](#deploy)
+  - [Deploy via Factory](#deploy-via-factory)
+  - [Deploy Manually](#deploy-manually)
   - [Add Liquidity](#add-liquidity)
   - [Swap Tokens](#swap-tokens)
   - [Remove Liquidity](#remove-liquidity)
@@ -49,11 +51,13 @@ soroban-amm/
 └── contracts/
     ├── amm/                    # Core AMM pool contract
     │   └── src/lib.rs
-    └── token/                  # SEP-41 LP token contract
+    ├── token/                  # SEP-41 LP token contract
+    │   └── src/lib.rs
+    └── factory/                # Pool factory contract
         └── src/lib.rs
 ```
 
-The AMM contract depends on the token contract. When liquidity is added or removed, the AMM calls the LP token contract to mint or burn shares on behalf of the provider.
+The AMM contract depends on the token contract. When liquidity is added or removed, the AMM calls the LP token contract to mint or burn shares on behalf of the provider. The factory contract depends on both AMM and token: it deploys and initialises them as a pair when a new pool is created.
 
 ---
 
@@ -87,6 +91,40 @@ Located in [contracts/amm/src/lib.rs](contracts/amm/src/lib.rs).
 | `get_amount_out(token_in, amount_in) → amount_out` | Quote a swap without executing it |
 | `get_info() → PoolInfo` | Read pool state (reserves, fee, shares) |
 | `shares_of(provider) → shares` | Read an LP's share balance |
+
+### Factory Contract
+
+Located in [contracts/factory/src/lib.rs](contracts/factory/src/lib.rs).
+
+A single-entry-point contract for creating and discovering AMM pools. The factory deploys a new AMM pool and its paired LP token in one transaction, enforces uniqueness per token pair, and maintains a registry of all pools it has deployed.
+
+#### Storage
+
+| Key | Type | Description |
+|---|---|---|
+| `Admin` | `Address` | Factory administrator; set as AMM fee recipient |
+| `AmmWasmHash` | `BytesN<32>` | WASM hash of the AMM pool contract |
+| `TokenWasmHash` | `BytesN<32>` | WASM hash of the LP token contract |
+| `Pool(Address, Address)` | `Address` | Normalised token pair → pool address |
+| `AllPools` | `Vec<Address>` | Ordered list of all deployed pool addresses |
+| `PoolCount` | `u64` | Monotonic counter used to derive deploy salts |
+
+#### Public Interface
+
+| Function | Description |
+|---|---|
+| `initialize(admin, amm_wasm_hash, token_wasm_hash)` | One-time factory setup |
+| `create_pool(token_a, token_b, fee_bps) → Address` | Deploy a new AMM + LP token pair; panics on duplicate |
+| `get_pool(token_a, token_b) → Option<Address>` | Look up an existing pool (order-independent) |
+| `all_pools() → Vec<Address>` | List every pool deployed by this factory |
+
+#### Notes
+
+- Token pair order is **normalised** at creation time (smaller address stored first). `get_pool` accepts either order.
+- `create_pool` panics with `"pool already exists"` if a pool for the pair is already registered.
+- The factory admin is set as the AMM's `fee_recipient`; protocol fees start at 0 bps and can be enabled later.
+
+---
 
 ### LP Token Contract
 
@@ -245,19 +283,96 @@ target/wasm32-unknown-unknown/release/token.wasm
 
 ### Test
 
-Run the full test suite:
+The AMM and token contract tests run without pre-built WASM:
 
 ```sh
-cargo test
+cargo test -p amm -p token
 ```
 
-Tests are located in [contracts/amm/src/lib.rs](contracts/amm/src/lib.rs) and cover adding liquidity, swapping, and removing liquidity.
+The factory tests embed compiled WASM at compile time, so build WASM first:
+
+```sh
+cargo build --release --target wasm32-unknown-unknown
+cargo test -p factory
+```
+
+Or run the full suite in one go:
+
+```sh
+cargo build --release --target wasm32-unknown-unknown && cargo test
+```
 
 ---
 
 ## Usage
 
-### Deploy
+### Deploy via Factory
+
+The factory is the recommended way to create pools. It deploys and initialises the AMM pool and its LP token in a single transaction, and registers the pool in its on-chain registry.
+
+**1. Upload the contract WASM blobs:**
+
+```sh
+stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/amm.wasm \
+  --network testnet --source <YOUR_KEY>
+# → prints AMM_WASM_HASH
+
+stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/token.wasm \
+  --network testnet --source <YOUR_KEY>
+# → prints TOKEN_WASM_HASH
+```
+
+**2. Deploy the factory:**
+
+```sh
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/factory.wasm \
+  --network testnet --source <YOUR_KEY>
+# → prints FACTORY_CONTRACT_ID
+```
+
+**3. Initialise the factory:**
+
+```sh
+stellar contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  --network testnet --source <YOUR_KEY> \
+  -- initialize \
+  --admin <YOUR_ADDRESS> \
+  --amm_wasm_hash <AMM_WASM_HASH> \
+  --token_wasm_hash <TOKEN_WASM_HASH>
+```
+
+**4. Create a pool (deploys AMM + LP token, registers the pair):**
+
+```sh
+stellar contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  --network testnet --source <YOUR_KEY> \
+  -- create_pool \
+  --token_a <TOKEN_A_CONTRACT_ID> \
+  --token_b <TOKEN_B_CONTRACT_ID> \
+  --fee_bps 30
+# → prints the new POOL_CONTRACT_ID
+```
+
+**5. Look up an existing pool:**
+
+```sh
+stellar contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  -- get_pool \
+  --token_a <TOKEN_A_CONTRACT_ID> \
+  --token_b <TOKEN_B_CONTRACT_ID>
+
+stellar contract invoke --id <FACTORY_CONTRACT_ID> -- all_pools
+```
+
+---
+
+### Deploy Manually
 
 Deploy the LP token contract first, then the AMM pool. The AMM contract address becomes the LP token's admin.
 
@@ -300,7 +415,9 @@ stellar contract invoke \
   --token_a <TOKEN_A_CONTRACT_ID> \
   --token_b <TOKEN_B_CONTRACT_ID> \
   --lp_token <LP_TOKEN_CONTRACT_ID> \
-  --fee_bps 30
+  --fee_bps 30 \
+  --fee_recipient <FEE_RECIPIENT_ADDRESS> \
+  --protocol_fee_bps 0
 ```
 
 ### Add Liquidity

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -28,7 +28,11 @@ pub enum DataKey {
     ReserveB,
     TotalShares,
     Shares(Address),
-    FeeBps, // fee in basis points, e.g. 30 = 0.30 %
+    FeeBps,          // swap fee in basis points, e.g. 30 = 0.30 %
+    FeeRecipient,    // Address — receives accrued protocol fees
+    ProtocolFeeBps,  // i128 — protocol fee bps (subset of FeeBps going to protocol)
+    AccruedFeeA,     // i128 — protocol fees accrued in TokenA
+    AccruedFeeB,     // i128 — protocol fees accrued in TokenB
 }
 
 // ── Pool info returned by `get_info` ─────────────────────────────────────────
@@ -55,26 +59,38 @@ impl AmmPool {
     /// Initialize the pool.
     ///
     /// `lp_token` must already be deployed and its admin set to this contract.
+    /// `fee_recipient` receives accrued protocol fees via `withdraw_protocol_fees`.
+    /// `protocol_fee_bps` must be ≤ `fee_bps`; set to 0 to disable protocol fees.
     pub fn initialize(
         env: Env,
         token_a: Address,
         token_b: Address,
         lp_token: Address,
         fee_bps: i128, // recommended: 30 (0.30 %)
+        fee_recipient: Address,
+        protocol_fee_bps: i128,
     ) {
         if env.storage().instance().has(&DataKey::TokenA) {
             panic!("already initialized");
         }
         assert!(token_a != token_b, "tokens must differ");
         assert!(fee_bps >= 0 && fee_bps <= 10_000, "invalid fee");
+        assert!(
+            protocol_fee_bps >= 0 && protocol_fee_bps <= fee_bps,
+            "invalid protocol fee"
+        );
 
         env.storage().instance().set(&DataKey::TokenA, &token_a);
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::LpToken, &lp_token);
         env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
+        env.storage().instance().set(&DataKey::FeeRecipient, &fee_recipient);
+        env.storage().instance().set(&DataKey::ProtocolFeeBps, &protocol_fee_bps);
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
         env.storage().instance().set(&DataKey::TotalShares, &0_i128);
+        env.storage().instance().set(&DataKey::AccruedFeeA, &0_i128);
+        env.storage().instance().set(&DataKey::AccruedFeeB, &0_i128);
     }
 
     // ── Liquidity ─────────────────────────────────────────────────────────────
@@ -215,6 +231,7 @@ impl AmmPool {
     /// Swap an exact `amount_in` of `token_in` for at least `min_out` of the other token.
     ///
     /// Uses the constant-product formula with fee deducted from `amount_in`.
+    /// The `protocol_fee_bps` portion of `amount_in` is held for `withdraw_protocol_fees`.
     pub fn swap(
         env: Env,
         trader: Address,
@@ -257,21 +274,44 @@ impl AmmPool {
         let client_out = SepTokenClient::new(&env, &token_out);
         client_out.transfer(&env.current_contract_address(), &trader, &amount_out);
 
-        // Update reserves.
+        // Separate protocol fee from LP reserves.
+        let protocol_fee_bps: i128 =
+            env.storage().instance().get(&DataKey::ProtocolFeeBps).unwrap_or(0);
+        let protocol_fee = if protocol_fee_bps > 0 {
+            amount_in * protocol_fee_bps / 10_000
+        } else {
+            0
+        };
+
+        // Update reserves (protocol fee held outside LP reserves).
         if token_in == token_a {
             env.storage()
                 .instance()
-                .set(&DataKey::ReserveA, &(reserve_in + amount_in));
+                .set(&DataKey::ReserveA, &(reserve_in + amount_in - protocol_fee));
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveB, &(reserve_out - amount_out));
+            if protocol_fee > 0 {
+                let accrued: i128 =
+                    env.storage().instance().get(&DataKey::AccruedFeeA).unwrap_or(0);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::AccruedFeeA, &(accrued + protocol_fee));
+            }
         } else {
             env.storage()
                 .instance()
-                .set(&DataKey::ReserveB, &(reserve_in + amount_in));
+                .set(&DataKey::ReserveB, &(reserve_in + amount_in - protocol_fee));
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveA, &(reserve_out - amount_out));
+            if protocol_fee > 0 {
+                let accrued: i128 =
+                    env.storage().instance().get(&DataKey::AccruedFeeB).unwrap_or(0);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::AccruedFeeB, &(accrued + protocol_fee));
+            }
         }
 
         env.events().publish(
@@ -280,6 +320,44 @@ impl AmmPool {
         );
 
         amount_out
+    }
+
+    // ── Protocol Fees ─────────────────────────────────────────────────────────
+
+    /// Withdraw all accrued protocol fees to the configured fee recipient.
+    ///
+    /// Only callable by the fee recipient. Resets accrued balances to zero.
+    /// Returns `(fee_a_withdrawn, fee_b_withdrawn)`.
+    pub fn withdraw_protocol_fees(env: Env) -> (i128, i128) {
+        let fee_recipient: Address =
+            env.storage().instance().get(&DataKey::FeeRecipient).unwrap();
+        fee_recipient.require_auth();
+
+        let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
+        let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
+
+        let fee_a: i128 = env.storage().instance().get(&DataKey::AccruedFeeA).unwrap_or(0);
+        let fee_b: i128 = env.storage().instance().get(&DataKey::AccruedFeeB).unwrap_or(0);
+
+        if fee_a > 0 {
+            SepTokenClient::new(&env, &token_a).transfer(
+                &env.current_contract_address(),
+                &fee_recipient,
+                &fee_a,
+            );
+            env.storage().instance().set(&DataKey::AccruedFeeA, &0_i128);
+        }
+
+        if fee_b > 0 {
+            SepTokenClient::new(&env, &token_b).transfer(
+                &env.current_contract_address(),
+                &fee_recipient,
+                &fee_b,
+            );
+            env.storage().instance().set(&DataKey::AccruedFeeB, &0_i128);
+        }
+
+        (fee_a, fee_b)
     }
 
     // ── Quotes (read-only) ────────────────────────────────────────────────────
@@ -394,7 +472,7 @@ mod tests {
             &7u32,
         );
 
-        (env, admin, amm_addr, lp_addr, admin)
+        (env, admin.clone(), amm_addr, lp_addr, admin)
     }
 
     #[test]
@@ -406,7 +484,14 @@ mod tests {
         let (tb_client, tb_sac) = create_sac(&env, &admin);
 
         let amm = AmmPoolClient::new(&env, &amm_addr);
-        amm.initialize(&ta_client.address, &tb_client.address, &lp_addr, &30_i128);
+        amm.initialize(
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &0_i128,
+        );
 
         // Mint tokens to provider
         let provider = Address::generate(&env);
@@ -438,7 +523,14 @@ mod tests {
         let (tb_client, tb_sac) = create_sac(&env, &admin);
 
         let amm = AmmPoolClient::new(&env, &amm_addr);
-        amm.initialize(&ta_client.address, &tb_client.address, &lp_addr, &30_i128);
+        amm.initialize(
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &0_i128,
+        );
 
         let provider = Address::generate(&env);
         ta_sac.mint(&provider, &1_000_000_i128);
@@ -451,5 +543,115 @@ mod tests {
 
         let info = amm.get_info();
         assert_eq!(info.total_shares, 0);
+    }
+
+    #[test]
+    fn test_protocol_fee_accrual() {
+        let (env, admin, amm_addr, lp_addr, _) = setup();
+
+        let (ta_client, ta_sac) = create_sac(&env, &admin);
+        let (tb_client, tb_sac) = create_sac(&env, &admin);
+
+        let amm = AmmPoolClient::new(&env, &amm_addr);
+        // fee_bps=30, protocol_fee_bps=5
+        amm.initialize(
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &5_i128,
+        );
+
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        amm.add_liquidity(&provider, &1_000_000_i128, &1_000_000_i128, &0_i128);
+
+        let trader = Address::generate(&env);
+        ta_sac.mint(&trader, &200_000_i128);
+
+        // Two swaps of 100_000 A each — protocol fee per swap = 100_000 * 5 / 10_000 = 50
+        amm.swap(&trader, &ta_client.address, &100_000_i128, &0_i128);
+        amm.swap(&trader, &ta_client.address, &100_000_i128, &0_i128);
+
+        let admin_bal_before = ta_client.balance(&admin);
+        let (withdrawn_a, withdrawn_b) = amm.withdraw_protocol_fees();
+        let admin_bal_after = ta_client.balance(&admin);
+
+        assert_eq!(withdrawn_a, 100_i128); // 50 + 50
+        assert_eq!(withdrawn_b, 0_i128);
+        assert_eq!(admin_bal_after - admin_bal_before, 100_i128);
+    }
+
+    #[test]
+    fn test_withdraw_resets_accrued() {
+        let (env, admin, amm_addr, lp_addr, _) = setup();
+
+        let (ta_client, ta_sac) = create_sac(&env, &admin);
+        let (tb_client, tb_sac) = create_sac(&env, &admin);
+
+        let amm = AmmPoolClient::new(&env, &amm_addr);
+        amm.initialize(
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &5_i128,
+        );
+
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        amm.add_liquidity(&provider, &1_000_000_i128, &1_000_000_i128, &0_i128);
+
+        let trader = Address::generate(&env);
+        ta_sac.mint(&trader, &100_000_i128);
+        amm.swap(&trader, &ta_client.address, &100_000_i128, &0_i128);
+
+        // First withdrawal collects accrued fees.
+        let (w1_a, _) = amm.withdraw_protocol_fees();
+        assert!(w1_a > 0);
+
+        // Second withdrawal: accrued balances were reset to zero.
+        let (w2_a, w2_b) = amm.withdraw_protocol_fees();
+        assert_eq!(w2_a, 0_i128);
+        assert_eq!(w2_b, 0_i128);
+    }
+
+    #[test]
+    fn test_reaccrual_after_withdrawal() {
+        let (env, admin, amm_addr, lp_addr, _) = setup();
+
+        let (ta_client, ta_sac) = create_sac(&env, &admin);
+        let (tb_client, tb_sac) = create_sac(&env, &admin);
+
+        let amm = AmmPoolClient::new(&env, &amm_addr);
+        amm.initialize(
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &5_i128,
+        );
+
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        amm.add_liquidity(&provider, &1_000_000_i128, &1_000_000_i128, &0_i128);
+
+        let trader = Address::generate(&env);
+        ta_sac.mint(&trader, &200_000_i128);
+
+        // Swap → withdraw → swap again → withdraw: fees re-accrue after reset.
+        amm.swap(&trader, &ta_client.address, &100_000_i128, &0_i128);
+        let (w1, _) = amm.withdraw_protocol_fees();
+        assert!(w1 > 0);
+
+        amm.swap(&trader, &ta_client.address, &100_000_i128, &0_i128);
+        let (w2, _) = amm.withdraw_protocol_fees();
+        assert!(w2 > 0);
     }
 }

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DataKey {
     TotalShares,
     Shares(Address),
     FeeBps,          // swap fee in basis points, e.g. 30 = 0.30 %
+    Admin,           // Address — contract administrator; authorises set_protocol_fee
     FeeRecipient,    // Address — receives accrued protocol fees
     ProtocolFeeBps,  // i128 — protocol fee bps (subset of FeeBps going to protocol)
     AccruedFeeA,     // i128 — protocol fees accrued in TokenA
@@ -59,10 +60,13 @@ impl AmmPool {
     /// Initialize the pool.
     ///
     /// `lp_token` must already be deployed and its admin set to this contract.
+    /// `admin` is stored as the contract administrator and is the only address
+    /// permitted to call `set_protocol_fee` after deployment.
     /// `fee_recipient` receives accrued protocol fees via `withdraw_protocol_fees`.
     /// `protocol_fee_bps` must be ≤ `fee_bps`; set to 0 to disable protocol fees.
     pub fn initialize(
         env: Env,
+        admin: Address,
         token_a: Address,
         token_b: Address,
         lp_token: Address,
@@ -80,6 +84,7 @@ impl AmmPool {
             "invalid protocol fee"
         );
 
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TokenA, &token_a);
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::LpToken, &lp_token);
@@ -91,6 +96,39 @@ impl AmmPool {
         env.storage().instance().set(&DataKey::TotalShares, &0_i128);
         env.storage().instance().set(&DataKey::AccruedFeeA, &0_i128);
         env.storage().instance().set(&DataKey::AccruedFeeB, &0_i128);
+    }
+
+    /// Update the protocol fee configuration. Admin-only.
+    ///
+    /// Set `protocol_fee_bps` to 0 to disable protocol fee collection.
+    /// `protocol_fee_bps` must be ≤ the pool's `fee_bps`.
+    pub fn set_protocol_fee(
+        env: Env,
+        admin: Address,
+        recipient: Address,
+        protocol_fee_bps: i128,
+    ) {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "not admin");
+        admin.require_auth();
+
+        let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap();
+        assert!(
+            protocol_fee_bps >= 0 && protocol_fee_bps <= fee_bps,
+            "invalid protocol fee"
+        );
+
+        env.storage().instance().set(&DataKey::FeeRecipient, &recipient);
+        env.storage().instance().set(&DataKey::ProtocolFeeBps, &protocol_fee_bps);
+    }
+
+    /// Return the current protocol fee recipient and rate.
+    ///
+    /// Returns `(None, 0)` when protocol fees are disabled.
+    pub fn get_protocol_fee(env: Env) -> (Option<Address>, i128) {
+        let recipient: Option<Address> = env.storage().instance().get(&DataKey::FeeRecipient);
+        let bps: i128 = env.storage().instance().get(&DataKey::ProtocolFeeBps).unwrap_or(0);
+        (recipient, bps)
     }
 
     // ── Liquidity ─────────────────────────────────────────────────────────────
@@ -485,6 +523,7 @@ mod tests {
 
         let amm = AmmPoolClient::new(&env, &amm_addr);
         amm.initialize(
+            &admin,
             &ta_client.address,
             &tb_client.address,
             &lp_addr,
@@ -524,6 +563,7 @@ mod tests {
 
         let amm = AmmPoolClient::new(&env, &amm_addr);
         amm.initialize(
+            &admin,
             &ta_client.address,
             &tb_client.address,
             &lp_addr,
@@ -555,6 +595,7 @@ mod tests {
         let amm = AmmPoolClient::new(&env, &amm_addr);
         // fee_bps=30, protocol_fee_bps=5
         amm.initialize(
+            &admin,
             &ta_client.address,
             &tb_client.address,
             &lp_addr,

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "factory"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils", "amm/testutils", "token/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+amm = { path = "../amm" }
+token = { path = "../token" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+amm = { path = "../amm", features = ["testutils"] }
+token = { path = "../token", features = ["testutils"] }

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -1,0 +1,306 @@
+//! Factory contract — deploys and registers AMM pool instances.
+//!
+//! Flow:
+//!   1. Deploy this contract.
+//!   2. Call `initialize` with the admin address and pre-uploaded WASM hashes
+//!      for the AMM pool and LP token contracts.
+//!   3. Call `create_pool` for each token pair you want a pool for.
+//!   4. Use `get_pool` / `all_pools` to discover deployed pools.
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    Address, BytesN, Env, Vec,
+};
+use amm::AmmPoolClient;
+use token::LpTokenClient;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Pool(Address, Address), // normalized (token_a, token_b) → pool Address
+    AllPools,               // Vec<Address> of every deployed pool
+    Admin,
+    AmmWasmHash,
+    TokenWasmHash,
+    PoolCount, // u64 monotonic counter — used to derive unique deploy salts
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct Factory;
+
+#[contractimpl]
+impl Factory {
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    /// One-time factory setup.
+    ///
+    /// `amm_wasm_hash` and `token_wasm_hash` must be uploaded to the network
+    /// (via `stellar contract upload`) before calling this function.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        amm_wasm_hash: BytesN<32>,
+        token_wasm_hash: BytesN<32>,
+    ) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::AmmWasmHash, &amm_wasm_hash);
+        env.storage().instance().set(&DataKey::TokenWasmHash, &token_wasm_hash);
+        env.storage().instance().set(&DataKey::AllPools, &Vec::<Address>::new(&env));
+        env.storage().instance().set(&DataKey::PoolCount, &0u64);
+    }
+
+    // ── Pool creation ─────────────────────────────────────────────────────────
+
+    /// Deploy a new AMM pool for `(token_a, token_b)` with `fee_bps` swap fee.
+    ///
+    /// Token pair order is normalised — the pool is always stored with the
+    /// lexicographically smaller address as `token_a`, so callers do not need
+    /// to match the original order when looking up a pool.
+    ///
+    /// Panics if a pool for this pair already exists.
+    pub fn create_pool(
+        env: Env,
+        token_a: Address,
+        token_b: Address,
+        fee_bps: i128,
+    ) -> Address {
+        // Normalise: smaller address is always token_a.
+        let (ta, tb) = if token_a < token_b {
+            (token_a, token_b)
+        } else {
+            (token_b, token_a)
+        };
+
+        if env.storage().instance().has(&DataKey::Pool(ta.clone(), tb.clone())) {
+            panic!("pool already exists");
+        }
+
+        let amm_wasm: BytesN<32> =
+            env.storage().instance().get(&DataKey::AmmWasmHash).unwrap();
+        let token_wasm: BytesN<32> =
+            env.storage().instance().get(&DataKey::TokenWasmHash).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+
+        // Derive two unique salts per pool from a monotonic counter.
+        let n: u64 = env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0);
+        env.storage().instance().set(&DataKey::PoolCount, &(n + 1));
+
+        let lp_salt = Self::make_salt(&env, n * 2);
+        let pool_salt = Self::make_salt(&env, n * 2 + 1);
+
+        // Deploy LP token then AMM pool.
+        let lp_addr = env.deployer().with_current_contract(lp_salt).deploy(token_wasm);
+        let pool_addr = env.deployer().with_current_contract(pool_salt).deploy(amm_wasm);
+
+        // Initialize LP token — admin must be the pool so it can mint/burn.
+        LpTokenClient::new(&env, &lp_addr).initialize(
+            &pool_addr,
+            &soroban_sdk::String::from_str(&env, "AMM LP Token"),
+            &soroban_sdk::String::from_str(&env, "ALP"),
+            &7u32,
+        );
+
+        // Initialize AMM pool.
+        AmmPoolClient::new(&env, &pool_addr).initialize(
+            &ta,
+            &tb,
+            &lp_addr,
+            &fee_bps,
+            &admin,   // fee_recipient
+            &0_i128,  // protocol_fee_bps (disabled by default)
+        );
+
+        // Register pool in both lookup indexes.
+        env.storage()
+            .instance()
+            .set(&DataKey::Pool(ta.clone(), tb.clone()), &pool_addr);
+
+        let mut all: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllPools)
+            .unwrap_or_else(|| Vec::new(&env));
+        all.push_back(pool_addr.clone());
+        env.storage().instance().set(&DataKey::AllPools, &all);
+
+        pool_addr
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    /// Return the pool address for `(token_a, token_b)`, or `None` if it does
+    /// not exist. Token pair order does not matter.
+    pub fn get_pool(env: Env, token_a: Address, token_b: Address) -> Option<Address> {
+        let (ta, tb) = if token_a < token_b {
+            (token_a, token_b)
+        } else {
+            (token_b, token_a)
+        };
+        env.storage().instance().get(&DataKey::Pool(ta, tb))
+    }
+
+    /// Return the addresses of every pool deployed by this factory.
+    pub fn all_pools(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::AllPools)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────────
+
+    /// Build a deterministic 32-byte salt from a u64 index.
+    fn make_salt(env: &Env, index: u64) -> BytesN<32> {
+        let mut arr = [0u8; 32];
+        arr[..8].copy_from_slice(&index.to_be_bytes());
+        BytesN::from_array(env, &arr)
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+//
+// Tests deploy the AMM and token contracts as real WASM. Build the WASM first:
+//
+//   cargo build --release --target wasm32-unknown-unknown
+//
+// Then run:
+//
+//   cargo test -p factory
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    // Embed compiled WASM at test-compile time.
+    mod amm_wasm {
+        soroban_sdk::contractimport!(
+            file = "../../target/wasm32-unknown-unknown/release/amm.wasm"
+        );
+    }
+
+    mod token_wasm {
+        soroban_sdk::contractimport!(
+            file = "../../target/wasm32-unknown-unknown/release/token.wasm"
+        );
+    }
+
+    /// Deploy the factory and return (env, factory_client).
+    fn setup() -> (Env, Address, FactoryClient<'static>) {
+        // SAFETY: the client borrows from env. We return both so the borrow is valid.
+        // Workaround: heap-allocate env and leak. In tests this is fine.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm_wasm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token_wasm::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Return env + factory_addr so caller can rebuild the client without
+        // lifetime friction.
+        (env, factory_addr, factory)
+    }
+
+    #[test]
+    fn test_create_pool() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm_wasm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token_wasm::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        let pool = factory.create_pool(&ta, &tb, &30_i128);
+
+        assert_eq!(factory.get_pool(&ta, &tb), Some(pool.clone()));
+        assert_eq!(factory.all_pools().len(), 1);
+    }
+
+    #[test]
+    fn test_normalize_order() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm_wasm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token_wasm::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        factory.create_pool(&ta, &tb, &30_i128);
+
+        // Reverse-order lookup returns the same pool.
+        assert_eq!(factory.get_pool(&ta, &tb), factory.get_pool(&tb, &ta));
+    }
+
+    #[test]
+    fn test_duplicate_pool_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm_wasm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token_wasm::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        factory.create_pool(&ta, &tb, &30_i128);
+        let result = factory.try_create_pool(&ta, &tb, &30_i128);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_all_pools() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm_wasm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token_wasm::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        assert_eq!(factory.all_pools().len(), 0);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let tc = Address::generate(&env);
+
+        factory.create_pool(&ta, &tb, &30_i128);
+        assert_eq!(factory.all_pools().len(), 1);
+
+        factory.create_pool(&ta, &tc, &30_i128);
+        assert_eq!(factory.all_pools().len(), 2);
+    }
+}

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -110,6 +110,7 @@ impl Factory {
 
         // Initialize AMM pool.
         AmmPoolClient::new(&env, &pool_addr).initialize(
+            &admin,
             &ta,
             &tb,
             &lp_addr,


### PR DESCRIPTION
closes #20 Admin storage key and admin parameter to initialize(). Add
set_protocol_fee(admin, recipient, protocol_fee_bps) for post-deploy
configuration — requires auth from the stored admin. Add read-only
get_protocol_fee() returning (Option<Address>, i128). Protocol fees
are off by default (protocol_fee_bps = 0); set_protocol_fee enables
or disables them at any time. Update factory to pass admin to AMM
initialize().
