### PR TITLE
feat: add CL pause, governance timelock/events, typed errors across c…

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -10,8 +10,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN,
-    Env, Symbol,
+    contract, contractclient, contractimpl, contracterror, contracttype, symbol_short, Address,
+    Bytes, BytesN, Env, Symbol,
 };
 // Export compiled WASM for tests/dev usage when the `testutils` feature is enabled.
 #[cfg(feature = "testutils")]
@@ -38,6 +38,26 @@ pub trait LpTokenInterface {
     fn mint(env: Env, to: Address, amount: i128);
     fn burn(env: Env, from: Address, amount: i128);
     fn balance(env: Env, id: Address) -> i128;
+}
+
+// ── Typed errors ─────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AmmError {
+    AlreadyInitialized   = 1,
+    InvalidFeeBps        = 2,
+    InsufficientShares   = 3,
+    DeadlineExceeded     = 4,
+    SlippageExceeded     = 5,
+    Paused               = 6,
+    Unauthorized         = 7,
+    ZeroAmount           = 8,
+    InvalidToken         = 9,
+    EmptyPool            = 10,
+    InsufficientLiquidity = 11,
+    NoPendingAdmin       = 12,
+    WrongAdmin           = 13,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -138,7 +158,7 @@ impl AmmPool {
         fee_bps: i128, // recommended: 30 (0.30 %)
         fee_recipient: Address,
         protocol_fee_bps: i128,
-    ) {
+    ) -> Result<(), AmmError> {
         Self::initialize_with_flash_loan_fee(
             env,
             admin,
@@ -149,7 +169,7 @@ impl AmmPool {
             fee_recipient,
             protocol_fee_bps,
             fee_bps,
-        );
+        )
     }
 
     /// Initialize the pool with a distinct flash-loan fee.
@@ -164,23 +184,18 @@ impl AmmPool {
         fee_recipient: Address,
         protocol_fee_bps: i128,
         flash_loan_fee_bps: i128,
-    ) {
+    ) -> Result<(), AmmError> {
         if env.storage().instance().has(&DataKey::TokenA) {
-            panic!(
-                "already initialized: contract {:?}",
-                env.current_contract_address()
-            );
+            return Err(AmmError::AlreadyInitialized);
         }
-        assert!(
-            token_a != token_b,
-            "tokens must differ: token_a={token_a:?}, token_b={token_b:?}"
-        );
-        Self::validate_fee_bps(fee_bps);
-        Self::validate_fee_bps(flash_loan_fee_bps);
-        assert!(
-            (0..=fee_bps).contains(&protocol_fee_bps),
-            "invalid protocol fee: {protocol_fee_bps} must be in 0..={fee_bps}"
-        );
+        if token_a == token_b {
+            return Err(AmmError::InvalidToken);
+        }
+        Self::validate_fee_bps(fee_bps)?;
+        Self::validate_fee_bps(flash_loan_fee_bps)?;
+        if !(0..=fee_bps).contains(&protocol_fee_bps) {
+            return Err(AmmError::InvalidFeeBps);
+        }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TokenA, &token_a);
@@ -211,18 +226,21 @@ impl AmmPool {
             .instance()
             .set(&DataKey::LastTimestamp, &env.ledger().timestamp());
         env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
     }
 
-    pub fn pause(env: Env) {
+    pub fn pause(env: Env) -> Result<(), AmmError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
     }
 
