### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Report a reproducible bug in the AMM, token, or factory contracts
+title: "fix: <short description>"
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual Behaviour
+
+<!-- What actually happened. Include any panic messages, error codes, or unexpected output. -->
+
+## Contract Version
+
+<!-- The contract version or git commit SHA you are running against. -->
+
+- Contract version / commit:
+
+## Network
+
+- [ ] Testnet
+- [ ] Mainnet
+- [ ] Local (e.g. `stellar-quickstart`)
+
+## Environment
+
+<!-- Fill in the relevant details. -->
+
+- Rust toolchain (`rustup show`):
+- `soroban-sdk` version:
+- Stellar CLI version (`stellar --version`):
+- OS:
+
+## Additional Context
+
+<!-- Logs, screenshots, transaction IDs, or anything else that might help. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+title: "feat: <short description>"
+labels: enhancement
+assignees: ""
+---
+
+## Problem Statement
+
+<!-- What problem does this feature solve? Who is affected and how often?
+     e.g. "As a liquidity provider I cannot X, which means I have to Y manually." -->
+
+## Proposed Solution
+
+<!-- Describe the change you'd like to see. Be as specific as possible —
+     include function signatures, storage changes, or interface sketches if relevant. -->
+
+## Alternatives Considered
+
+<!-- What other approaches did you evaluate? Why did you rule them out? -->
+
+## Additional Context
+
+<!-- Links to prior art, related issues, research, or any other context that
+     would help maintainers evaluate this request. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary of Changes
+
+<!-- Explain *what* changed and *why*. Keep it concise but complete enough
+     for a reviewer who has no prior context. -->
+
+## Related Issue(s)
+
+<!-- Link every issue this PR addresses.
+     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->
+
+- Closes #
+
+## Type of Change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no behaviour change)
+- [ ] Tests only
+- [ ] Documentation only
+- [ ] Chore (build, tooling, dependencies)
+
+## Checklist
+
+<!-- Complete every item before requesting review. -->
+
+- [ ] `cargo fmt` has been run
+- [ ] `cargo clippy -- -D warnings` passes with no new warnings
+- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
+- [ ] New behaviour is covered by tests
+- [ ] Public interface changes are reflected in the README
+- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format


### PR DESCRIPTION
## Summary of Changes

Adds GitHub issue and pull request templates under `.github/` so contributors
consistently provide the information maintainers need to review contributions
quickly. No logic or contract code was changed.

## Related Issue(s)

- Related to #1 (Phase 1 — contributor experience)
Close #30

## Type of Change

- [x] Chore (build, tooling, dependencies)
- [x] Documentation only

## Files Added

| File | Purpose |
|---|---|
| `.github/ISSUE_TEMPLATE/bug_report.md` | Structured bug report with contract version and network fields |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature proposal with problem statement, solution, and alternatives |
| `.github/PULL_REQUEST_TEMPLATE.md` | PR description template with checklist aligned to README contributing guidelines |

## Checklist

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes
- [x] New behaviour is covered by tests
- [x] Public interface changes are reflected in the README
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
