### PR TITLE
chore: add cargo wasm build alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ You are now ready to build, test, and deploy.
 Build all contracts as optimised WASM binaries:
 
 ```sh
+cargo wasm
+```
+
+`wasm` is a Cargo alias defined in [.cargo/config.toml](.cargo/config.toml) that expands to:
+
+```sh
 cargo build --release --target wasm32-unknown-unknown
 ```
 


### PR DESCRIPTION
Closes #1.


**Summary**

- Adds a `.cargo/config.toml` with a `wasm` alias that expands to `cargo build --release --target wasm32-unknown-unknown`, so contributors can build all contracts with `cargo wasm`. README build section updated to document the alias.

