### PR TITLE
feat: add price impact to simulate_swap, pool_created event test, cargo-audit CI and tick_spacing to concentrated_liquidity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,13 @@ jobs:
       - name: Check docs
         run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
 
+      - name: Security audit
+        uses: rustsec/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        # Advisories can be ignored via audit.toml at the repo root.
+        # Example:
+        #   [[ignore]]
+        #   id = "RUSTSEC-0000-0000"
+        #   reason = "Not exploitable in this context because ..."
+

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -3548,4 +3548,52 @@ mod prop_tests {
         let data: (Address,) = evt.2.into_val(env);
         assert_eq!(data, (nominee,));
     }
+    // Issue #193: simulate_swap price_impact_bps grows for large swaps.
+    #[test]
+    fn test_simulate_swap_price_impact_bps() {
+        let ts = setup_pool(30); // 0.30 % fee
+        let env = &ts.env;
+        let amm = AmmPoolClient::new(env, &ts.amm_addr);
+
+        // Mint tokens for the provider and seed the pool with 1_000_000 of each.
+        let provider = Address::generate(env);
+        let ta_sac = soroban_sdk::token::StellarAssetClient::new(env, &ts.ta_addr);
+        let tb_sac = soroban_sdk::token::StellarAssetClient::new(env, &ts.tb_addr);
+        ta_sac.mint(&provider, &2_000_000_i128);
+        tb_sac.mint(&provider, &2_000_000_i128);
+
+        amm.add_liquidity(
+            &provider,
+            &1_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        )
+        .unwrap();
+
+        // --- Tiny swap: price_impact_bps should be 0 (rounds to 0 at 1 unit). ---
+        let tiny = amm.simulate_swap(&ts.ta_addr, &1_i128).unwrap();
+        // spot and effective price differ by sub-bps amounts for 1-unit swap.
+        assert_eq!(tiny.price_impact_bps, 0);
+
+        // --- Large swap: price_impact_bps must be positive. ---
+        let large = amm.simulate_swap(&ts.ta_addr, &100_000_i128).unwrap();
+        // With reserves 1_000_000 / 1_000_000 and amount_in 100_000 (10 % of pool):
+        //   spot_price  = 1_000_000 * 1_000_000 / 1_000_000 = 1_000_000
+        //   amount_in_with_fee = 100_000 * (10000 - 30) = 997_000_000
+        //   amount_out ≈ 90_661; effective_price ≈ 906_610
+        //   price_impact_bps ≈ 934
+        assert!(large.price_impact_bps > 0, "price_impact_bps must be positive for large swap");
+
+        // Larger swap must have higher price impact than smaller swap.
+        let medium = amm.simulate_swap(&ts.ta_addr, &10_000_i128).unwrap();
+        assert!(
+            large.price_impact_bps > medium.price_impact_bps,
+            "larger swap must have larger price impact"
+        );
+        assert!(
+            medium.price_impact_bps > tiny.price_impact_bps,
+            "medium swap must have larger price impact than tiny"
+        );
+    }
 }

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -33,6 +33,8 @@ pub enum ClError {
     DeadlineExpired     = 10,
     Paused              = 11,
     Unauthorized        = 12,
+    TickNotAligned      = 13, // tick is not a multiple of tick_spacing
+    InvalidTickSpacing  = 14, // tick_spacing must be > 0
 }
 
 #[contracttype]
@@ -55,6 +57,7 @@ pub enum DataKey {
     TickBitmap(i32),
     Admin,
     Paused,
+    TickSpacing,              // i32 — only multiples of this value may be initialized as ticks
 }
 
 #[contracttype]
@@ -74,6 +77,7 @@ pub struct PoolState {
     pub sqrt_price: u128,
     pub current_tick: i32,
     pub active_liquidity: i128,
+    pub tick_spacing: i32,
 }
 
 #[contracttype]
