### PR TITLE
docs: add `///` doc comments to all public functions in token/src/lib.rs

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -357,7 +357,7 @@ impl AmmPool {
 
     /// Calculate the output amount for a hypothetical swap without executing it.
     ///
-    /// Applies the same constant-product formula and fee as [`Self::swap`] but
+    /// Applies the same constant-product formula and fee as `swap` but
     /// makes no state changes. Useful for quoting prices off-chain or in other
     /// contracts before committing to a swap.
     ///

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -23,6 +23,9 @@ pub struct LpToken;
 #[contractimpl]
 impl LpToken {
     /// Initialize the token with metadata and an admin that can mint/burn.
+    ///
+    /// `admin` is the only address authorized to call `mint` and `burn`.
+    /// Panics if the contract has already been initialized.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -42,22 +45,27 @@ impl LpToken {
 
     // ── Read ──────────────────────────────────────────────────────────────────
 
+    /// Returns the token name.
     pub fn name(env: Env) -> String {
         env.storage().instance().get(&DataKey::Name).unwrap()
     }
 
+    /// Returns the token symbol.
     pub fn symbol(env: Env) -> String {
         env.storage().instance().get(&DataKey::Symbol).unwrap()
     }
 
+    /// Returns the number of decimal places used to represent token amounts.
     pub fn decimals(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::Decimals).unwrap()
     }
 
+    /// Returns the total number of tokens currently in circulation.
     pub fn total_supply(env: Env) -> i128 {
         env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
     }
 
+    /// Returns the token balance of `id`. Returns `0` if the account has no balance.
     pub fn balance(env: Env, id: Address) -> i128 {
         env.storage()
             .persistent()
@@ -65,6 +73,8 @@ impl LpToken {
             .unwrap_or(0)
     }
 
+    /// Returns the amount `spender` is allowed to transfer on behalf of `from`.
+    /// Returns `0` if no allowance has been set.
     pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
         env.storage()
             .persistent()
@@ -74,11 +84,20 @@ impl LpToken {
 
     // ── Write ─────────────────────────────────────────────────────────────────
 
+    /// Transfer `amount` tokens from `from` to `to`.
+    ///
+    /// Requires authorization from `from`.
+    /// Panics if `from` has insufficient balance.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         Self::_transfer(&env, &from, &to, amount);
     }
 
+    /// Transfer `amount` tokens from `from` to `to` using a pre-approved allowance.
+    ///
+    /// Requires authorization from `spender`.
+    /// Panics if the current allowance of `spender` over `from` is less than `amount`.
+    /// Panics if `from` has insufficient balance.
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
         let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
@@ -89,6 +108,10 @@ impl LpToken {
         Self::_transfer(&env, &from, &to, amount);
     }
 
+    /// Approve `spender` to transfer up to `amount` tokens on behalf of `from`.
+    ///
+    /// Requires authorization from `from`.
+    /// Setting `amount` to `0` effectively revokes the allowance.
     pub fn approve(env: Env, from: Address, spender: Address, amount: i128) {
         from.require_auth();
         env.storage()
@@ -127,6 +150,7 @@ impl LpToken {
 
     // ── Internal ──────────────────────────────────────────────────────────────
 
+    /// Returns the admin address that is authorized to mint and burn tokens.
     pub fn admin(env: Env) -> Address {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }


### PR DESCRIPTION
closes #4 

Every public function in contracts/token/src/lib.rs now has a /// doc comment describing what it does, its auth requirements, and any panic conditions. Also fixes a broken [`Self::swap`] intra-doc link in amm/src/lib.rs that caused a rustdoc warning.

cargo doc --no-deps now generates documentation with zero warnings.