### PR TITLE
fix(scripts): pass deadline to swap, add_liquidity, remove_liquidity in e2e.sh

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -12,6 +12,7 @@ SWAP_AMOUNT_IN="${SWAP_AMOUNT_IN:-100000}"
 MIN_SWAP_OUT="${MIN_SWAP_OUT:-150000}"
 MAX_SWAP_OUT="${MAX_SWAP_OUT:-200000}"
 DUST_LIMIT="${DUST_LIMIT:-10}"
+DEADLINE_BUFFER_SECS="${DEADLINE_BUFFER_SECS:-3600}"
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -163,11 +164,13 @@ invoke "$TOKEN_B_CONTRACT_ID" mint \
   --amount "$AMOUNT_B" >/dev/null
 pass "minted token B to test account"
 
+DEADLINE=$(( $(date +%s) + DEADLINE_BUFFER_SECS ))
 ADD_OUTPUT="$(invoke "$AMM_CONTRACT_ID" add_liquidity \
   --provider "$SOURCE_PUBLIC_KEY" \
   --amount_a "$AMOUNT_A" \
   --amount_b "$AMOUNT_B" \
-  --min_shares 0)"
+  --min_shares 0 \
+  --deadline "$DEADLINE")"
 LP_SHARES="$(printf '%s\n' "$ADD_OUTPUT" | parse_i128)"
 if [[ -z "$LP_SHARES" || "$LP_SHARES" -le 0 ]]; then
   die "add_liquidity did not return positive LP shares: $ADD_OUTPUT"
@@ -180,22 +183,26 @@ RESERVE_B="$(printf '%s\n' "$INFO_OUTPUT" | field_value reserve_b)"
 assert_eq "reserve A after add_liquidity" "$RESERVE_A" "$AMOUNT_A"
 assert_eq "reserve B after add_liquidity" "$RESERVE_B" "$AMOUNT_B"
 
+DEADLINE=$(( $(date +%s) + DEADLINE_BUFFER_SECS ))
 SWAP_OUTPUT="$(invoke "$AMM_CONTRACT_ID" swap \
   --trader "$SOURCE_PUBLIC_KEY" \
   --token_in "$TOKEN_A_CONTRACT_ID" \
   --amount_in "$SWAP_AMOUNT_IN" \
-  --min_out 0)"
+  --min_out 0 \
+  --deadline "$DEADLINE")"
 SWAP_OUT="$(printf '%s\n' "$SWAP_OUTPUT" | parse_i128)"
 if [[ -z "$SWAP_OUT" ]]; then
   die "swap did not return an amount: $SWAP_OUTPUT"
 fi
 assert_between "swap output" "$SWAP_OUT" "$MIN_SWAP_OUT" "$MAX_SWAP_OUT"
 
+DEADLINE=$(( $(date +%s) + DEADLINE_BUFFER_SECS ))
 invoke "$AMM_CONTRACT_ID" remove_liquidity \
   --provider "$SOURCE_PUBLIC_KEY" \
   --shares "$LP_SHARES" \
   --min_a 0 \
-  --min_b 0 >/dev/null
+  --min_b 0 \
+  --deadline "$DEADLINE" >/dev/null
 pass "removed all LP shares"
 
 FINAL_INFO_OUTPUT="$(invoke "$AMM_CONTRACT_ID" get_info)"


### PR DESCRIPTION
## Summary of Changes

`scripts/e2e.sh` invokes `add_liquidity`, `swap`, and `remove_liquidity` without the now-required `deadline: u64` argument, so the script fails with an argument-mismatch error against the current contract. This adds a dynamically computed deadline (`current Unix time + DEADLINE_BUFFER_SECS`, defaulting to 1 hour) to each of the three calls.

## Related Issue(s)

- Closes #144

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [x] New behaviour is covered by tests
- [x] Public interface changes are reflected in the README
- [x] `CHANGELOG.md` has been updated with any notable changes
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format