@@ -90,7 +94,12 @@ pub struct ConcentratedLiquidity;
 
 #[contractimpl]
 impl ConcentratedLiquidity {
-    /// One-time initialisation. Sets admin, token pair, fee, and starting tick.
+    /// One-time initialisation. Sets admin, token pair, fee, starting tick, and tick spacing.
+    ///
+    /// `tick_spacing` must be > 0. Only tick values that are exact multiples of
+    /// `tick_spacing` may be used as position boundaries in `mint_position`.
+    /// Suggested defaults: fee 5 bps → spacing 1, fee 30 bps → spacing 10,
+    /// fee 100 bps → spacing 60.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -98,6 +107,7 @@ impl ConcentratedLiquidity {
         token_b: Address,
         fee_bps: i128,
         initial_tick: i32,
+        tick_spacing: i32,
     ) -> Result<(), ClError> {
         if env.storage().instance().has(&DataKey::TokenA) {
             return Err(ClError::AlreadyInitialized);
@@ -111,12 +121,16 @@ impl ConcentratedLiquidity {
         if !(MIN_TICK..=MAX_TICK).contains(&initial_tick) {
             return Err(ClError::TickOutOfRange);
         }
+        if tick_spacing <= 0 {
+            return Err(ClError::InvalidTickSpacing);
+        }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::TokenA, &token_a);
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
         env.storage().instance().set(&DataKey::CurrentTick, &initial_tick);
+        env.storage().instance().set(&DataKey::TickSpacing, &tick_spacing);
         env.storage().instance().set(&DataKey::FeeGrowthGlobalA, &0_i128);
         env.storage().instance().set(&DataKey::FeeGrowthGlobalB, &0_i128);
         env.storage().instance().set(&DataKey::ActiveLiquidity, &0_i128);
@@ -173,6 +187,15 @@ impl ConcentratedLiquidity {
         }
         if lower_tick < MIN_TICK || upper_tick > MAX_TICK {
             return Err(ClError::TickOutOfRange);
+        }
+        // Enforce tick spacing: ticks must be multiples of tick_spacing.
+        let tick_spacing: i32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TickSpacing)
+            .unwrap_or(1);
+        if lower_tick % tick_spacing != 0 || upper_tick % tick_spacing != 0 {
+            return Err(ClError::TickNotAligned);
         }
         if amount_a_desired <= 0 && amount_b_desired <= 0 {
             return Err(ClError::ZeroAmounts);
@@ -450,6 +473,11 @@ impl ConcentratedLiquidity {
             .instance()
             .get(&DataKey::ActiveLiquidity)
             .unwrap_or(0);
+        let tick_spacing: i32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TickSpacing)
+            .unwrap_or(1);
         let sqrt_price = env
             .storage()
             .instance()
@@ -463,6 +491,7 @@ impl ConcentratedLiquidity {
             sqrt_price,
             current_tick,
             active_liquidity,
+            tick_spacing,
         }
     }
 
@@ -1236,7 +1265,7 @@ mod tests {
 
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &fee_bps, &initial_tick);
+        client.initialize(&admin, &token_a, &token_b, &fee_bps, &initial_tick, &1_i32);
 
         let sac_a = StellarAssetClient::new(env, &token_a);
         let sac_b = StellarAssetClient::new(env, &token_b);
@@ -1494,7 +1523,7 @@ mod test {
 
         let contract_id = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &contract_id);
-        client.initialize(&admin, &token_a_addr, &token_b_addr, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a_addr, &token_b_addr, &30_i128, &0_i32, &1_i32);
 
         let provider = Address::generate(&env);
         StellarAssetClient::new(&env, &token_a_addr).mint(&provider, &1_000_i128);
@@ -1549,7 +1578,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &1_i32);
         (admin, token_a, token_b, client)
     }
 
@@ -1566,7 +1595,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &10_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &10_i32, &1_i32);
 
         // Mint tokens for swapping
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
@@ -1606,7 +1635,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &5_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &5_i32, &1_i32);
 
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
         StellarAssetClient::new(&env, &token_b).mint(&cl_addr, &1_000_000_i128);
@@ -1633,7 +1662,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &1_i32);
 
         StellarAssetClient::new(&env, &token_a).mint(&cl_addr, &1_000_000_i128);
         StellarAssetClient::new(&env, &token_b).mint(&cl_addr, &1_000_000_i128);
@@ -1671,7 +1700,7 @@ mod test_new_features {
         let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &1_i32);
 
         let provider = Address::generate(&env);
         StellarAssetClient::new(&env, &token_a).mint(&provider, &10_000_i128);
@@ -1708,7 +1737,7 @@ mod test_new_features {
         let cl_addr = env.register_contract(None, ConcentratedLiquidity);
         let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
         // current_tick = 0; range [100, 200] is entirely above → pure token-A position
-        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &1_i32);
 
         // quote_position: above-range means all in token_a → (liquidity, 0)
         let (qa, qb) = client.quote_position(&100_i32, &200_i32, &3_000_i128);
@@ -1740,5 +1769,114 @@ mod test_new_features {
         );
         assert_eq!(ma2, qa2);
         assert_eq!(mb2, qb2);
+    }
+}
+
+// ── Issue #187: tick_spacing tests ───────────────────────────────────────────
+#[cfg(test)]
+mod test_tick_spacing {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::token::StellarAssetClient;
+    use soroban_sdk::Env;
+
+    fn setup_cl(env: &Env, tick_spacing: i32) -> (Address, Address, Address, ConcentratedLiquidityClient) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let token_a = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let cl_addr = env.register_contract(None, ConcentratedLiquidity);
+        let client = ConcentratedLiquidityClient::new(env, &cl_addr);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &tick_spacing);
+
+        let provider = Address::generate(env);
+        StellarAssetClient::new(env, &token_a).mint(&provider, &1_000_000_i128);
+        StellarAssetClient::new(env, &token_b).mint(&provider, &1_000_000_i128);
+        (provider, token_a, token_b, client)
+    }
+
+    /// Ticks that are exact multiples of tick_spacing must be accepted.
+    #[test]
+    fn test_aligned_ticks_succeed() {
+        let env = Env::default();
+        let (provider, _ta, _tb, client) = setup_cl(&env, 10);
+
+        // -100 and 100 are both multiples of 10 → must succeed.
+        let result = client.try_mint_position(
+            &provider, &-100_i32, &100_i32,
+            &100_000_i128, &100_000_i128,
+            &0_i128, &0_i128,
+        );
+        assert!(result.is_ok(), "aligned ticks should be accepted");
+    }
+
+    /// Ticks that are NOT multiples of tick_spacing must be rejected.
+    #[test]
+    fn test_misaligned_lower_tick_rejected() {
+        let env = Env::default();
+        let (provider, _ta, _tb, client) = setup_cl(&env, 10);
+
+        // lower_tick = -95 is not a multiple of 10.
+        let result = client.try_mint_position(
+            &provider, &-95_i32, &100_i32,
+            &100_000_i128, &100_000_i128,
+            &0_i128, &0_i128,
+        );
+        assert_eq!(result, Err(Ok(ClError::TickNotAligned)));
+    }
+
+    /// Misaligned upper tick must also be rejected.
+    #[test]
+    fn test_misaligned_upper_tick_rejected() {
+        let env = Env::default();
+        let (provider, _ta, _tb, client) = setup_cl(&env, 10);
+
+        // upper_tick = 105 is not a multiple of 10.
+        let result = client.try_mint_position(
+            &provider, &-100_i32, &105_i32,
+            &100_000_i128, &100_000_i128,
+            &0_i128, &0_i128,
+        );
+        assert_eq!(result, Err(Ok(ClError::TickNotAligned)));
+    }
+
+    /// tick_spacing = 0 must be rejected at initialize time.
+    #[test]
+    fn test_zero_tick_spacing_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_a = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let cl_addr = env.register_contract(None, ConcentratedLiquidity);
+        let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
+
+        let result = client.try_initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &0_i32);
+        assert_eq!(result, Err(Ok(ClError::InvalidTickSpacing)));
+    }
+
+    /// get_pool_state must include tick_spacing set at initialize time.
+    #[test]
+    fn test_get_pool_state_returns_tick_spacing() {
+        let env = Env::default();
+        let (_provider, _ta, _tb, client) = setup_cl(&env, 60);
+
+        let state = client.get_pool_state();
+        assert_eq!(state.tick_spacing, 60, "get_pool_state must return tick_spacing = 60");
+    }
+
+    /// tick_spacing = 1 allows every tick (no restriction).
+    #[test]
+    fn test_spacing_one_allows_any_tick() {
+        let env = Env::default();
+        let (provider, _ta, _tb, client) = setup_cl(&env, 1);
+
+        // Odd ticks (not multiples of anything > 1) should work fine.
+        let result = client.try_mint_position(
+            &provider, &-7_i32, &13_i32,
+            &100_000_i128, &100_000_i128,
+            &0_i128, &0_i128,
+        );
+        assert!(result.is_ok(), "tick_spacing=1 must allow any tick pair");
     }
 }

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -36,6 +36,7 @@ pub trait ClPoolInterface {
         token_b: Address,
         fee_bps: i128,
         initial_tick: i32,
+        tick_spacing: i32,
     );
 }
 
@@ -381,7 +382,14 @@ impl Factory {
             .deploy(cl_wasm);
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        ClPoolClient::new(&env, &pool_addr).initialize(&admin, &ta, &tb, &fee_bps, &initial_tick);
+        // Derive tick_spacing from fee tier (matching Uniswap v3 conventions).
+        let tick_spacing: i32 = match fee_bps {
+            5   => 1,
+            30  => 10,
+            100 => 60,
+            _   => 1,
+        };
+        ClPoolClient::new(&env, &pool_addr).initialize(&admin, &ta, &tb, &fee_bps, &initial_tick, &tick_spacing);
 
         env.storage().instance().set(&cl_key, &pool_addr);
 
@@ -861,5 +869,86 @@ mod tests {
         // Limit = 0.
         let page5 = factory.get_pools(&1u32, &0u32);
         assert_eq!(page5.len(), 0);
+    }
+
+    // ── Issue #194: pool_created event ───────────────────────────────────────
+
+    #[test]
+    fn test_create_pool_emits_pool_created_event() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::IntoVal;
+
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        let (pool_addr, _) = factory.create_pool(&ta, &tb, &30_i128, &None);
+
+        // Locate the pool_created event.
+        let events = env.events().all();
+        let expected_topic: soroban_sdk::Vec<soroban_sdk::Val> =
+            (Symbol::new(&env, "pool_created"),).into_val(&env);
+
+        let event = events
+            .iter()
+            .find(|e| e.0 == factory_addr && e.1 == expected_topic)
+            .expect("pool_created event must be emitted on successful create_pool");
+
+        // The event data is (token_a, token_b, pool_address, fee_bps, lp_token_address).
+        // Normalised token order may differ — just assert pool and fee_bps fields.
+        let lp_addr = factory.get_lp_token(&pool_addr).unwrap();
+        let data: (Address, Address, Address, i128, Address) = event.2.into_val(&env);
+        assert_eq!(data.2, pool_addr,   "pool address in event must match");
+        assert_eq!(data.3, 30_i128,     "fee_bps in event must be 30");
+        assert_eq!(data.4, lp_addr,     "lp_token address in event must match");
+    }
+
+    #[test]
+    fn test_create_pool_duplicate_does_not_emit_event() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::IntoVal;
+
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        factory.create_pool(&ta, &tb, &30_i128, &None);
+
+        // Clear events so we only see events from the second (failing) call.
+        // Soroban test env accumulates events — count before the duplicate attempt.
+        let count_before = env.events().all().len();
+
+        // Duplicate call must fail.
+        let result = factory.try_create_pool(&ta, &tb, &30_i128, &None);
+        assert!(result.is_err(), "duplicate pool creation must fail");
+
+        // No new events must have been added.
+        let count_after = env.events().all().len();
+        assert_eq!(
+            count_before, count_after,
+            "no event should be emitted when create_pool reverts"
+        );
     }
 }


### PR DESCRIPTION

## Summary

Resolves four open issues across the AMM, factory, concentrated-liquidity, and CI pipeline.

---

### feat: add `price_impact_bps` to `simulate_swap` response

The `SwapSimulation` struct already held the field but had no test coverage. Adds `test_simulate_swap_price_impact_bps` which verifies:

- `price_impact_bps` is `0` for an infinitesimally small (1-unit) swap — rounds away at sub-basis-point level
- `price_impact_bps` is positive for a large swap (~10 % of pool depth)
- Impact grows monotonically with swap size (large > medium > tiny)

Formula used: `(spot_price - effective_price) / spot_price * 10_000`

Closes #193

---

### feat: assert `pool_created` event on every new pool deployment

The event was already emitted by `create_pool` but had no test coverage. Adds two unit tests:

- `test_create_pool_emits_pool_created_event` — asserts the event fires on success and that `pool_address`, `fee_bps`, and `lp_token_address` in the event data match the deployed contracts
- `test_create_pool_duplicate_does_not_emit_event` — asserts that a reverted duplicate-pool call emits zero new events

Closes #194

---

### chore: add `cargo audit` to CI for known vulnerability advisories

Adds a `Security audit` step to `.github/workflows/ci.yml` using the maintained `rustsec/audit-check@v1` GitHub Action. CI will fail on any unfixed advisory in a direct or transitive dependency. Advisories can be silenced by adding an `[[ignore]]` block to `audit.toml` at the repo root with a written justification.

Closes #191

---

### feat: add `tick_spacing` parameter to `concentrated_liquidity`

Implements Uniswap v3-style tick spacing to reduce the number of initializable ticks, making tick bitmap lookups cheaper for swaps.

**Changes:**
- `DataKey::TickSpacing` — new persistent storage key (set at `initialize`)
- Two new error variants: `TickNotAligned = 13`, `InvalidTickSpacing = 14`
- `initialize` now takes `tick_spacing: i32` — validated `> 0`
- `mint_position` rejects any tick where `tick % tick_spacing != 0`
- `PoolState` gains `tick_spacing: i32`, returned by `get_pool_state`
- Factory `create_cl_pool` derives spacing automatically from fee tier: `5 bps → 1`, `30 bps → 10`, `100 bps → 60`
- All existing tests updated (pass `tick_spacing = 1` — no behavioral change)
- Five new unit tests: aligned ticks accepted, misaligned lower/upper tick rejected, zero spacing rejected at init, `get_pool_state` returns correct value, `tick_spacing = 1` allows all ticks

Closes #187
