### PR TITLE
chore: switch WASM target from wasm32-unknown-unknown to wasm32v1-none (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Rust stable with wasm32 target
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: Check formatting
@@ -24,11 +24,11 @@ jobs:
       - name: Run tests
         run: cargo test
       - name: Build WASM release
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: cargo build --release --target wasm32v1-none
       - name: Check WASM Binary Size
         run: |
-          AMM_SIZE=$(wc -c < target/wasm32-unknown-unknown/release/amm.wasm)
-          TOKEN_SIZE=$(wc -c < target/wasm32-unknown-unknown/release/token.wasm)
+          AMM_SIZE=$(wc -c < target/wasm32v1-none/release/amm.wasm)
+          TOKEN_SIZE=$(wc -c < target/wasm32v1-none/release/token.wasm)
           MAX_SIZE=102400  # 100 KB threshold
           echo "AMM WASM size: $AMM_SIZE bytes"
           echo "TOKEN WASM size: $TOKEN_SIZE bytes"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Rust stable with wasm32 target
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: build
 
 build:
-	cargo build --release --target wasm32-unknown-unknown
+	cargo build --release --target wasm32v1-none
 
 test:
 	cargo test

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,8 +9,8 @@ ADMIN_ADDRESS="${ADMIN_ADDRESS:-}"
 FEE_RECIPIENT="${FEE_RECIPIENT:-}"
 PROTOCOL_FEE_BPS="${PROTOCOL_FEE_BPS:-0}"
 
-TOKEN_WASM="${TOKEN_WASM:-"$ROOT_DIR/target/wasm32-unknown-unknown/release/token.wasm"}"
-AMM_WASM="${AMM_WASM:-"$ROOT_DIR/target/wasm32-unknown-unknown/release/amm.wasm"}"
+TOKEN_WASM="${TOKEN_WASM:-"$ROOT_DIR/target/wasm32v1-none/release/token.wasm"}"
+AMM_WASM="${AMM_WASM:-"$ROOT_DIR/target/wasm32v1-none/release/amm.wasm"}"
 
 log() {
   printf '[deploy] %s\n' "$*" >&2
@@ -87,7 +87,7 @@ fi
 if [[ ! -f "$TOKEN_WASM" || ! -f "$AMM_WASM" ]]; then
   require_cmd cargo
   log "building release WASM artifacts"
-  (cd "$ROOT_DIR" && cargo build --release --target wasm32-unknown-unknown)
+  (cd "$ROOT_DIR" && cargo build --release --target wasm32v1-none)
 fi
 
 log "deploying Token A"


### PR DESCRIPTION
Closes #140.

## What

The Soroban toolchain now requires `wasm32v1-none` for contracts;
`wasm32-unknown-unknown` produces binaries the Stellar validator
rejects at upload time.

## Files changed

| File | Change |
|---|---|
| `Makefile` | `cargo build --target` string |
| `scripts/deploy.sh` | WASM artifact paths *and* the `cargo build --target` invocation |
| `.github/workflows/smoke-test.yml` | `rust-toolchain` targets |
| `.github/workflows/ci.yml` | `rust-toolchain` targets, build target, **and** the `wc -c < target/.../release/*.wasm` paths used for the size report |

The issue listed Makefile / smoke-test.yml / deploy.sh, but
`ci.yml` had the same surface and would have started failing once
the smoke-test path moved — fixing it here keeps CI in lockstep.

## Acceptance criteria (from #140)

- [x] `make build` produces output at `target/wasm32v1-none/release/`
- [x] Smoke-test CI installs the correct Rust target
- [x] `scripts/deploy.sh` references the correct output path
- [x] No remaining `wasm32-unknown-unknown` strings in the four
      files audited above

(`grep -rn "wasm32-unknown-unknown" Makefile scripts/deploy.sh
.github/workflows/` returns 0 matches after this PR.)