### PR TITLE
docs: add CHANGELOG.md and update contributing guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,4 +30,5 @@
 - [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
 - [ ] New behaviour is covered by tests
 - [ ] Public interface changes are reflected in the README
+- [ ] `CHANGELOG.md` has been updated with any notable changes
 - [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Constant-product AMM pool contract
+- SEP-41 compliant LP token contract
+- add_liquidity, remove_liquidity, swap, get_amount_out functions
+- Slippage protection on all state-changing operations

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A constant-product Automated Market Maker (AMM) built as a Soroban smart contrac
   - [TypeScript Client Example](#typescript-client-example)
   - [Python Client Example](#python-client-example)
 - [Contributing](#contributing)
+- [Changelog](#changelog)
 - [Security](#security)
 - [License](#license)
 
@@ -713,11 +714,18 @@ Before requesting review, confirm:
 - [ ] `cargo test` passes
 - [ ] New behavior is covered by tests
 - [ ] Public interface changes are reflected in this README
+- [ ] `CHANGELOG.md` has been updated with any notable changes
 - [ ] Commit messages follow the Conventional Commits format
 
 ### Versioning
 
 This project follows [Semantic Versioning](https://semver.org/). Breaking changes to the on-chain interface (function signatures, storage layout, error codes) constitute a major version bump.
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of notable changes to this project.
 
 ---
 


### PR DESCRIPTION
## Summary of Changes

This PR introduces a `CHANGELOG.md` file to the root of the repository following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. It seeds the initial unreleased version with the core AMM and token functionality. 

Additionally, this PR updates the `README.md` to link to the new changelog and modifies both the contributing guidelines and the pull request template to ensure that updating the changelog is part of the required workflow moving forward.

Closes #26