### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.toml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Contributions are welcome. Please follow the guidelines below to keep the codeba
 
 ### Code Style
 
+- An [`.editorconfig`](.editorconfig) at the workspace root defines shared formatting rules (UTF-8, LF line endings, 4-space indentation, trailing-whitespace trimming). Most editors apply it automatically; install the [EditorConfig plugin](https://editorconfig.org/#download) if yours does not.
 - Run `cargo fmt` before committing — the project uses default `rustfmt` settings.
 - Run `cargo clippy -- -D warnings` and resolve any warnings before opening a PR.
 - Prefer explicit arithmetic with overflow checks over silent wrapping. The release profile already enables `overflow-checks = true`.


### PR DESCRIPTION
Closes #7


**Summary**

- Defines shared editor formatting rules (UTF-8, LF line endings, 4-space indentation, 2-space for TOML, trimmed trailing whitespace, final newline) so contributors get consistent output without per-editor configuration. Settings match rustfmt defaults.

README Contributing > Code Style section updated to reference the file.