-    pub fn unpause(env: Env) {
+    pub fn unpause(env: Env) -> Result<(), AmmError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
     }
 
     pub fn is_paused(env: Env) -> bool {
@@ -236,21 +254,23 @@ impl AmmPool {
     ///
     /// Set `protocol_fee_bps` to 0 to disable protocol fee collection.
     /// `protocol_fee_bps` must be ≤ the pool's `fee_bps`.
-    pub fn set_protocol_fee(env: Env, admin: Address, recipient: Address, protocol_fee_bps: i128) {
+    pub fn set_protocol_fee(env: Env, admin: Address, recipient: Address, protocol_fee_bps: i128) -> Result<(), AmmError> {
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "not admin");
+        if admin != stored_admin {
+            return Err(AmmError::Unauthorized);
+        }
         admin.require_auth();
         let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap();
-        assert!(
-            protocol_fee_bps >= 0 && protocol_fee_bps <= fee_bps,
-            "invalid protocol fee"
-        );
+        if protocol_fee_bps < 0 || protocol_fee_bps > fee_bps {
+            return Err(AmmError::InvalidFeeBps);
+        }
         env.storage()
             .instance()
             .set(&DataKey::FeeRecipient, &recipient);
         env.storage()
             .instance()
             .set(&DataKey::ProtocolFeeBps, &protocol_fee_bps);
+        Ok(())
     }
 
     /// Return the current protocol fee recipient and rate.
@@ -268,11 +288,11 @@ impl AmmPool {
 
     /// Validate that a fee value is within the allowed range [0, 10_000].
     /// Shared by initialize, update_fee, and set_protocol_fee.
-    fn validate_fee_bps(fee_bps: i128) {
-        assert!(
-            (0..=10_000).contains(&fee_bps),
-            "invalid fee_bps: {fee_bps} is outside 0..=10_000"
-        );
+    fn validate_fee_bps(fee_bps: i128) -> Result<(), AmmError> {
+        if !(0..=10_000).contains(&fee_bps) {
+            return Err(AmmError::InvalidFeeBps);
+        }
+        Ok(())
     }
 
     /// Update the swap fee post-deployment. Admin-only.
@@ -288,29 +308,29 @@ impl AmmPool {
     /// - If `admin` auth fails.
     /// - If `new_fee_bps` is outside [0, 10_000].
     /// - If `new_fee_bps` is less than the current `protocol_fee_bps`.
-    pub fn update_fee(env: Env, new_fee_bps: i128) {
+    pub fn update_fee(env: Env, new_fee_bps: i128) -> Result<(), AmmError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        Self::validate_fee_bps(new_fee_bps);
+        Self::validate_fee_bps(new_fee_bps)?;
         let protocol_fee_bps: i128 = env
             .storage()
             .instance()
             .get(&DataKey::ProtocolFeeBps)
             .unwrap_or(0);
-        assert!(
-            new_fee_bps >= protocol_fee_bps,
-            "fee_bps must be >= protocol_fee_bps: new={new_fee_bps}, protocol={protocol_fee_bps}"
-        );
+        if new_fee_bps < protocol_fee_bps {
+            return Err(AmmError::InvalidFeeBps);
+        }
         env.storage().instance().set(&DataKey::FeeBps, &new_fee_bps);
         env.events()
             .publish((symbol_short!("fee_upd"), admin.clone()), (new_fee_bps,));
+        Ok(())
     }
 
     /// Update the flash loan fee post-deployment. Admin-only.
-    pub fn update_flash_loan_fee(env: Env, new_fee_bps: i128) {
+    pub fn update_flash_loan_fee(env: Env, new_fee_bps: i128) -> Result<(), AmmError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        Self::validate_fee_bps(new_fee_bps);
+        Self::validate_fee_bps(new_fee_bps)?;
         env.storage()
             .instance()
             .set(&DataKey::FlashLoanFeeBps, &new_fee_bps);
@@ -318,6 +338,7 @@ impl AmmPool {
             (Symbol::new(&env, "flash_fee_upd"), admin.clone()),
             (new_fee_bps,),
         );
+        Ok(())
     }
 
     /// Nominate a new admin. The nominee must call `accept_admin` to complete the transfer.
@@ -325,9 +346,11 @@ impl AmmPool {
     /// # Panics
     /// - If `current_admin` is not the stored admin.
     /// - If `current_admin` auth fails.
-    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
+    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), AmmError> {
         let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(current_admin == stored, "not admin");
+        if current_admin != stored {
+            return Err(AmmError::Unauthorized);
+        }
         current_admin.require_auth();
         env.storage()
             .instance()
@@ -336,22 +359,20 @@ impl AmmPool {
             (Symbol::new(&env, "admin_nominated"),),
             (current_admin, new_admin),
         );
+        Ok(())
     }
 
     /// Accept the pending admin nomination. Caller becomes the new admin.
-    ///
-    /// # Panics
-    /// - If there is no pending admin proposal.
-    /// - If `new_admin` does not match the pending nominee.
-    /// - If `new_admin` auth fails.
-    pub fn accept_admin(env: Env, new_admin: Address) {
+    pub fn accept_admin(env: Env, new_admin: Address) -> Result<(), AmmError> {
         let pending: Option<Address> = env
             .storage()
             .instance()
             .get(&DataKey::PendingAdmin)
             .unwrap_or(None);
-        let nominee = pending.expect("no pending admin proposal");
-        assert!(new_admin == nominee, "caller is not the pending admin");
+        let nominee = pending.ok_or(AmmError::NoPendingAdmin)?;
+        if new_admin != nominee {
+            return Err(AmmError::WrongAdmin);
+        }
         new_admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         env.storage()
@@ -359,19 +380,21 @@ impl AmmPool {
             .set(&DataKey::PendingAdmin, &Option::<Address>::None);
         env.events()
             .publish((Symbol::new(&env, "admin_changed"),), (new_admin,));
+        Ok(())
     }
 
     /// Replace the contract WASM with a new version. Admin-only.
     ///
     /// The new WASM must already be uploaded to the network.
     /// State is preserved; only bytecode is replaced.
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), AmmError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.deployer()
             .update_current_contract_wasm(new_wasm_hash.clone());
         env.events()
             .publish((Symbol::new(&env, "upgraded"),), (new_wasm_hash,));
+        Ok(())
     }
 
     /// Return the pending admin nominee, or `None` if no transfer is in progress.
@@ -457,14 +480,17 @@ impl AmmPool {
         amount_b: i128,
         min_shares: i128,
         deadline: u64,
-    ) -> i128 {
-        assert!(deadline >= env.ledger().timestamp(), "deadline exceeded");
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
+    ) -> Result<i128, AmmError> {
+        if deadline < env.ledger().timestamp() {
+            return Err(AmmError::DeadlineExceeded);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
         provider.require_auth();
-        assert!(
-            amount_a > 0 && amount_b > 0,
-            "amounts must be positive: amount_a={amount_a}, amount_b={amount_b}"
-        );
+        if amount_a <= 0 || amount_b <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
@@ -488,14 +514,12 @@ impl AmmPool {
             shares_a.min(shares_b)
         };
 
-        assert!(
-            shares > 0,
-            "amounts too small: computed shares would be zero"
-        );
-        assert!(
-            shares >= min_shares,
-            "slippage: insufficient shares minted: computed={shares}, minimum={min_shares}"
-        );
+        if shares <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
+        if shares < min_shares {
+            return Err(AmmError::SlippageExceeded);
+        }
 
         // Pull tokens from provider into the pool contract.
         let client_a = SepTokenClient::new(&env, &token_a);
@@ -523,7 +547,7 @@ impl AmmPool {
             (amount_a, amount_b, shares),
         );
 
-        shares
+        Ok(shares)
     }
 
     /// Withdraw liquidity from the pool by burning LP shares.
@@ -559,20 +583,25 @@ impl AmmPool {
         min_a: i128,
         min_b: i128,
         deadline: u64,
-    ) -> (i128, i128) {
-        assert!(deadline >= env.ledger().timestamp(), "deadline exceeded");
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
+    ) -> Result<(i128, i128), AmmError> {
+        if deadline < env.ledger().timestamp() {
+            return Err(AmmError::DeadlineExceeded);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
         provider.require_auth();
-        assert!(shares > 0, "shares must be positive: got {shares}");
+        if shares <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
 
         let owned = Self::shares_of(env.clone(), provider.clone());
-        assert!(
-            owned >= shares,
-            "insufficient LP shares: owned={owned}, requested={shares}"
-        );
+        if owned < shares {
+            return Err(AmmError::InsufficientShares);
+        }
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
@@ -585,14 +614,9 @@ impl AmmPool {
         let out_a = shares * reserve_a / total_shares;
         let out_b = shares * reserve_b / total_shares;
 
-        assert!(
-            out_a >= min_a,
-            "slippage: insufficient token_a out: got={out_a}, min={min_a}"
-        );
-        assert!(
-            out_b >= min_b,
-            "slippage: insufficient token_b out: got={out_b}, min={min_b}"
-        );
+        if out_a < min_a || out_b < min_b {
+            return Err(AmmError::SlippageExceeded);
+        }
 
         // Burn LP tokens.
         let lp_client = LpTokenClient::new(&env, &lp_token);
@@ -620,7 +644,7 @@ impl AmmPool {
             (provider.clone(), shares, out_a, out_b),
         );
 
-        (out_a, out_b)
+        Ok((out_a, out_b))
     }
 
     /// Burn LP shares and return a single token, swapping the other internally.
@@ -657,29 +681,33 @@ impl AmmPool {
         token_out: Address,
         min_out: i128,
         deadline: u64,
-    ) -> i128 {
-        assert!(deadline >= env.ledger().timestamp(), "deadline exceeded");
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
+    ) -> Result<i128, AmmError> {
+        if deadline < env.ledger().timestamp() {
+            return Err(AmmError::DeadlineExceeded);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
         provider.require_auth();
-        assert!(shares > 0, "shares must be positive: got {shares}");
+        if shares <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
 
         let owned = Self::shares_of(env.clone(), provider.clone());
-        assert!(
-            owned >= shares,
-            "insufficient LP shares: owned={owned}, requested={shares}"
-        );
+        if owned < shares {
+            return Err(AmmError::InsufficientShares);
+        }
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
         let lp_token: Address = env.storage().instance().get(&DataKey::LpToken).unwrap();
 
-        assert!(
-            token_out == token_a || token_out == token_b,
-            "token_out is not part of this pool: {token_out:?}"
-        );
+        if token_out != token_a && token_out != token_b {
+            return Err(AmmError::InvalidToken);
+        }
 
         let reserve_a = Self::get_reserve_a(env.clone());
         let reserve_b = Self::get_reserve_b(env.clone());
@@ -744,10 +772,9 @@ impl AmmPool {
         // Total output is the amount we kept from withdrawal plus the swap output.
         let total_out = amount_keep + swap_output;
 
-        assert!(
-            total_out >= min_out,
-            "slippage: insufficient output amount: got={total_out}, min={min_out}"
-        );
+        if total_out < min_out {
+            return Err(AmmError::SlippageExceeded);
+        }
 
         // Update reserves after internal swap.
         let protocol_fee_bps: i128 = env
@@ -822,7 +849,7 @@ impl AmmPool {
             (provider.clone(), shares, token_out.clone(), total_out),
         );
 
-        total_out
+        Ok(total_out)
     }
 
     // ── Swap ──────────────────────────────────────────────────────────────────
@@ -863,11 +890,17 @@ impl AmmPool {
         min_out: i128,
         deadline: u64,
         referrer: Option<Address>,
-    ) -> i128 {
-        assert!(deadline >= env.ledger().timestamp(), "deadline exceeded");
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
+    ) -> Result<i128, AmmError> {
+        if deadline < env.ledger().timestamp() {
+            return Err(AmmError::DeadlineExceeded);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
         trader.require_auth();
-        assert!(amount_in > 0, "amount_in must be positive: got {amount_in}");
+        if amount_in <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
@@ -888,13 +921,12 @@ impl AmmPool {
                 token_a.clone(),
             )
         } else {
-            panic!("token_in is not part of this pool: {token_in:?}");
+            return Err(AmmError::InvalidToken);
         };
 
-        assert!(
-            reserve_in > 0 && reserve_out > 0,
-            "pool is empty: reserve_in={reserve_in}, reserve_out={reserve_out}"
-        );
+        if reserve_in <= 0 || reserve_out <= 0 {
+            return Err(AmmError::EmptyPool);
+        }
 
         let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap();
 
@@ -904,14 +936,12 @@ impl AmmPool {
         let amount_out =
             amount_in_with_fee * reserve_out / (reserve_in * 10_000 + amount_in_with_fee);
 
-        assert!(
-            amount_out >= min_out,
-            "slippage: insufficient output amount: got={amount_out}, min={min_out}"
-        );
-        assert!(
-            amount_out < reserve_out,
-            "insufficient liquidity: amount_out={amount_out} >= reserve_out={reserve_out}"
-        );
+        if amount_out < min_out {
+            return Err(AmmError::SlippageExceeded);
+        }
+        if amount_out >= reserve_out {
+            return Err(AmmError::InsufficientLiquidity);
+        }
 
         // Transfer in.
         let client_in = SepTokenClient::new(&env, &token_in);
@@ -974,7 +1004,7 @@ impl AmmPool {
             (token_in, amount_in, token_out, amount_out, referrer),
         );
 
-        amount_out
+        Ok(amount_out)
     }
 
     /// Swap a variable input amount to receive exactly `amount_out` of `token_out`.
@@ -1006,11 +1036,17 @@ impl AmmPool {
         max_in: i128,
         deadline: u64,
         referrer: Option<Address>,
-    ) -> i128 {
-        assert!(deadline >= env.ledger().timestamp(), "deadline exceeded");
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
+    ) -> Result<i128, AmmError> {
+        if deadline < env.ledger().timestamp() {
+            return Err(AmmError::DeadlineExceeded);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
         trader.require_auth();
-        assert!(amount_out > 0, "amount_out must be positive");
+        if amount_out <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
@@ -1023,14 +1059,13 @@ impl AmmPool {
         } else if token_out == token_b {
             token_a.clone()
         } else {
-            panic!("token_out is not part of this pool: {token_out:?}");
+            return Err(AmmError::InvalidToken);
         };
 
         let amount_in = Self::get_amount_in(env.clone(), token_out.clone(), amount_out);
-        assert!(
-            amount_in <= max_in,
-            "slippage: required_in={amount_in} exceeds max_in={max_in}"
-        );
+        if amount_in > max_in {
+            return Err(AmmError::SlippageExceeded);
+        }
 
         // Transfer tokens.
         SepTokenClient::new(&env, &token_in).transfer(
@@ -1100,7 +1135,7 @@ impl AmmPool {
             (token_in, amount_in, token_out, amount_out, referrer),
         );
 
-        amount_in
+        Ok(amount_in)
     }
 
     // ── Protocol Fees ─────────────────────────────────────────────────────────
@@ -1109,7 +1144,7 @@ impl AmmPool {
     ///
     /// Only callable by the fee recipient. Resets accrued balances to zero.
     /// Returns `(fee_a_withdrawn, fee_b_withdrawn)`.
-    pub fn withdraw_protocol_fees(env: Env) -> (i128, i128) {
+    pub fn withdraw_protocol_fees(env: Env) -> Result<(i128, i128), AmmError> {
         let fee_recipient: Address = env
             .storage()
             .instance()
@@ -1149,7 +1184,7 @@ impl AmmPool {
             env.storage().instance().set(&DataKey::AccruedFeeB, &0_i128);
         }
 
-        (fee_a, fee_b)
+        Ok((fee_a, fee_b))
     }
 
     /// Borrow pool liquidity and repay it plus a fee during the receiver callback.
@@ -1159,9 +1194,13 @@ impl AmmPool {
         token: Address,
         amount: i128,
         data: Bytes,
-    ) -> i128 {
-        assert!(!Self::is_paused(env.clone()), "pool is paused");
-        assert!(amount > 0, "amount must be positive");
+    ) -> Result<i128, AmmError> {
+        if Self::is_paused(env.clone()) {
+            return Err(AmmError::Paused);
+        }
+        if amount <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
@@ -1173,9 +1212,11 @@ impl AmmPool {
         } else if token == token_b {
             Self::get_reserve_b(env.clone())
         } else {
-            panic!("token is not part of this pool");
+            return Err(AmmError::InvalidToken);
         };
-        assert!(reserve >= amount, "insufficient liquidity");
+        if reserve < amount {
+            return Err(AmmError::InsufficientLiquidity);
+        }
 
         let fee_bps = Self::get_flash_loan_fee_bps(env.clone());
         let fee = if fee_bps > 0 {
@@ -1191,13 +1232,14 @@ impl AmmPool {
 
         let accepted = FlashLoanReceiverClient::new(&env, &receiver)
             .on_flash_loan(&token, &amount, &fee, &data);
-        assert!(accepted, "flash loan callback rejected");
+        if !accepted {
+            return Err(AmmError::InsufficientLiquidity);
+        }
 
         let balance_after = token_client.balance(&pool);
-        assert!(
-            balance_after >= balance_before + fee,
-            "flash loan was not repaid"
-        );
+        if balance_after < balance_before + fee {
+            return Err(AmmError::InsufficientLiquidity);
+        }
 
         let accrued_fee = if token == token_a {
             env.storage()
@@ -1226,7 +1268,7 @@ impl AmmPool {
             (token, amount, fee),
         );
 
-        fee
+        Ok(fee)
     }
 
     // ── Quotes (read-only) ────────────────────────────────────────────────────
@@ -1239,13 +1281,15 @@ impl AmmPool {
     /// - `price_b` = price of token_b in terms of token_a (reserve_a * 1_000_000 / reserve_b)
     ///
     /// Panics if either reserve is zero (pool is empty).
-    pub fn price_ratio(env: Env) -> (i128, i128) {
+    pub fn price_ratio(env: Env) -> Result<(i128, i128), AmmError> {
         let reserve_a = Self::get_reserve_a(env.clone());
         let reserve_b = Self::get_reserve_b(env);
-        assert!(reserve_a > 0 && reserve_b > 0, "pool is empty");
+        if reserve_a <= 0 || reserve_b <= 0 {
+            return Err(AmmError::EmptyPool);
+        }
         let price_a = reserve_b * 1_000_000 / reserve_a;
         let price_b = reserve_a * 1_000_000 / reserve_b;
-        (price_a, price_b)
+        Ok((price_a, price_b))
     }
 
     /// Quote how much `token_out` you receive for `amount_in` of `token_in`.
@@ -1266,7 +1310,7 @@ impl AmmPool {
     ///
     /// # Panics
     /// - If `token_in` is not one of the two pool tokens.
-    pub fn get_amount_out(env: Env, token_in: Address, amount_in: i128) -> i128 {
+    pub fn get_amount_out(env: Env, token_in: Address, amount_in: i128) -> Result<i128, AmmError> {
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
         let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap();
@@ -1282,15 +1326,14 @@ impl AmmPool {
                 Self::get_reserve_a(env.clone()),
             )
         } else {
-            panic!("unknown token_in: {token_in:?}");
+            return Err(AmmError::InvalidToken);
         };
 
-        assert!(
-            reserve_in > 0 && reserve_out > 0,
-            "pool is empty: reserve_in={reserve_in}, reserve_out={reserve_out}"
-        );
+        if reserve_in <= 0 || reserve_out <= 0 {
+            return Err(AmmError::EmptyPool);
+        }
         let amount_in_with_fee = amount_in * (10_000 - fee_bps);
-        amount_in_with_fee * reserve_out / (reserve_in * 10_000 + amount_in_with_fee)
+        Ok(amount_in_with_fee * reserve_out / (reserve_in * 10_000 + amount_in_with_fee))
     }
 
     /// Simulate a swap and return a detailed breakdown without executing it.
@@ -1298,8 +1341,10 @@ impl AmmPool {
     /// Returns the expected output, total fee taken, effective execution price,
     /// spot price, and price impact — all computed from current reserve state.
     /// `amount_out` is guaranteed to match `get_amount_out` for the same inputs.
-    pub fn simulate_swap(env: Env, token_in: Address, amount_in: i128) -> SwapSimulation {
-        assert!(amount_in > 0, "amount_in must be positive");
+    pub fn simulate_swap(env: Env, token_in: Address, amount_in: i128) -> Result<SwapSimulation, AmmError> {
+        if amount_in <= 0 {
+            return Err(AmmError::ZeroAmount);
+        }
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
         let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap();
@@ -1314,26 +1359,25 @@ impl AmmPool {
                 Self::get_reserve_a(env.clone()),
             )
         } else {
-            panic!("unknown token");
+            return Err(AmmError::InvalidToken);
         };
-        assert!(reserve_in > 0 && reserve_out > 0, "pool is empty");
+        if reserve_in <= 0 || reserve_out <= 0 {
+            return Err(AmmError::EmptyPool);
+        }
         let amount_in_with_fee = amount_in * (10_000 - fee_bps);
         let amount_out =
             amount_in_with_fee * reserve_out / (reserve_in * 10_000 + amount_in_with_fee);
         let fee_amount = amount_in * fee_bps / 10_000;
-        // Prices scaled by 1_000_000 to preserve precision in integer arithmetic.
         let spot_price = reserve_out * 1_000_000 / reserve_in;
         let effective_price = amount_out * 1_000_000 / amount_in;
-        // Price impact: how far the execution price deviates from the spot price.
-        // Clamp to [0, 10_000] to handle integer truncation edge cases on tiny amounts.
         let price_impact_bps = ((spot_price - effective_price) * 10_000 / spot_price).max(0);
-        SwapSimulation {
+        Ok(SwapSimulation {
             amount_out,
             fee_amount,
             price_impact_bps,
             effective_price,
             spot_price,
-        }
+        })
     }
 
     /// Quote how much `token_in` is required to receive exactly `amount_out` of `token_out`.
@@ -1751,8 +1795,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "pool is empty")]
-    fn test_price_ratio_panics_on_empty_pool() {
+    fn test_price_ratio_errors_on_empty_pool() {
         let (env, admin, amm_addr, lp_addr, _) = setup();
 
         let (ta_client, _) = create_sac(&env, &admin);
@@ -1769,8 +1812,9 @@ pub(crate) mod tests {
             &0_i128,
         );
 
-        // No liquidity added — reserves are zero, should panic
-        amm.price_ratio();
+        // No liquidity added — reserves are zero, should return typed error
+        let result = amm.try_price_ratio();
+        assert_eq!(result, Err(Ok(AmmError::EmptyPool)));
     }
 
     #[test]

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -1,9 +1,10 @@
 //! Concentrated Liquidity AMM (Uniswap v3-style tick-based ranges).
 //! Standalone contract — does NOT modify the existing AMM pool.
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracterror, contracttype, symbol_short, Address, Env, Vec,
+};
 use soroban_sdk::token::Client as TokenClient;
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[cfg(feature = "testutils")]
 pub const WASM: &[u8] = include_bytes!(concat!(
@@ -16,6 +17,23 @@ const TICK_BASE_NUM: i128 = 1_000_100;
 const TICK_BASE_DEN: i128 = PRICE_SCALE;
 const MIN_TICK: i32 = -887_272;
 const MAX_TICK: i32 = 887_272;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ClError {
+    AlreadyInitialized  = 1,
+    TokensMustDiffer    = 2,
+    InvalidFeeBps       = 3,
+    TickOutOfRange      = 4,
+    ZeroAmounts         = 5,
+    SlippageExceeded    = 6,
+    ZeroLiquidity       = 7,
+    InsufficientLiquidity = 8,
+    PositionNotFound    = 9,
+    DeadlineExpired     = 10,
+    Paused              = 11,
+    Unauthorized        = 12,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -35,6 +53,8 @@ pub enum DataKey {
     SqrtPriceX96,
     Tick(i32),
     TickBitmap(i32),
+    Admin,
+    Paused,
 }
 
 #[contracttype]
@@ -70,24 +90,29 @@ pub struct ConcentratedLiquidity;
 
 #[contractimpl]
 impl ConcentratedLiquidity {
-    /// One-time initialisation. Sets token pair, fee, and starting tick.
+    /// One-time initialisation. Sets admin, token pair, fee, and starting tick.
     pub fn initialize(
         env: Env,
+        admin: Address,
         token_a: Address,
         token_b: Address,
         fee_bps: i128,
         initial_tick: i32,
-    ) {
-        assert!(
-            !env.storage().instance().has(&DataKey::TokenA),
-            "already initialized"
-        );
-        assert!(token_a != token_b, "tokens must differ");
-        assert!((0..=10_000).contains(&fee_bps), "invalid fee_bps");
-        assert!(
-            (MIN_TICK..=MAX_TICK).contains(&initial_tick),
-            "tick out of range"
-        );
+    ) -> Result<(), ClError> {
+        if env.storage().instance().has(&DataKey::TokenA) {
+            return Err(ClError::AlreadyInitialized);
+        }
+        if token_a == token_b {
+            return Err(ClError::TokensMustDiffer);
+        }
+        if !(0..=10_000).contains(&fee_bps) {
+            return Err(ClError::InvalidFeeBps);
+        }
+        if !(MIN_TICK..=MAX_TICK).contains(&initial_tick) {
+            return Err(ClError::TickOutOfRange);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::TokenA, &token_a);
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
@@ -99,16 +124,59 @@ impl ConcentratedLiquidity {
         env.storage().instance().set(&DataKey::TickCumulative, &0_i64);
         env.storage().instance().set(&DataKey::LastOracleTimestamp, &init_ts);
         env.storage().instance().set(&DataKey::OraclePoint(init_ts), &0_i64);
+        Ok(())
     }
 
-    pub fn mint_position(env: Env, provider: Address, lower_tick: i32, upper_tick: i32, amount_a_desired: i128, amount_b_desired: i128, min_a: i128, min_b: i128) -> (i128, i128) {
+    /// Pause all minting and swapping. Admin-only.
+    pub fn pause(env: Env, admin: Address) -> Result<(), ClError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored {
+            return Err(ClError::Unauthorized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
+    }
+
+    /// Resume minting and swapping. Admin-only.
+    pub fn unpause(env: Env, admin: Address) -> Result<(), ClError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored {
+            return Err(ClError::Unauthorized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    /// Returns true when the pool is paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    pub fn mint_position(
+        env: Env,
+        provider: Address,
+        lower_tick: i32,
+        upper_tick: i32,
+        amount_a_desired: i128,
+        amount_b_desired: i128,
+        min_a: i128,
+        min_b: i128,
+    ) -> Result<(i128, i128), ClError> {
+        if Self::is_paused(env.clone()) {
+            return Err(ClError::Paused);
+        }
         provider.require_auth();
-        assert!(lower_tick < upper_tick, "lower_tick must be < upper_tick");
-        assert!(
-            lower_tick >= MIN_TICK && upper_tick <= MAX_TICK,
-            "tick out of range"
-        );
-        assert!(amount_a_desired > 0 || amount_b_desired > 0, "zero amounts");
+        if lower_tick >= upper_tick {
+            return Err(ClError::TickOutOfRange);
+        }
+        if lower_tick < MIN_TICK || upper_tick > MAX_TICK {
+            return Err(ClError::TickOutOfRange);
+        }
+        if amount_a_desired <= 0 && amount_b_desired <= 0 {
+            return Err(ClError::ZeroAmounts);
+        }
         let current_tick: i32 = env.storage().instance().get(&DataKey::CurrentTick).unwrap();
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
@@ -119,11 +187,14 @@ impl ConcentratedLiquidity {
             amount_a_desired,
             amount_b_desired,
         );
-        assert!(amount_a >= min_a, "slippage: amount_a too low");
-        assert!(amount_b >= min_b, "slippage: amount_b too low");
+        if amount_a < min_a || amount_b < min_b {
+            return Err(ClError::SlippageExceeded);
+        }
         let liquidity =
             Self::liquidity_from_amounts(current_tick, lower_tick, upper_tick, amount_a, amount_b);
-        assert!(liquidity > 0, "liquidity would be zero");
+        if liquidity <= 0 {
+            return Err(ClError::ZeroLiquidity);
+        }
         if amount_a > 0 {
             TokenClient::new(&env, &token_a).transfer(
                 &provider,
@@ -158,7 +229,11 @@ impl ConcentratedLiquidity {
         pos.liquidity += liquidity;
         // Track position list for get_positions view
         let list_key = DataKey::PositionList(provider.clone());
-        let mut list: Vec<(i32, i32)> = env.storage().instance().get(&list_key).unwrap_or_else(|| Vec::new(&env));
+        let mut list: Vec<(i32, i32)> = env
+            .storage()
+            .instance()
+            .get(&list_key)
+            .unwrap_or_else(|| Vec::new(&env));
         let range = (lower_tick, upper_tick);
         if !list.iter().any(|r| r == range) {
             list.push_back(range);
@@ -193,7 +268,7 @@ impl ConcentratedLiquidity {
             (symbol_short!("mint_pos"), provider),
             (lower_tick, upper_tick, liquidity, amount_a, amount_b),
         );
-        (amount_a, amount_b)
+        Ok((amount_a, amount_b))
     }
 
     pub fn burn_position(
@@ -202,16 +277,21 @@ impl ConcentratedLiquidity {
         lower_tick: i32,
         upper_tick: i32,
         liquidity: i128,
-    ) -> (i128, i128) {
+    ) -> Result<(i128, i128), ClError> {
+        // No pause guard — LPs must always be able to exit.
         provider.require_auth();
-        assert!(liquidity > 0, "liquidity must be positive");
+        if liquidity <= 0 {
+            return Err(ClError::ZeroLiquidity);
+        }
         let pos_key = DataKey::Position(provider.clone(), lower_tick, upper_tick);
         let mut pos: Position = env
             .storage()
             .instance()
             .get(&pos_key)
-            .expect("position not found");
-        assert!(pos.liquidity >= liquidity, "insufficient liquidity");
+            .ok_or(ClError::PositionNotFound)?;
+        if pos.liquidity < liquidity {
+            return Err(ClError::InsufficientLiquidity);
+        }
         let current_tick: i32 = env.storage().instance().get(&DataKey::CurrentTick).unwrap();
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
@@ -229,7 +309,11 @@ impl ConcentratedLiquidity {
         // Remove from position list when position is fully closed
         if pos.liquidity == 0 {
             let list_key = DataKey::PositionList(provider.clone());
-            let list: Vec<(i32, i32)> = env.storage().instance().get(&list_key).unwrap_or_else(|| Vec::new(&env));
+            let list: Vec<(i32, i32)> = env
+                .storage()
+                .instance()
+                .get(&list_key)
+                .unwrap_or_else(|| Vec::new(&env));
             let range = (lower_tick, upper_tick);
             let mut new_list: Vec<(i32, i32)> = Vec::new(&env);
             for r in list.iter() {
@@ -250,15 +334,7 @@ impl ConcentratedLiquidity {
             .instance()
             .get(&DataKey::FeeGrowthGlobalB)
             .unwrap_or(0);
-        Self::update_tick(
-            &env,
-            lower_tick,
-            current_tick,
-            -liquidity,
-            false,
-            fg_a,
-            fg_b,
-        );
+        Self::update_tick(&env, lower_tick, current_tick, -liquidity, false, fg_a, fg_b);
         Self::update_tick(&env, upper_tick, current_tick, -liquidity, true, fg_a, fg_b);
 
         if current_tick >= lower_tick && current_tick < upper_tick {
@@ -294,7 +370,7 @@ impl ConcentratedLiquidity {
             (symbol_short!("burn_pos"), provider),
             (lower_tick, upper_tick, liquidity, amount_a, amount_b),
         );
-        (amount_a, amount_b)
+        Ok((amount_a, amount_b))
     }
 
     pub fn collect_fees(
@@ -302,14 +378,15 @@ impl ConcentratedLiquidity {
         provider: Address,
         lower_tick: i32,
         upper_tick: i32,
-    ) -> (i128, i128) {
+    ) -> Result<(i128, i128), ClError> {
+        // No pause guard — LPs must always be able to collect fees.
         provider.require_auth();
         let pos_key = DataKey::Position(provider.clone(), lower_tick, upper_tick);
         let mut pos: Position = env
             .storage()
             .instance()
             .get(&pos_key)
-            .expect("position not found");
+            .ok_or(ClError::PositionNotFound)?;
 
         let (fg_inside_a, fg_inside_b) =
             Self::fee_growth_inside(env.clone(), lower_tick, upper_tick);
@@ -336,14 +413,19 @@ impl ConcentratedLiquidity {
                 &total_b,
             );
         }
-        (total_a, total_b)
+        Ok((total_a, total_b))
     }
 
-    pub fn get_position(env: Env, provider: Address, lower_tick: i32, upper_tick: i32) -> Position {
+    pub fn get_position(
+        env: Env,
+        provider: Address,
+        lower_tick: i32,
+        upper_tick: i32,
+    ) -> Result<Position, ClError> {
         env.storage()
             .instance()
             .get(&DataKey::Position(provider, lower_tick, upper_tick))
-            .expect("position not found")
+            .ok_or(ClError::PositionNotFound)
     }
 
     pub fn current_tick(env: Env) -> i32 {
@@ -392,86 +474,49 @@ impl ConcentratedLiquidity {
         sqrt_price_limit_x96: u128,
         min_amount_out: i128,
         deadline: u64,
-    ) -> i128 {
-        assert!(env.ledger().timestamp() <= deadline, "deadline expired");
+    ) -> Result<i128, ClError> {
+        if env.ledger().timestamp() > deadline {
+            return Err(ClError::DeadlineExpired);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(ClError::Paused);
+        }
         sender.require_auth();
-        assert!(amount_in > 0, "amount_in must be positive");
+        if amount_in <= 0 {
+            return Err(ClError::ZeroAmounts);
+        }
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
-        assert!(token_in == token_a || token_in == token_b, "invalid token_in");
-        assert!(target_tick >= MIN_TICK && target_tick <= MAX_TICK, "target tick out of range");
+
         // Update tick accumulator before changing current tick
         let now = env.ledger().timestamp();
-        let last_ts: u64 = env.storage().instance().get(&DataKey::LastOracleTimestamp).unwrap_or(now);
+        let last_ts: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LastOracleTimestamp)
+            .unwrap_or(now);
         let elapsed = now.saturating_sub(last_ts) as i64;
         if elapsed > 0 {
-            let current_tick: i32 = env.storage().instance().get(&DataKey::CurrentTick).unwrap_or(0);
-            let cum: i64 = env.storage().instance().get(&DataKey::TickCumulative).unwrap_or(0);
-            let new_cum = cum + (current_tick as i64) * elapsed;
+            let current_tick_oracle: i32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::CurrentTick)
+                .unwrap_or(0);
+            let cum: i64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::TickCumulative)
+                .unwrap_or(0);
+            let new_cum = cum + (current_tick_oracle as i64) * elapsed;
             env.storage().instance().set(&DataKey::TickCumulative, &new_cum);
             env.storage().instance().set(&DataKey::LastOracleTimestamp, &now);
             env.storage().instance().set(&DataKey::OraclePoint(now), &new_cum);
         }
-        env.storage().instance().set(&DataKey::CurrentTick, &target_tick);
-        TokenClient::new(&env, &token_in).transfer(&buyer, &env.current_contract_address(), &amount_in);
-        let token_out = if token_in == token_a { token_b } else { token_a };
-        TokenClient::new(&env, &token_out).transfer(&env.current_contract_address(), &buyer, &amount_in);
-        env.events().publish((soroban_sdk::symbol_short!("swap"), buyer), (token_in, amount_in, target_tick));
-        amount_in
-    }
 
-    /// Returns raw (tick_cumulative, last_timestamp) for external consumers.
-    pub fn get_tick_cumulative(env: Env) -> (i64, u64) {
-        let cum: i64 = env.storage().instance().get(&DataKey::TickCumulative).unwrap_or(0);
-        let ts: u64 = env.storage().instance().get(&DataKey::LastOracleTimestamp).unwrap_or(0);
-        (cum, ts)
-    }
-
-    /// Returns tick_cumulative at `seconds_ago` seconds in the past.
-    /// Looks up the stored oracle snapshot at exactly `now - seconds_ago`.
-    /// `seconds_ago == 0` returns the current cumulative value (extrapolated to now).
-    pub fn observe(env: Env, seconds_ago: u64) -> i64 {
-        let cum: i64 = env.storage().instance().get(&DataKey::TickCumulative).unwrap_or(0);
-        let last_ts: u64 = env.storage().instance().get(&DataKey::LastOracleTimestamp).unwrap_or(0);
-        let now = env.ledger().timestamp();
-        let current_tick: i32 = env.storage().instance().get(&DataKey::CurrentTick).unwrap_or(0);
-        let target_ts = now.saturating_sub(seconds_ago);
-        if target_ts >= last_ts {
-            // Extrapolate forward from last stored point
-            let elapsed = (target_ts - last_ts) as i64;
-            cum + (current_tick as i64) * elapsed
-        } else {
-            // Look up stored oracle point at target timestamp
-            env.storage()
-                .instance()
-                .get(&DataKey::OraclePoint(target_ts))
-                .unwrap_or(0)
-        }
-    }
-
-    /// Returns all open position tick-range pairs for `provider`.
-    /// Positions with zero liquidity are excluded.
-    pub fn get_positions(env: Env, provider: Address) -> Vec<(i32, i32)> {
-        env.storage()
-            .instance()
-            .get(&DataKey::PositionList(provider))
-            .unwrap_or_else(|| Vec::new(&env))
-    }
-
-    /// Simulate token amounts required for a given tick range and liquidity.
-    /// Pure read — does not transfer tokens or modify state.
-    pub fn quote_position(env: Env, lower_tick: i32, upper_tick: i32, liquidity: i128) -> (i128, i128) {
-        assert!(lower_tick < upper_tick, "lower_tick must be < upper_tick");
-        assert!(lower_tick >= MIN_TICK && upper_tick <= MAX_TICK, "tick out of range");
-        assert!(liquidity > 0, "liquidity must be positive");
-        let current_tick: i32 = env.storage().instance().get(&DataKey::CurrentTick).unwrap_or(0);
-        Self::amounts_for_liquidity(current_tick, lower_tick, upper_tick, liquidity, liquidity)
         let fee_bps: i128 = env.storage().instance().get(&DataKey::FeeBps).unwrap_or(0);
-
         let mut amount_remaining = amount_in;
         let mut amount_out_total = 0_i128;
-
         let mut current_tick = env
             .storage()
             .instance()
@@ -482,7 +527,6 @@ impl ConcentratedLiquidity {
             .instance()
             .get(&DataKey::ActiveLiquidity)
             .unwrap_or(0);
-
         let mut sqrt_price_x96 = env
             .storage()
             .instance()
@@ -610,7 +654,6 @@ impl ConcentratedLiquidity {
                 }
             } else {
                 if active_liquidity > 0 {
-                    // If we hit the limit, we only swap up to the limit
                     let (_target_p_x96, amt_in_after_fee) = if hit_limit {
                         (target_price_x96, amount_in_step_after_fee)
                     } else {
@@ -679,10 +722,9 @@ impl ConcentratedLiquidity {
         }
 
         let amount_in_actual = amount_in - amount_remaining;
-        assert!(
-            amount_out_total >= min_amount_out,
-            "slippage: amount_out too low"
-        );
+        if amount_out_total < min_amount_out {
+            return Err(ClError::SlippageExceeded);
+        }
 
         let token_in = if zero_for_one {
             token_a.clone()
@@ -731,7 +773,83 @@ impl ConcentratedLiquidity {
             ),
         );
 
-        amount_out_total
+        Ok(amount_out_total)
+    }
+
+    /// Returns raw (tick_cumulative, last_timestamp) for external consumers.
+    pub fn get_tick_cumulative(env: Env) -> (i64, u64) {
+        let cum: i64 = env.storage().instance().get(&DataKey::TickCumulative).unwrap_or(0);
+        let ts: u64 = env.storage().instance().get(&DataKey::LastOracleTimestamp).unwrap_or(0);
+        (cum, ts)
+    }
+
+    /// Returns tick_cumulative at `seconds_ago` seconds in the past.
+    /// Looks up the stored oracle snapshot at exactly `now - seconds_ago`.
+    /// `seconds_ago == 0` returns the current cumulative value (extrapolated to now).
+    pub fn observe(env: Env, seconds_ago: u64) -> i64 {
+        let cum: i64 = env.storage().instance().get(&DataKey::TickCumulative).unwrap_or(0);
+        let last_ts: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LastOracleTimestamp)
+            .unwrap_or(0);
+        let now = env.ledger().timestamp();
+        let current_tick: i32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CurrentTick)
+            .unwrap_or(0);
+        let target_ts = now.saturating_sub(seconds_ago);
+        if target_ts >= last_ts {
+            // Extrapolate forward from last stored point
+            let elapsed = (target_ts - last_ts) as i64;
+            cum + (current_tick as i64) * elapsed
+        } else {
+            // Look up stored oracle point at target timestamp
+            env.storage()
+                .instance()
+                .get(&DataKey::OraclePoint(target_ts))
+                .unwrap_or(0)
+        }
+    }
+
+    /// Returns all open position tick-range pairs for `provider`.
+    pub fn get_positions(env: Env, provider: Address) -> Vec<(i32, i32)> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PositionList(provider))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Simulate token amounts required for a given tick range and liquidity.
+    /// Pure read — does not transfer tokens or modify state.
+    pub fn quote_position(
+        env: Env,
+        lower_tick: i32,
+        upper_tick: i32,
+        liquidity: i128,
+    ) -> Result<(i128, i128), ClError> {
+        if lower_tick >= upper_tick {
+            return Err(ClError::TickOutOfRange);
+        }
+        if lower_tick < MIN_TICK || upper_tick > MAX_TICK {
+            return Err(ClError::TickOutOfRange);
+        }
+        if liquidity <= 0 {
+            return Err(ClError::ZeroLiquidity);
+        }
+        let current_tick: i32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CurrentTick)
+            .unwrap_or(0);
+        Ok(Self::amounts_for_liquidity(
+            current_tick,
+            lower_tick,
+            upper_tick,
+            liquidity,
+            liquidity,
+        ))
     }
 
     pub fn fee_growth_inside(env: Env, lower_tick: i32, upper_tick: i32) -> (i128, i128) {
@@ -1095,6 +1213,7 @@ mod tests {
     #[allow(dead_code)]
     struct TestEnv<'a> {
         env: Env,
+        admin: Address,
         provider: Address,
         token_a: Address,
         token_b: Address,
@@ -1117,7 +1236,7 @@ mod tests {
 
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(env, &cl_addr);
-        client.initialize(&token_a, &token_b, &fee_bps, &initial_tick);
+        client.initialize(&admin, &token_a, &token_b, &fee_bps, &initial_tick);
 
         let sac_a = StellarAssetClient::new(env, &token_a);
         let sac_b = StellarAssetClient::new(env, &token_b);
@@ -1132,6 +1251,7 @@ mod tests {
 
         TestEnv {
             env: env.clone(),
+            admin,
             provider,
             token_a,
             token_b,
@@ -1234,12 +1354,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "deadline expired")]
     fn test_deadline_expired() {
         let env = Env::default();
         let te = setup_test_env(&env, 0, 0);
         env.ledger().set_timestamp(101);
-        te.client.swap(&te.provider, &true, &1000, &0, &0, &100);
+        let result = te.client.try_swap(&te.provider, &true, &1000, &0, &0, &100);
+        assert_eq!(result, Err(Ok(ClError::DeadlineExpired)));
     }
 
     #[test]
@@ -1268,6 +1388,90 @@ mod tests {
         assert!(f1_a > 0 || f1_b > 0);
         assert!(f2_a > 0 || f2_b > 0);
     }
+
+    // ── Issue #186: emergency pause tests ─────────────────────────────────────
+
+    #[test]
+    fn test_pause_rejects_mint_position() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 30, 0);
+
+        te.client.pause(&te.admin);
+        assert!(te.client.is_paused());
+
+        let result = te.client.try_mint_position(
+            &te.provider,
+            &-100,
+            &100,
+            &10_000,
+            &10_000,
+            &0,
+            &0,
+        );
+        assert_eq!(result, Err(Ok(ClError::Paused)));
+    }
+
+    #[test]
+    fn test_pause_rejects_swap() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 30, 0);
+
+        te.client.mint_position(&te.provider, &-100, &100, &10_000, &10_000, &0, &0);
+        te.client.pause(&te.admin);
+
+        let result = te.client.try_swap(&te.provider, &true, &1_000, &0, &0, &u64::MAX);
+        assert_eq!(result, Err(Ok(ClError::Paused)));
+    }
+
+    #[test]
+    fn test_paused_allows_burn_and_collect() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 30, 0);
+
+        te.client.mint_position(&te.provider, &100, &200, &5_000, &0, &0, &0);
+        let pos = te.client.get_position(&te.provider, &100, &200);
+        let liq = pos.liquidity;
+
+        te.client.pause(&te.admin);
+
+        // burn_position should succeed while paused
+        let result = te.client.try_burn_position(&te.provider, &100, &200, &liq);
+        assert!(result.is_ok());
+
+        // collect_fees should also succeed while paused (nothing to collect here but shouldn't error)
+        // Re-mint to get a position to collect on
+        te.client.unpause(&te.admin);
+        te.client.mint_position(&te.provider, &100, &200, &5_000, &0, &0, &0);
+        te.client.pause(&te.admin);
+        let collect_result = te.client.try_collect_fees(&te.provider, &100, &200);
+        assert!(collect_result.is_ok());
+    }
+
+    #[test]
+    fn test_non_admin_pause_rejected() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 30, 0);
+
+        let non_admin = Address::generate(&env);
+        let result = te.client.try_pause(&non_admin);
+        assert_eq!(result, Err(Ok(ClError::Unauthorized)));
+        assert!(!te.client.is_paused());
+    }
+
+    #[test]
+    fn test_unpause_resumes_operations() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 30, 0);
+
+        te.client.pause(&te.admin);
+        assert!(te.client.is_paused());
+
+        te.client.unpause(&te.admin);
+        assert!(!te.client.is_paused());
+
+        // Should now succeed
+        te.client.mint_position(&te.provider, &-100, &100, &10_000, &10_000, &0, &0);
+    }
 }
 
 #[cfg(test)]
@@ -1290,7 +1494,7 @@ mod test {
 
         let contract_id = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &contract_id);
-        client.initialize(&token_a_addr, &token_b_addr, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a_addr, &token_b_addr, &30_i128, &0_i32);
 
         let provider = Address::generate(&env);
         StellarAssetClient::new(&env, &token_a_addr).mint(&provider, &1_000_i128);
@@ -1339,14 +1543,14 @@ mod test_new_features {
     use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::Env;
 
-    fn setup(env: &Env) -> (Address, Address, ConcentratedLiquidityClient) {
+    fn setup(env: &Env) -> (Address, Address, Address, ConcentratedLiquidityClient) {
         let admin = Address::generate(env);
         let token_a = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(env, &cl_addr);
-        client.initialize(&token_a, &token_b, &30_i128, &0_i32);
-        (token_a, token_b, client)
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
+        (admin, token_a, token_b, client)
     }
 
     // ── Issue #183: TWAP tick accumulator ────────────────────────────────────
@@ -1362,7 +1566,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&token_a, &token_b, &30_i128, &10_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &10_i32);
 
         // Mint tokens for swapping
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
@@ -1374,16 +1578,20 @@ mod test_new_features {
 
         // First swap at t=1060: tick was 10 for 60 seconds → cumulative += 10 * 60 = 600
         env.ledger().set_timestamp(1_060);
-        client.swap(&buyer, &token_a, &100_i128, &20_i32);
+        client.swap(&buyer, &true, &100_i128, &0_u128, &0_i128, &u64::MAX);
         let (cum1, ts1) = client.get_tick_cumulative();
         assert_eq!(cum1, 600); // 10 * 60
         assert_eq!(ts1, 1_060);
 
-        // Second swap at t=1160: tick was 20 for 100 seconds → cumulative += 20 * 100 = 2000
+        // Get tick after first swap, then record cumulative after second swap
+        let tick_after_first = client.current_tick();
+
+        // Second swap at t=1160: tick was tick_after_first for 100 seconds
         env.ledger().set_timestamp(1_160);
-        client.swap(&buyer, &token_b, &100_i128, &5_i32);
+        client.swap(&buyer, &false, &100_i128, &u128::MAX, &0_i128, &u64::MAX);
         let (cum2, ts2) = client.get_tick_cumulative();
-        assert_eq!(cum2, 2_600); // 600 + 2000
+        let expected_cum2 = 600 + (tick_after_first as i64) * 100;
+        assert_eq!(cum2, expected_cum2);
         assert_eq!(ts2, 1_160);
     }
 
@@ -1398,7 +1606,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&token_a, &token_b, &30_i128, &5_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &5_i32);
 
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
         StellarAssetClient::new(&env, &token_b).mint(&cl_addr, &1_000_000_i128);
@@ -1407,9 +1615,9 @@ mod test_new_features {
 
         // At t=1100: tick was 5 for 100 seconds → expect 5*100=500 at observe(0)
         env.ledger().set_timestamp(1_100);
-        client.swap(&buyer, &token_a, &100_i128, &10_i32);
-        // After swap: cum=500 (from tick=5), now at tick=10
-        // observe(0) should extrapolate to now: 500 + 10*(1100-1100) = 500
+        client.swap(&buyer, &true, &100_i128, &0_u128, &0_i128, &u64::MAX);
+        // After swap: cum=500 (from tick=5), now at some new tick
+        // observe(0) should extrapolate to now: 500 + new_tick*(1100-1100) = 500
         let obs = client.observe(&0_u64);
         assert_eq!(obs, 500);
     }
@@ -1425,31 +1633,30 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
 
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
         StellarAssetClient::new(&env, &token_b).mint(&cl_addr, &1_000_000_i128);
         let buyer = Address::generate(&env);
         StellarAssetClient::new(&env, &token_a).mint(&buyer, &2_000_i128);
 
-        // Swap at t=1100 → moves tick from 0 to 100; cumulative = 0*100 = 0
+        // Swap at t=1100 → oracle accumulates tick=0 * 100s = 0
         env.ledger().set_timestamp(1_100);
-        client.swap(&buyer, &token_a, &100_i128, &100_i32);
+        client.swap(&buyer, &true, &100_i128, &0_u128, &0_i128, &u64::MAX);
+        let tick_at_1100 = client.current_tick();
 
-        // Swap at t=1200 → moves tick from 100 to 200; cumulative = 0 + 100*100 = 10_000
+        // Swap at t=1200 → oracle accumulates tick_at_1100 * 100s
         env.ledger().set_timestamp(1_200);
-        client.swap(&buyer, &token_a, &100_i128, &200_i32);
+        client.swap(&buyer, &true, &100_i128, &0_u128, &0_i128, &u64::MAX);
 
-        // observe(200) = cum at t=1000 = 0  (before any ticks moved)
-        // observe(0)   = cum at t=1200 + 200*(1200-1200) = 10_000 + 0 = 10_000
-        let obs_now = client.observe(&0_u64);
-        let obs_200s_ago = client.observe(&200_u64);
+        // Compute average tick over [1000, 1200]:
+        // cum at t=1000 = 0 (initialized)
+        // cum at t=1200 = 0*100 + tick_at_1100*100
+        let obs_now = client.observe(&0_u64);   // cum at t=1200
+        let obs_200s_ago = client.observe(&200_u64); // cum at t=1000 = 0
         let avg_tick = (obs_now - obs_200s_ago) / 200_i64;
-        // avg tick over 200s: 0*100 + 100*100 = 10000 / 200 = 50
-        assert_eq!(avg_tick, 50_i64);
-        // price at avg tick 50 should be > 1.0
-        let price = ConcentratedLiquidity::tick_to_price(50_i32);
-        assert!(price > 1_000_000);
+        // avg tick = tick_at_1100 * 100 / 200 = tick_at_1100 / 2
+        assert_eq!(avg_tick, (tick_at_1100 as i64) / 2);
     }
 
     // ── Issue #184: get_positions ─────────────────────────────────────────────
@@ -1464,7 +1671,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
 
         let provider = Address::generate(&env);
         StellarAssetClient::new(&env, &token_a).mint(&provider, &10_000_i128);
@@ -1501,7 +1708,7 @@ mod test_new_features {
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
         // current_tick = 0; range [100, 200] is entirely above → pure token-A position
-        client.initialize(&token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
 
         // quote_position: above-range means all in token_a → (liquidity, 0)
         let (qa, qb) = client.quote_position(&100_i32, &200_i32, &3_000_i128);

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -10,13 +10,28 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, Address, BytesN, Env, Symbol, Vec,
+    contract, contractclient, contractimpl, contracterror, contracttype, Address, BytesN, Env,
+    Symbol, Vec,
 };
+
+// ── Typed errors ─────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FactoryError {
+    AlreadyInitialized  = 1,
+    InvalidFeeBps       = 2,
+    PoolAlreadyExists   = 3,
+    ClPoolAlreadyExists = 4,
+    ClWasmNotSet        = 5,
+    Unauthorized        = 6,
+}
 
 #[contractclient(name = "ClPoolClient")]
 pub trait ClPoolInterface {
     fn initialize(
         env: Env,
+        admin: Address,
         token_a: Address,
         token_b: Address,
         fee_bps: i128,
@@ -100,9 +115,9 @@ impl Factory {
         admin: Address,
         amm_wasm_hash: BytesN<32>,
         token_wasm_hash: BytesN<32>,
-    ) {
+    ) -> Result<(), FactoryError> {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            return Err(FactoryError::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
@@ -115,6 +130,7 @@ impl Factory {
             .instance()
             .set(&DataKey::AllPools, &Vec::<Address>::new(&env));
         env.storage().instance().set(&DataKey::PoolCount, &0u64);
+        Ok(())
     }
 
     // ── Pool creation ─────────────────────────────────────────────────────────
@@ -135,7 +151,7 @@ impl Factory {
         token_b: Address,
         fee_bps: i128,
         governance_wasm_hash: Option<BytesN<32>>,
-    ) -> (Address, Option<Address>) {
+    ) -> Result<(Address, Option<Address>), FactoryError> {
         // Normalise: smaller address is always token_a.
         let (ta, tb) = if token_a < token_b {
             (token_a, token_b)
@@ -143,17 +159,16 @@ impl Factory {
             (token_b, token_a)
         };
 
-        assert!(
-            (0..=10_000).contains(&fee_bps),
-            "invalid fee_bps: {fee_bps} must be in 0..=10_000"
-        );
+        if !(0..=10_000).contains(&fee_bps) {
+            return Err(FactoryError::InvalidFeeBps);
+        }
 
         if env
             .storage()
             .instance()
             .has(&DataKey::Pool(ta.clone(), tb.clone()))
         {
-            panic!("pool already exists");
+            return Err(FactoryError::PoolAlreadyExists);
         }
 
         let amm_wasm: BytesN<32> = env.storage().instance().get(&DataKey::AmmWasmHash).unwrap();
@@ -260,7 +275,7 @@ impl Factory {
             ),
         );
 
-        (pool_addr, gov_addr)
+        Ok((pool_addr, gov_addr))
     }
 
     // ── Admin ─────────────────────────────────────────────────────────────────
@@ -276,7 +291,7 @@ impl Factory {
         env: Env,
         amm_wasm_hash: Option<BytesN<32>>,
         token_wasm_hash: Option<BytesN<32>>,
-    ) {
+    ) -> Result<(), FactoryError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         if let Some(ref h) = amm_wasm_hash {
@@ -289,26 +304,29 @@ impl Factory {
             (Symbol::new(&env, "wasm_updated"),),
             (amm_wasm_hash, token_wasm_hash),
         );
+        Ok(())
     }
 
     /// Replace the factory contract WASM with a new version. Admin-only.
     ///
     /// The new WASM must already be uploaded to the network.
     /// State is preserved; only bytecode is replaced.
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), FactoryError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.deployer()
             .update_current_contract_wasm(new_wasm_hash.clone());
         env.events()
             .publish((Symbol::new(&env, "upgraded"),), (new_wasm_hash,));
+        Ok(())
     }
 
     /// Set or update the WASM hash used for concentrated_liquidity deployments. Admin-only.
-    pub fn set_cl_wasm_hash(env: Env, cl_wasm_hash: BytesN<32>) {
+    pub fn set_cl_wasm_hash(env: Env, cl_wasm_hash: BytesN<32>) -> Result<(), FactoryError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DataKey::ClWasmHash, &cl_wasm_hash);
+        Ok(())
     }
 
     /// Deploy a new concentrated liquidity pool for `(token_a, token_b)` at `fee_bps`.
@@ -325,11 +343,10 @@ impl Factory {
         token_b: Address,
         fee_bps: i128,
         initial_tick: i32,
-    ) -> Address {
-        assert!(
-            (0..=10_000).contains(&fee_bps),
-            "invalid fee_bps: must be in 0..=10_000"
-        );
+    ) -> Result<Address, FactoryError> {
+        if !(0..=10_000).contains(&fee_bps) {
+            return Err(FactoryError::InvalidFeeBps);
+        }
 
         // Normalise token order.
         let (ta, tb) = if token_a < token_b {
@@ -340,14 +357,14 @@ impl Factory {
 
         let cl_key = DataKey::ClPool(ta.clone(), tb.clone(), fee_bps);
         if env.storage().instance().has(&cl_key) {
-            panic!("cl pool already exists for this (token_a, token_b, fee_bps)");
+            return Err(FactoryError::ClPoolAlreadyExists);
         }
 
         let cl_wasm: BytesN<32> = env
             .storage()
             .instance()
             .get(&DataKey::ClWasmHash)
-            .expect("cl_wasm_hash not set; call set_cl_wasm_hash first");
+            .ok_or(FactoryError::ClWasmNotSet)?;
 
         let n: u64 = env
             .storage()
@@ -363,7 +380,8 @@ impl Factory {
             .with_current_contract(cl_salt)
             .deploy(cl_wasm);
 
-        ClPoolClient::new(&env, &pool_addr).initialize(&ta, &tb, &fee_bps, &initial_tick);
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        ClPoolClient::new(&env, &pool_addr).initialize(&admin, &ta, &tb, &fee_bps, &initial_tick);
 
         env.storage().instance().set(&cl_key, &pool_addr);
 
@@ -372,7 +390,7 @@ impl Factory {
             (ta.clone(), tb.clone(), fee_bps, pool_addr.clone()),
         );
 
-        pool_addr
+        Ok(pool_addr)
     }
 
     // ── Queries ───────────────────────────────────────────────────────────────

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -19,13 +19,45 @@ pub const WASM: &[u8] = include_bytes!(concat!(
     "/../../target/wasm32v1-none/release/governance.wasm"
 ));
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracterror, contracttype, Address, Env, Symbol};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const MAX_BPS: i128 = 10_000;
 const MIN_PERSISTENT_TTL: u32 = 172_800; // ~10 days at 5s/ledger
 const PERSISTENT_TTL_BUMP_TO: u32 = 259_200; // ~15 days at 5s/ledger
+
+// ── Typed errors ─────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum GovernanceError {
+    AlreadyInitialized      = 1,
+    InvalidVotingPeriod     = 2,
+    InvalidTimelock         = 3,
+    InvalidQuorumBps        = 4,
+    InvalidProposerStake    = 5,
+    InvalidFeeBps           = 6,
+    ZeroTotalSupply         = 7,
+    InsufficientStake       = 8,
+    ProposalNotFound        = 9,
+    VotingNotStarted        = 10,
+    VotingPeriodEnded       = 11,
+    AlreadyExecuted         = 12,
+    ProposalCancelled       = 13,
+    AlreadyVoted            = 14,
+    NoVotingPower           = 15,
+    VotingPeriodActive      = 16,
+    ProposalExpired         = 17,
+    TimelockNotElapsed      = 18,
+    QuorumNotMet            = 19,
+    ProposalDefeated        = 20,
+    NotProposer             = 21,
+    NoLockedVote            = 22,
+    ProposalNotConcluded    = 23,
+    CannotDelegateToSelf    = 24,
+    Unauthorized            = 25,
+}
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
@@ -195,21 +227,22 @@ impl Governance {
         timelock_secs: u64,
         quorum_bps: i128,
         min_proposer_stake_bps: i128,
-    ) {
-        assert!(
-            !env.storage().instance().has(&DataKey::AmmPool),
-            "already initialized"
-        );
-        assert!(voting_period_secs > 0, "voting_period_secs must be > 0");
-        assert!(timelock_secs > 0, "timelock_secs must be > 0");
-        assert!(
-            (1..=MAX_BPS).contains(&quorum_bps),
-            "quorum_bps must be in [1, 10_000]"
-        );
-        assert!(
-            (0..=MAX_BPS).contains(&min_proposer_stake_bps),
-            "invalid min proposer stake bps"
-        );
+    ) -> Result<(), GovernanceError> {
+        if env.storage().instance().has(&DataKey::AmmPool) {
+            return Err(GovernanceError::AlreadyInitialized);
+        }
+        if voting_period_secs == 0 {
+            return Err(GovernanceError::InvalidVotingPeriod);
+        }
+        if timelock_secs == 0 {
+            return Err(GovernanceError::InvalidTimelock);
+        }
+        if !(1..=MAX_BPS).contains(&quorum_bps) {
+            return Err(GovernanceError::InvalidQuorumBps);
+        }
+        if !(0..=MAX_BPS).contains(&min_proposer_stake_bps) {
+            return Err(GovernanceError::InvalidProposerStake);
+        }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::AmmPool, &amm_pool);
         env.storage().instance().set(&DataKey::LpToken, &lp_token);
@@ -226,19 +259,29 @@ impl Governance {
             .instance()
             .set(&DataKey::MinProposerStakeBps, &min_proposer_stake_bps);
         env.storage().instance().set(&DataKey::ProposalCount, &0u32);
+        Ok(())
     }
 
     /// Admin-only governance parameter update.
-    pub fn set_min_proposer_stake_bps(env: Env, new_bps: i128) {
+    pub fn set_min_proposer_stake_bps(env: Env, new_bps: i128) -> Result<(), GovernanceError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        assert!(
-            (0..=MAX_BPS).contains(&new_bps),
-            "invalid min proposer stake bps"
-        );
+        if !(0..=MAX_BPS).contains(&new_bps) {
+            return Err(GovernanceError::InvalidProposerStake);
+        }
         env.storage()
             .instance()
             .set(&DataKey::MinProposerStakeBps, &new_bps);
+        Ok(())
+    }
+
+    /// Admin-only: update the timelock delay between vote end and execution.
+    /// A delay of 0 means execution is allowed immediately after the voting period ends.
+    pub fn set_timelock_delay(env: Env, new_delay: u64) -> Result<(), GovernanceError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Timelock, &new_delay);
+        Ok(())
     }
 
     // ── Core functions ────────────────────────────────────────────────────────
@@ -247,24 +290,24 @@ impl Governance {
     ///
     /// The proposer must hold at least the configured minimum LP stake.
     /// Returns the new `proposal_id`.
-    pub fn propose(env: Env, proposer: Address, kind: ProposalKind) -> u32 {
+    pub fn propose(env: Env, proposer: Address, kind: ProposalKind) -> Result<u32, GovernanceError> {
         proposer.require_auth();
 
         match &kind {
             ProposalKind::UpdateFee(new_fee_bps) => {
-                assert!((0..=MAX_BPS).contains(new_fee_bps), "invalid fee");
+                if !(0..=MAX_BPS).contains(new_fee_bps) {
+                    return Err(GovernanceError::InvalidFeeBps);
+                }
             }
             ProposalKind::UpdateProtocolFee(params) => {
-                assert!(
-                    (0..=MAX_BPS).contains(&params.new_bps),
-                    "invalid protocol fee bps"
-                );
+                if !(0..=MAX_BPS).contains(&params.new_bps) {
+                    return Err(GovernanceError::InvalidFeeBps);
+                }
             }
             ProposalKind::UpdateFlashLoanFee(new_bps) => {
-                assert!(
-                    (0..=MAX_BPS).contains(new_bps),
-                    "invalid flash loan fee bps"
-                );
+                if !(0..=MAX_BPS).contains(new_bps) {
+                    return Err(GovernanceError::InvalidFeeBps);
+                }
             }
             ProposalKind::TransferAdmin(_new_admin) => {}
             ProposalKind::PausePool => {}
@@ -275,7 +318,9 @@ impl Governance {
         let lp_client = LpTokenClient::new(&env, &lp_token);
 
         let total_supply = lp_client.total_supply();
-        assert!(total_supply > 0, "LP total supply is zero");
+        if total_supply == 0 {
+            return Err(GovernanceError::ZeroTotalSupply);
+        }
         let proposer_balance = lp_client.balance(&proposer);
         let min_bps: i128 = env
             .storage()
@@ -283,10 +328,9 @@ impl Governance {
             .get(&DataKey::MinProposerStakeBps)
             .unwrap_or(0);
         let min_stake = ((total_supply * min_bps) / MAX_BPS).max(1);
-        assert!(
-            proposer_balance >= min_stake,
-            "insufficient stake to propose"
-        );
+        if proposer_balance < min_stake {
+            return Err(GovernanceError::InsufficientStake);
+        }
 
         let voting_period: u64 = env
             .storage()
@@ -298,7 +342,8 @@ impl Governance {
         let now = env.ledger().timestamp();
         let vote_end = now + voting_period;
         let execute_after = vote_end + timelock;
-        let expires_at = execute_after + timelock; // extra window to execute
+        // Execution window: at least one voting period even when timelock is 0.
+        let expires_at = execute_after + timelock.max(voting_period);
 
         let id: u32 = env
             .storage()
@@ -334,14 +379,14 @@ impl Governance {
             (id, proposer, kind, vote_end),
         );
 
-        id
+        Ok(id)
     }
 
     /// Cast a vote on an active proposal.
     ///
     /// Voting power = voter's current LP balance, which is then locked until
     /// the proposal concludes. Each address may only vote once per proposal.
-    pub fn vote(env: Env, voter: Address, proposal_id: u32, choice: Vote) {
+    pub fn vote(env: Env, voter: Address, proposal_id: u32, choice: Vote) -> Result<(), GovernanceError> {
         voter.require_auth();
 
         let proposal_key = DataKey::Proposal(proposal_id);
@@ -349,22 +394,34 @@ impl Governance {
             .storage()
             .persistent()
             .get(&proposal_key)
-            .expect("proposal not found");
+            .ok_or(GovernanceError::ProposalNotFound)?;
         Self::bump_key_ttl(&env, &proposal_key);
 
         let now = env.ledger().timestamp();
-        assert!(now >= proposal.vote_start, "voting not started");
-        assert!(now <= proposal.vote_end, "voting period has ended");
-        assert!(!proposal.executed, "proposal already executed");
-        assert!(!proposal.cancelled, "proposal is cancelled");
+        if now < proposal.vote_start {
+            return Err(GovernanceError::VotingNotStarted);
+        }
+        if now > proposal.vote_end {
+            return Err(GovernanceError::VotingPeriodEnded);
+        }
+        if proposal.executed {
+            return Err(GovernanceError::AlreadyExecuted);
+        }
+        if proposal.cancelled {
+            return Err(GovernanceError::ProposalCancelled);
+        }
 
         let voted_key = DataKey::HasVoted(proposal_id, voter.clone());
-        assert!(!env.storage().persistent().has(&voted_key), "already voted");
+        if env.storage().persistent().has(&voted_key) {
+            return Err(GovernanceError::AlreadyVoted);
+        }
 
         let lp_token: Address = env.storage().instance().get(&DataKey::LpToken).unwrap();
         let lp_client = LpTokenClient::new(&env, &lp_token);
         let voting_power = lp_client.balance(&voter);
-        assert!(voting_power > 0, "no LP tokens: voting power is zero");
+        if voting_power == 0 {
+            return Err(GovernanceError::NoVotingPower);
+        }
         lp_client.lock(&voter, &voting_power);
 
         match choice {
@@ -398,43 +455,50 @@ impl Governance {
             (Symbol::new(&env, "voted"),),
             (proposal_id, voter, choice, voting_power),
         );
+        Ok(())
     }
 
     /// Execute a passed proposal after the timelock has elapsed.
     ///
     /// Anyone can call this once the conditions are met.
-    pub fn execute(env: Env, proposal_id: u32) {
+    pub fn execute(env: Env, proposal_id: u32) -> Result<(), GovernanceError> {
         let proposal_key = DataKey::Proposal(proposal_id);
         let mut proposal: Proposal = env
             .storage()
             .persistent()
             .get(&proposal_key)
-            .expect("proposal not found");
+            .ok_or(GovernanceError::ProposalNotFound)?;
         Self::bump_key_ttl(&env, &proposal_key);
 
-        assert!(!proposal.executed, "already executed");
-        assert!(!proposal.cancelled, "proposal is cancelled");
+        if proposal.executed {
+            return Err(GovernanceError::AlreadyExecuted);
+        }
+        if proposal.cancelled {
+            return Err(GovernanceError::ProposalCancelled);
+        }
 
         let now = env.ledger().timestamp();
 
-        assert!(now > proposal.vote_end, "voting period not ended");
-        assert!(now <= proposal.expires_at, "proposal expired");
-        assert!(now >= proposal.execute_after, "timelock not elapsed");
+        if now <= proposal.vote_end {
+            return Err(GovernanceError::VotingPeriodActive);
+        }
+        if now > proposal.expires_at {
+            return Err(GovernanceError::ProposalExpired);
+        }
+        if now < proposal.execute_after {
+            return Err(GovernanceError::TimelockNotElapsed);
+        }
 
         let quorum_bps: i128 = env.storage().instance().get(&DataKey::QuorumBps).unwrap();
         let total_votes = proposal.votes_for + proposal.votes_against + proposal.votes_abstain;
         let quorum_threshold = proposal.snapshot_total_supply * quorum_bps / MAX_BPS;
-        assert!(
-            total_votes >= quorum_threshold,
-            "quorum not met: votes={total_votes}, required={quorum_threshold}"
-        );
+        if total_votes < quorum_threshold {
+            return Err(GovernanceError::QuorumNotMet);
+        }
 
-        assert!(
-            proposal.votes_for > proposal.votes_against,
-            "proposal defeated: for={}, against={}",
-            proposal.votes_for,
-            proposal.votes_against
-        );
+        if proposal.votes_for <= proposal.votes_against {
+            return Err(GovernanceError::ProposalDefeated);
+        }
 
         let amm_pool: Address = env.storage().instance().get(&DataKey::AmmPool).unwrap();
         let amm_client = AmmPoolClient::new(&env, &amm_pool);
@@ -469,11 +533,12 @@ impl Governance {
             (Symbol::new(&env, "executed"),),
             (proposal_id, proposal.kind.clone()),
         );
+        Ok(())
     }
 
     /// Cancel an active proposal. Only the original proposer can cancel,
     /// and only while voting is still open.
-    pub fn cancel_proposal(env: Env, proposal_id: u32, proposer: Address) {
+    pub fn cancel_proposal(env: Env, proposal_id: u32, proposer: Address) -> Result<(), GovernanceError> {
         proposer.require_auth();
 
         let proposal_key = DataKey::Proposal(proposal_id);
@@ -481,16 +546,21 @@ impl Governance {
             .storage()
             .persistent()
             .get(&proposal_key)
-            .expect("proposal not found");
+            .ok_or(GovernanceError::ProposalNotFound)?;
         Self::bump_key_ttl(&env, &proposal_key);
 
-        assert!(!proposal.executed, "cannot cancel executed proposal");
-        assert!(!proposal.cancelled, "already cancelled");
-        assert!(
-            env.ledger().timestamp() <= proposal.vote_end,
-            "voting period ended"
-        );
-        assert!(proposal.proposer == proposer, "not the proposer");
+        if proposal.executed {
+            return Err(GovernanceError::AlreadyExecuted);
+        }
+        if proposal.cancelled {
+            return Err(GovernanceError::ProposalCancelled);
+        }
+        if env.ledger().timestamp() > proposal.vote_end {
+            return Err(GovernanceError::VotingPeriodEnded);
+        }
+        if proposal.proposer != proposer {
+            return Err(GovernanceError::NotProposer);
+        }
 
         proposal.cancelled = true;
         env.storage().persistent().set(&proposal_key, &proposal);
@@ -498,6 +568,7 @@ impl Governance {
 
         env.events()
             .publish((Symbol::new(&env, "cancelled"),), (proposal_id,));
+        Ok(())
     }
 
     /// Query how an address voted on a proposal.
@@ -529,23 +600,31 @@ impl Governance {
     }
 
     /// Unlock voting power for a concluded proposal.
-    pub fn unlock_vote(env: Env, voter: Address, proposal_id: u32) {
+    pub fn unlock_vote(env: Env, voter: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         voter.require_auth();
         let status = Self::proposal_status(env.clone(), proposal_id);
-        assert!(
-            status == ProposalStatus::Executed
-                || status == ProposalStatus::Defeated
-                || status == ProposalStatus::Expired
-                || status == ProposalStatus::Cancelled,
-            "proposal not concluded"
-        );
+        if status != ProposalStatus::Executed
+            && status != ProposalStatus::Defeated
+            && status != ProposalStatus::Expired
+            && status != ProposalStatus::Cancelled
+        {
+            return Err(GovernanceError::ProposalNotConcluded);
+        }
         let lock_key = DataKey::LockedVote(proposal_id, voter.clone());
         let locked: i128 = env.storage().persistent().get(&lock_key).unwrap_or(0);
-        assert!(locked > 0, "no locked vote");
+        if locked == 0 {
+            return Err(GovernanceError::NoLockedVote);
+        }
 
         let lp_token: Address = env.storage().instance().get(&DataKey::LpToken).unwrap();
         LpTokenClient::new(&env, &lp_token).unlock(&voter, &locked);
         env.storage().persistent().remove(&lock_key);
+
+        env.events().publish(
+            (Symbol::new(&env, "vote_unlocked"), voter.clone()),
+            (proposal_id, locked),
+        );
+        Ok(())
     }
 
     /// Delegate voting power to another address.
@@ -559,9 +638,11 @@ impl Governance {
     ///
     /// # Panics
     /// - If `from` is the same as `to`.
-    pub fn delegate(env: Env, from: Address, to: Address) {
+    pub fn delegate(env: Env, from: Address, to: Address) -> Result<(), GovernanceError> {
         from.require_auth();
-        assert!(from != to, "cannot delegate to self");
+        if from == to {
+            return Err(GovernanceError::CannotDelegateToSelf);
+        }
 
         env.storage()
             .instance()
@@ -569,6 +650,7 @@ impl Governance {
 
         env.events()
             .publish((Symbol::new(&env, "delegated"),), (from, to));
+        Ok(())
     }
 
     /// Remove delegation of voting power.
@@ -1190,6 +1272,121 @@ mod tests {
         let result = gov.try_execute(&pid);
         assert!(result.is_err());
     }
+
+    // ── Issue #188: set_timelock_delay ────────────────────────────────────────
+
+    #[test]
+    fn test_timelock_delay_zero_allows_immediate_execution() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+        let lp1 = Address::generate(&s.env);
+        let lp2 = Address::generate(&s.env);
+        mint_lp(&s, &lp1, 600);
+        mint_lp(&s, &lp2, 400);
+
+        // Set timelock delay to 0 so execution is allowed immediately after vote_end.
+        gov.set_timelock_delay(&0_u64);
+        let params = gov.get_params();
+        assert_eq!(params.timelock_secs, 0);
+
+        let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+        gov.vote(&lp1, &pid, &Vote::For);
+        gov.vote(&lp2, &pid, &Vote::For);
+
+        let proposal = gov.get_proposal(&pid);
+        // With timelock = 0: execute_after = vote_end, expires_at = vote_end + voting_period.
+        // Jump to execute_after + 1 to satisfy now >= execute_after.
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+        gov.execute(&pid);
+        assert_eq!(gov.proposal_status(&pid), ProposalStatus::Executed);
+    }
+
+    #[test]
+    fn test_execute_reverts_before_timelock_elapses() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+        let lp1 = Address::generate(&s.env);
+        let lp2 = Address::generate(&s.env);
+        mint_lp(&s, &lp1, 600);
+        mint_lp(&s, &lp2, 400);
+
+        let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+        gov.vote(&lp1, &pid, &Vote::For);
+        gov.vote(&lp2, &pid, &Vote::For);
+
+        let proposal = gov.get_proposal(&pid);
+        // Jump past vote_end but NOT past execute_after.
+        s.env.ledger().set_timestamp(proposal.vote_end + 1);
+
+        let result = gov.try_execute(&pid);
+        assert_eq!(result, Err(Ok(GovernanceError::TimelockNotElapsed)));
+    }
+
+    #[test]
+    fn test_execute_succeeds_after_timelock_elapses() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+        let lp1 = Address::generate(&s.env);
+        let lp2 = Address::generate(&s.env);
+        mint_lp(&s, &lp1, 600);
+        mint_lp(&s, &lp2, 400);
+
+        let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+        gov.vote(&lp1, &pid, &Vote::For);
+        gov.vote(&lp2, &pid, &Vote::For);
+
+        let proposal = gov.get_proposal(&pid);
+        // Jump past execute_after.
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+        gov.execute(&pid);
+        assert_eq!(gov.proposal_status(&pid), ProposalStatus::Executed);
+    }
+
+    // ── Issue #189: vote_unlocked event ──────────────────────────────────────
+
+    #[test]
+    fn test_unlock_vote_emits_vote_unlocked_event() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::IntoVal;
+
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+        let lp1 = Address::generate(&s.env);
+        let lp2 = Address::generate(&s.env);
+        mint_lp(&s, &lp1, 600);
+        mint_lp(&s, &lp2, 400);
+
+        let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+        gov.vote(&lp1, &pid, &Vote::For);
+        gov.vote(&lp2, &pid, &Vote::For);
+
+        let proposal = gov.get_proposal(&pid);
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+        gov.execute(&pid);
+
+        gov.unlock_vote(&lp1, &pid);
+
+        let events = s.env.events().all();
+        let unlock_evt = events
+            .iter()
+            .find(|e| {
+                e.0 == s.gov_addr
+                    && e.1
+                        == (Symbol::new(&s.env, "vote_unlocked"), lp1.clone())
+                            .into_val(&s.env)
+            })
+            .expect("vote_unlocked event not emitted");
+
+        let data: (u32, i128) = unlock_evt.2.into_val(&s.env);
+        assert_eq!(data.0, pid);
+        assert_eq!(data.1, 600_i128); // amount_unlocked == voting power used
+    }
 }
 
 // ── Property-based tests ───────────────────────────────────────────────────────
@@ -1253,16 +1450,16 @@ mod prop_tests {
             prop_assert!(min_stake <= total_supply.max(1));
         }
 
-        /// Property 6: Expiry logic boundaries always remain correct.
+        /// Property 6: Expiry always comes at or after execute_after.
         #[test]
         fn expiry_logic_boundaries(
             vote_end in 0u64..u64::MAX / 3,
             timelock in 0u64..u64::MAX / 3,
+            voting_period in 1u64..u64::MAX / 3,
         ) {
             let execute_after = vote_end + timelock;
-            let expires_at = execute_after + timelock;
+            let expires_at = execute_after + timelock.max(voting_period);
             prop_assert!(expires_at >= execute_after);
-            prop_assert_eq!(expires_at, vote_end + 2 * timelock);
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves four open issues across the soroban-amm contracts.

closes #186 — Emergency pause for concentrated_liquidity

- `DataKey::Admin` and `DataKey::Paused` are now written during `initialize`, which gains an `admin: Address` parameter.
- `pause(admin)` / `unpause(admin)` require caller auth and check the stored admin address; they return `Err(ClError::Unauthorized)` if a non-admin calls them.
- `is_paused()` is a cheap boolean read.
- `mint_position` and `swap` return `Err(ClError::Paused)` immediately when the pool is paused.
- `burn_position` and `collect_fees` deliberately have no pause guard so LPs can always withdraw their principal and fees.
- The factory's `ClPoolInterface` and `create_cl_pool` are updated to pass the factory admin as the CL pool admin on deployment.
- The file also fixes pre-existing compile errors: duplicate `use soroban_sdk` imports, a broken `swap` stub that referenced undefined variables (`token_in`, `buyer`, `target_tick`), and orphaned swap-loop code that had been accidentally placed inside `quote_position`.

closes #188 — Governance timelock delay

The timelock mechanism was already structurally present. This PR adds:

- `set_timelock_delay(new_delay: u64)` — admin-only; updates the stored `Timelock` value in-place. A delay of 0 is accepted.
- `expires_at` now uses `execute_after + timelock.max(voting_period)` so proposals always have a non-zero execution window even when the delay is set to 0.
- Three new unit tests: zero-delay allows execution immediately after `vote_end`; non-zero delay reverts with `GovernanceError::TimelockNotElapsed` before `execute_after`; execution succeeds once `execute_after` is reached.
 closes #189 — vote_unlocked event
closes #190 
After `unlock_vote` removes the lock entry, it publishes:

