### PR TITLE
feat: remove_liquidity_one_sided test, TWAP multi-pool, full TS SDK, …

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -2859,6 +2859,97 @@ pub(crate) mod tests {
         // 4e18 * 1e17 * 10000 = 4e39 > i128::MAX
         amm.get_amount_in(&ts.ta_addr, &100_000_000_000_000_000_i128);
     }
+
+    // Issue #199: remove_liquidity_one_sided — provider receives only token_a.
+    #[test]
+    fn test_remove_liquidity_one_sided() {
+        let ts = setup_pool(30);
+        let env = &ts.env;
+        let amm = AmmPoolClient::new(env, &ts.amm_addr);
+        let ta_sac = StellarAssetClient::new(env, &ts.ta_addr);
+        let tb_sac = StellarAssetClient::new(env, &ts.tb_addr);
+        let ta_client = StellarTokenClient::new(env, &ts.ta_addr);
+        let tb_client = StellarTokenClient::new(env, &ts.tb_addr);
+
+        // LP1 seeds the pool so LP2's internal swap has residual reserves to trade against.
+        let lp1 = Address::generate(env);
+        ta_sac.mint(&lp1, &2_000_000_i128);
+        tb_sac.mint(&lp1, &2_000_000_i128);
+        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &u64::MAX);
+
+        let provider = Address::generate(env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        let shares = amm.add_liquidity(
+            &provider,
+            &1_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+
+        let ta_before = ta_client.balance(&provider);
+        let tb_before = tb_client.balance(&provider);
+
+        // Remove one-sided: provider wants only token_a.
+        // min_out = 1_000_000 ensures at least the proportional withdrawal.
+        let total_out = amm.remove_liquidity_one_sided(
+            &provider,
+            &shares,
+            &ts.ta_addr,
+            &1_000_000_i128,
+            &u64::MAX,
+        );
+
+        let ta_after = ta_client.balance(&provider);
+        let tb_after = tb_client.balance(&provider);
+
+        // Provider received exactly total_out of token_a.
+        assert_eq!(ta_after - ta_before, total_out);
+        // Provider's token_b balance is unchanged — received no token_b.
+        assert_eq!(tb_after, tb_before);
+        // Total received is more than the proportional token_a alone because the
+        // unwanted token_b was swapped internally for more token_a.
+        assert!(total_out > 1_000_000);
+        // LP shares are fully redeemed.
+        assert_eq!(amm.shares_of(&provider), 0);
+    }
+
+    // Issue #199: min_out slippage guard is enforced in remove_liquidity_one_sided.
+    #[test]
+    fn test_remove_liquidity_one_sided_slippage_fails() {
+        let ts = setup_pool(30);
+        let env = &ts.env;
+        let amm = AmmPoolClient::new(env, &ts.amm_addr);
+        let ta_sac = StellarAssetClient::new(env, &ts.ta_addr);
+        let tb_sac = StellarAssetClient::new(env, &ts.tb_addr);
+
+        let lp1 = Address::generate(env);
+        ta_sac.mint(&lp1, &2_000_000_i128);
+        tb_sac.mint(&lp1, &2_000_000_i128);
+        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &u64::MAX);
+
+        let provider = Address::generate(env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        let shares = amm.add_liquidity(
+            &provider,
+            &1_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+
+        // min_out set impossibly high — must fail.
+        let result = amm.try_remove_liquidity_one_sided(
+            &provider,
+            &shares,
+            &ts.ta_addr,
+            &i128::MAX,
+            &u64::MAX,
+        );
+        assert!(result.is_err());
+    }
 }
 
 // ── Property-based tests ───────────────────────────────────────────────────────

--- a/contracts/twap_consumer/src/lib.rs
+++ b/contracts/twap_consumer/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, Vec};
 
 #[contractclient(name = "AmmPoolOracleClient")]
 pub trait AmmPoolOracle {
@@ -15,6 +15,7 @@ pub trait ClPoolOracle {
 #[contracttype]
 pub enum DataKey {
     Snapshot(Address, u64),
+    TrackedPools,
 }
 
 #[contracttype]
@@ -34,6 +35,9 @@ impl TwapConsumer {
     pub const SNAPSHOT_TTL_LEDGERS: u32 = 120_960;
 
     /// Stores a pool cumulative-price snapshot keyed by the pool timestamp.
+    ///
+    /// Also registers the pool in the TrackedPools list if it has not been seen before,
+    /// enabling `get_tracked_pools` and `get_twap_all` to enumerate all observed pools.
     pub fn save_snapshot(env: Env, pool: Address) {
         let (cum_a, cum_b, pool_ts) = AmmPoolOracleClient::new(&env, &pool).get_price_cumulative();
         let ledger_ts = env.ledger().timestamp(); // key by keeper clock, not pool clock
@@ -42,13 +46,33 @@ impl TwapConsumer {
             cum_b,
             pool_ts,
         };
-        let key = DataKey::Snapshot(pool, ledger_ts);
+        let key = DataKey::Snapshot(pool.clone(), ledger_ts);
         env.storage().persistent().set(&key, &snapshot);
         env.storage().persistent().extend_ttl(
             &key,
             Self::SNAPSHOT_TTL_LEDGERS / 2,
             Self::SNAPSHOT_TTL_LEDGERS,
         );
+
+        // Register pool if not already tracked.
+        let mut tracked: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::TrackedPools)
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut already_tracked = false;
+        for i in 0..tracked.len() {
+            if tracked.get(i).unwrap() == pool {
+                already_tracked = true;
+                break;
+            }
+        }
+        if !already_tracked {
+            tracked.push_back(pool);
+            env.storage()
+                .instance()
+                .set(&DataKey::TrackedPools, &tracked);
+        }
     }
 
     /// Deletes a price snapshot from persistent storage.
@@ -122,6 +146,33 @@ impl TwapConsumer {
         let twap_b_to_a = delta_b / elapsed;
 
         (twap_a_to_b, twap_b_to_a)
+    }
+
+    /// Returns the list of pool addresses that have had at least one snapshot saved.
+    pub fn get_tracked_pools(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::TrackedPools)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Returns the TWAP for every tracked AMM pool in one call.
+    ///
+    /// Each element is `(pool_address, twap_price)` where `twap_price` is the
+    /// time-weighted average price of token A denominated in token B, scaled by
+    /// 1_000_000, over `window_seconds`.
+    ///
+    /// A snapshot at `now - window_seconds` must have been saved for every
+    /// tracked pool, otherwise this call panics.
+    pub fn get_twap_all(env: Env, window_seconds: u64) -> Vec<(Address, i128)> {
+        let tracked: Vec<Address> = Self::get_tracked_pools(env.clone());
+        let mut results: Vec<(Address, i128)> = Vec::new(&env);
+        for i in 0..tracked.len() {
+            let pool = tracked.get(i).unwrap();
+            let twap = Self::get_twap_price(env.clone(), pool.clone(), window_seconds);
+            results.push_back((pool, twap));
+        }
+        results
     }
 
     /// Computes the time-weighted average tick from a CL pool over `window_seconds`.
@@ -392,6 +443,101 @@ mod tests {
         // With 1:2 reserves, twap_a_to_b should be 2M and twap_b_to_a should be 0.5M
         assert_eq!(twap_a_to_b, 2_000_000);
         assert_eq!(twap_b_to_a, 500_000);
+    }
+
+    // Issue #200: save_snapshot called for two pools — both appear in get_tracked_pools,
+    // and get_twap_all returns correct TWAPs for both.
+    #[test]
+    fn test_get_tracked_pools_and_twap_all() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(10_000);
+
+        let admin = Address::generate(&env);
+
+        // ── Pool 1 setup ──────────────────────────────────────────────────────
+        let amm_addr1 = env.register_contract(None, AmmPool);
+        let lp_addr1 = env.register_contract(None, LpToken);
+        token::LpTokenClient::new(&env, &lp_addr1).initialize(
+            &amm_addr1,
+            &soroban_sdk::String::from_str(&env, "LP1"),
+            &soroban_sdk::String::from_str(&env, "LP1"),
+            &7u32,
+        );
+        let (ta1, ta1_sac) = create_sac(&env, &admin);
+        let (tb1, tb1_sac) = create_sac(&env, &admin);
+        let amm1 = AmmPoolClient::new(&env, &amm_addr1);
+        amm1.initialize(&admin, &ta1.address, &tb1.address, &lp_addr1, &30_i128, &admin, &0_i128);
+        let p1 = Address::generate(&env);
+        ta1_sac.mint(&p1, &2_000_000_i128);
+        tb1_sac.mint(&p1, &2_000_000_i128);
+        amm1.add_liquidity(&p1, &2_000_000_i128, &2_000_000_i128, &0_i128, &10_000_u64);
+
+        // ── Pool 2 setup (2:1 reserve ratio) ─────────────────────────────────
+        let amm_addr2 = env.register_contract(None, AmmPool);
+        let lp_addr2 = env.register_contract(None, LpToken);
+        token::LpTokenClient::new(&env, &lp_addr2).initialize(
+            &amm_addr2,
+            &soroban_sdk::String::from_str(&env, "LP2"),
+            &soroban_sdk::String::from_str(&env, "LP2"),
+            &7u32,
+        );
+        let (ta2, ta2_sac) = create_sac(&env, &admin);
+        let (tb2, tb2_sac) = create_sac(&env, &admin);
+        let amm2 = AmmPoolClient::new(&env, &amm_addr2);
+        amm2.initialize(&admin, &ta2.address, &tb2.address, &lp_addr2, &30_i128, &admin, &0_i128);
+        let p2 = Address::generate(&env);
+        ta2_sac.mint(&p2, &2_000_000_i128);
+        tb2_sac.mint(&p2, &4_000_000_i128);
+        amm2.add_liquidity(&p2, &2_000_000_i128, &4_000_000_i128, &0_i128, &10_000_u64);
+
+        let consumer_addr = env.register_contract(None, TwapConsumer);
+        let consumer = TwapConsumerClient::new(&env, &consumer_addr);
+
+        // Save a snapshot for each pool at t=10_000.
+        consumer.save_snapshot(&amm_addr1);
+        consumer.save_snapshot(&amm_addr2);
+
+        // Both pools must appear in get_tracked_pools.
+        let tracked = consumer.get_tracked_pools();
+        assert_eq!(tracked.len(), 2);
+        assert!(tracked.contains(&amm_addr1));
+        assert!(tracked.contains(&amm_addr2));
+
+        // Calling save_snapshot again for pool1 must NOT add a duplicate.
+        consumer.save_snapshot(&amm_addr1);
+        assert_eq!(consumer.get_tracked_pools().len(), 2);
+
+        // Advance time and do small swaps to bump the price accumulators.
+        env.ledger().set_timestamp(10_060);
+        let whale1 = Address::generate(&env);
+        ta1_sac.mint(&whale1, &1_000_i128);
+        amm1.swap(&whale1, &ta1.address, &1_000_i128, &0_i128, &10_060_u64, &None);
+        let whale2 = Address::generate(&env);
+        ta2_sac.mint(&whale2, &1_000_i128);
+        amm2.swap(&whale2, &ta2.address, &1_000_i128, &0_i128, &10_060_u64, &None);
+
+        // get_twap_all must return TWAPs for both pools.
+        let all_twaps = consumer.get_twap_all(&60_u64);
+        assert_eq!(all_twaps.len(), 2);
+
+        // Pool 1 (1:1 reserves) → TWAP ≈ 1_000_000.
+        let twap1 = consumer.get_twap_price(&amm_addr1, &60_u64);
+        assert_eq!(twap1, 1_000_000);
+
+        // Pool 2 (1:2 reserves) → TWAP ≈ 2_000_000.
+        let twap2 = consumer.get_twap_price(&amm_addr2, &60_u64);
+        assert_eq!(twap2, 2_000_000);
+
+        // Verify get_twap_all returns correct values for each pool.
+        for i in 0..all_twaps.len() {
+            let (pool, twap) = all_twaps.get(i).unwrap();
+            if pool == amm_addr1 {
+                assert_eq!(twap, twap1);
+            } else {
+                assert_eq!(twap, twap2);
+            }
+        }
     }
 
     #[test]

--- a/packages/sdk/src/amm.ts
+++ b/packages/sdk/src/amm.ts
@@ -1,0 +1,5 @@
+/**
+ * AMM contract typed client — re-exports the AmmPool class.
+ */
+
+export { AmmPool } from "./AmmPool.js";

--- a/packages/sdk/src/cl.ts
+++ b/packages/sdk/src/cl.ts
@@ -1,0 +1,283 @@
+/**
+ * ConcentratedLiquidityClient — typed client for the tick-based CL AMM contract.
+ *
+ * Covers the public interface of contracts/concentrated_liquidity/src/lib.rs.
+ */
+
+import {
+  Contract,
+  rpc as StellarRpc,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+  Address,
+} from "@stellar/stellar-sdk";
+import type { NetworkConfig } from "./types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function addr(address: string): xdr.ScVal {
+  return nativeToScVal(Address.fromString(address));
+}
+
+function i128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: "i128" });
+}
+
+function i32(value: number): xdr.ScVal {
+  return nativeToScVal(value, { type: "i32" });
+}
+
+function u64(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: "u64" });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/** A liquidity position returned by `get_position`. */
+export interface Position {
+  lowerTick: number;
+  upperTick: number;
+  liquidity: bigint;
+  feeGrowthInsideA: bigint;
+  feeGrowthInsideB: bigint;
+  tokensOwedA: bigint;
+  tokensOwedB: bigint;
+}
+
+/** Full pool state returned by `get_pool_state`. */
+export interface ClPoolState {
+  sqrtPrice: bigint;
+  currentTick: number;
+  activeLiquidity: bigint;
+  tickSpacing: number;
+}
+
+/** Quote returned by `quote_position`. */
+export interface PositionQuote {
+  amountA: bigint;
+  amountB: bigint;
+  liquidity: bigint;
+}
+
+// ── ConcentratedLiquidityClient ───────────────────────────────────────────────
+
+export class ConcentratedLiquidityClient {
+  private readonly server: StellarRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(config: NetworkConfig) {
+    this.server = new StellarRpc.Server(config.rpcUrl);
+    this.contract = new Contract(config.contractId);
+    this.networkPassphrase = config.networkPassphrase;
+  }
+
+  get contractId(): string {
+    return this.contract.contractId();
+  }
+
+  private async simulate(method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const op = this.contract.call(method, ...args);
+    const tx = new (await import("@stellar/stellar-sdk")).TransactionBuilder(
+      await this.server.getAccount("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"),
+      { fee: "100", networkPassphrase: this.networkPassphrase }
+    )
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+    const result = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(result.error);
+    }
+    return (result as StellarRpc.Api.SimulateTransactionSuccessResponse).result!.retval;
+  }
+
+  // ── Read-only methods ──────────────────────────────────────────────────────
+
+  /** Returns the full pool state (sqrt price, current tick, active liquidity, tick spacing). */
+  async getPoolState(): Promise<ClPoolState> {
+    const raw = await this.simulate("get_pool_state");
+    const native = scValToNative(raw) as Record<string, unknown>;
+    return {
+      sqrtPrice: BigInt(String(native.sqrt_price ?? 0)),
+      currentTick: Number(native.current_tick ?? 0),
+      activeLiquidity: BigInt(String(native.active_liquidity ?? 0)),
+      tickSpacing: Number(native.tick_spacing ?? 1),
+    };
+  }
+
+  /** Returns the current active tick. */
+  async currentTick(): Promise<number> {
+    const raw = await this.simulate("current_tick");
+    return Number(scValToNative(raw));
+  }
+
+  /** Returns the current active liquidity across the current tick. */
+  async activeLiquidity(): Promise<bigint> {
+    const raw = await this.simulate("active_liquidity");
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  /**
+   * Returns the tick cumulative and its timestamp `(tick_cumulative, last_ts)`.
+   *
+   * Used by the TWAP consumer via `save_cl_snapshot`.
+   */
+  async getTickCumulative(): Promise<{ tickCumulative: bigint; lastTimestamp: bigint }> {
+    const raw = await this.simulate("get_tick_cumulative");
+    const native = scValToNative(raw) as [unknown, unknown];
+    return {
+      tickCumulative: BigInt(String(native[0] ?? 0)),
+      lastTimestamp: BigInt(String(native[1] ?? 0)),
+    };
+  }
+
+  /** Returns the position for `owner` between `lowerTick` and `upperTick`. */
+  async getPosition(owner: string, lowerTick: number, upperTick: number): Promise<Position> {
+    const raw = await this.simulate("get_position", addr(owner), i32(lowerTick), i32(upperTick));
+    const native = scValToNative(raw) as Record<string, unknown>;
+    const owed = native.tokens_owed as [unknown, unknown];
+    return {
+      lowerTick: Number(native.lower_tick ?? lowerTick),
+      upperTick: Number(native.upper_tick ?? upperTick),
+      liquidity: BigInt(String(native.liquidity ?? 0)),
+      feeGrowthInsideA: BigInt(String(native.fee_growth_inside_a ?? 0)),
+      feeGrowthInsideB: BigInt(String(native.fee_growth_inside_b ?? 0)),
+      tokensOwedA: BigInt(String(owed?.[0] ?? 0)),
+      tokensOwedB: BigInt(String(owed?.[1] ?? 0)),
+    };
+  }
+
+  /**
+   * Quotes how much token A and token B are required — and how much liquidity
+   * would be minted — for a position between `lowerTick` and `upperTick` given
+   * desired deposit amounts.
+   */
+  async quotePosition(
+    lowerTick: number,
+    upperTick: number,
+    amountA: bigint,
+    amountB: bigint
+  ): Promise<PositionQuote> {
+    const raw = await this.simulate(
+      "quote_position",
+      i32(lowerTick),
+      i32(upperTick),
+      i128(amountA),
+      i128(amountB)
+    );
+    const native = scValToNative(raw) as [unknown, unknown, unknown];
+    return {
+      amountA: BigInt(String(native[0] ?? 0)),
+      amountB: BigInt(String(native[1] ?? 0)),
+      liquidity: BigInt(String(native[2] ?? 0)),
+    };
+  }
+
+  /**
+   * Returns the fee growth inside the tick range `[lowerTick, upperTick]` for
+   * both tokens as `(fee_growth_inside_a, fee_growth_inside_b)`.
+   */
+  async feeGrowthInside(
+    lowerTick: number,
+    upperTick: number
+  ): Promise<{ feeGrowthA: bigint; feeGrowthB: bigint }> {
+    const raw = await this.simulate("fee_growth_inside", i32(lowerTick), i32(upperTick));
+    const native = scValToNative(raw) as [unknown, unknown];
+    return {
+      feeGrowthA: BigInt(String(native[0] ?? 0)),
+      feeGrowthB: BigInt(String(native[1] ?? 0)),
+    };
+  }
+
+  /**
+   * Converts a tick index to the corresponding price ratio scaled by 1_000_000.
+   * Price = 1.0001^tick, returned as (price * 1_000_000).
+   */
+  async tickToPrice(tick: number): Promise<bigint> {
+    const raw = await this.simulate("tick_to_price", i32(tick));
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  /**
+   * Returns oracle tick cumulative values for an array of historical timestamps.
+   * Returns one `i64` per requested timestamp.
+   */
+  async observe(timestamps: bigint[]): Promise<bigint[]> {
+    const tsVec = nativeToScVal(timestamps.map((t) => nativeToScVal(t, { type: "u64" })));
+    const raw = await this.simulate("observe", tsVec);
+    const native = scValToNative(raw) as unknown[];
+    return (native ?? []).map((v) => BigInt(String(v)));
+  }
+
+  /** Returns whether the pool is paused. */
+  async isPaused(): Promise<boolean> {
+    const raw = await this.simulate("is_paused");
+    return Boolean(scValToNative(raw));
+  }
+
+  // ── Write-method parameter types ───────────────────────────────────────────
+
+  /**
+   * Parameters for `mint_position(provider, lower_tick, upper_tick,
+   * amount_a, amount_b, min_liquidity, deadline)`.
+   */
+  mintPositionParams(
+    provider: string,
+    lowerTick: number,
+    upperTick: number,
+    amountA: bigint,
+    amountB: bigint,
+    minLiquidity: bigint,
+    deadline: bigint
+  ): xdr.ScVal[] {
+    return [
+      addr(provider),
+      i32(lowerTick),
+      i32(upperTick),
+      i128(amountA),
+      i128(amountB),
+      i128(minLiquidity),
+      u64(deadline),
+    ];
+  }
+
+  /**
+   * Parameters for `burn_position(provider, lower_tick, upper_tick)`.
+   * Returns `(amount_a, amount_b)` of tokens sent back to the provider.
+   */
+  burnPositionParams(provider: string, lowerTick: number, upperTick: number): xdr.ScVal[] {
+    return [addr(provider), i32(lowerTick), i32(upperTick)];
+  }
+
+  /**
+   * Parameters for `collect_fees(provider, lower_tick, upper_tick)`.
+   * Returns `(fee_a, fee_b)`.
+   */
+  collectFeesParams(provider: string, lowerTick: number, upperTick: number): xdr.ScVal[] {
+    return [addr(provider), i32(lowerTick), i32(upperTick)];
+  }
+
+  /**
+   * Parameters for `swap(trader, token_in, amount_in, min_out, deadline,
+   * sqrt_price_limit)`.
+   */
+  swapParams(
+    trader: string,
+    tokenIn: string,
+    amountIn: bigint,
+    minOut: bigint,
+    deadline: bigint,
+    sqrtPriceLimit: bigint
+  ): xdr.ScVal[] {
+    return [
+      addr(trader),
+      addr(tokenIn),
+      i128(amountIn),
+      i128(minOut),
+      u64(deadline),
+      i128(sqrtPriceLimit),
+    ];
+  }
+}

--- a/packages/sdk/src/factory.ts
+++ b/packages/sdk/src/factory.ts
@@ -1,0 +1,132 @@
+/**
+ * FactoryClient — typed client for the pool factory contract.
+ *
+ * Covers the public interface of contracts/factory/src/lib.rs.
+ */
+
+import {
+  Contract,
+  rpc as StellarRpc,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+  Address,
+} from "@stellar/stellar-sdk";
+import type { NetworkConfig } from "./types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function addr(address: string): xdr.ScVal {
+  return nativeToScVal(Address.fromString(address));
+}
+
+function i128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: "i128" });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/** Result of `create_pool` — the pool address and optional governance address. */
+export interface CreatePoolResult {
+  poolAddress: string;
+  governanceAddress: string | null;
+}
+
+// ── FactoryClient ─────────────────────────────────────────────────────────────
+
+export class FactoryClient {
+  private readonly server: StellarRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(config: NetworkConfig) {
+    this.server = new StellarRpc.Server(config.rpcUrl);
+    this.contract = new Contract(config.contractId);
+    this.networkPassphrase = config.networkPassphrase;
+  }
+
+  get contractId(): string {
+    return this.contract.contractId();
+  }
+
+  private async simulate(method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const op = this.contract.call(method, ...args);
+    const tx = new (await import("@stellar/stellar-sdk")).TransactionBuilder(
+      await this.server.getAccount("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"),
+      { fee: "100", networkPassphrase: this.networkPassphrase }
+    )
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+    const result = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(result.error);
+    }
+    return (result as StellarRpc.Api.SimulateTransactionSuccessResponse).result!.retval;
+  }
+
+  // ── Read-only methods ──────────────────────────────────────────────────────
+
+  /**
+   * Look up the pool address for a token pair.
+   *
+   * Token order is normalised by the factory — pass them in either order.
+   * Returns `null` if no pool exists for this pair.
+   */
+  async getPool(tokenA: string, tokenB: string): Promise<string | null> {
+    const raw = await this.simulate("get_pool", addr(tokenA), addr(tokenB));
+    const native = scValToNative(raw);
+    return native !== null && native !== undefined ? String(native) : null;
+  }
+
+  /** Returns the addresses of all deployed AMM pools. */
+  async allPools(): Promise<string[]> {
+    const raw = await this.simulate("all_pools");
+    const native = scValToNative(raw) as unknown[];
+    return (native ?? []).map(String);
+  }
+
+  /** Returns the LP token address for a given pool, or `null` if not found. */
+  async getLpToken(pool: string): Promise<string | null> {
+    const raw = await this.simulate("get_lp_token", addr(pool));
+    const native = scValToNative(raw);
+    return native !== null && native !== undefined ? String(native) : null;
+  }
+
+  /**
+   * Returns the governance contract address for a given pool,
+   * or `null` if no governance was deployed for that pool.
+   */
+  async getGovernance(pool: string): Promise<string | null> {
+    const raw = await this.simulate("get_governance", addr(pool));
+    const native = scValToNative(raw);
+    return native !== null && native !== undefined ? String(native) : null;
+  }
+
+  /** Returns the pool count (monotonic counter used to derive deployment salts). */
+  async poolCount(): Promise<bigint> {
+    const raw = await this.simulate("pool_count");
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  // ── Write-method parameter types ───────────────────────────────────────────
+
+  /**
+   * Parameters for `create_pool(token_a, token_b, fee_bps, governance_wasm_hash)`.
+   *
+   * `governanceWasmHash` should be a 32-byte hex string, or omit the field to
+   * deploy a pool without governance.
+   */
+  createPoolParams(
+    tokenA: string,
+    tokenB: string,
+    feeBps: bigint,
+    governanceWasmHash?: string
+  ): xdr.ScVal[] {
+    const govHash =
+      governanceWasmHash !== undefined
+        ? nativeToScVal(Buffer.from(governanceWasmHash, "hex"), { type: "bytes" })
+        : xdr.ScVal.scvVoid();
+    return [addr(tokenA), addr(tokenB), i128(feeBps), govHash];
+  }
+}

--- a/packages/sdk/src/governance.ts
+++ b/packages/sdk/src/governance.ts
@@ -1,0 +1,198 @@
+/**
+ * GovernanceClient — typed client for the LP-governed fee-voting contract.
+ *
+ * Covers the public interface of contracts/governance/src/lib.rs.
+ */
+
+import {
+  Contract,
+  rpc as StellarRpc,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+  Address,
+} from "@stellar/stellar-sdk";
+import type { NetworkConfig } from "./types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function addr(address: string): xdr.ScVal {
+  return nativeToScVal(Address.fromString(address));
+}
+
+function u32(value: number): xdr.ScVal {
+  return nativeToScVal(value, { type: "u32" });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/** On-chain proposal status. */
+export type ProposalStatus =
+  | "Active"
+  | "Pending"
+  | "Queued"
+  | "Executed"
+  | "Defeated"
+  | "Expired"
+  | "Cancelled";
+
+/** Vote choice passed to `vote`. */
+export type VoteChoice = "For" | "Against" | "Abstain";
+
+/** On-chain vote record for a voter. */
+export type VoteRecord = "DidNotVote" | "VotedFor" | "VotedAgainst" | "VotedAbstain";
+
+/** Governance configuration returned by `get_params`. */
+export interface GovernanceParams {
+  votingPeriodSecs: bigint;
+  timelockSecs: bigint;
+  quorumBps: bigint;
+  minProposerStakeBps: bigint;
+}
+
+/** On-chain proposal data returned by `get_proposal`. */
+export interface Proposal {
+  id: number;
+  proposer: string;
+  snapshotTotalSupply: bigint;
+  voteStart: bigint;
+  voteEnd: bigint;
+  executeAfter: bigint;
+  expiresAt: bigint;
+  votesFor: bigint;
+  votesAgainst: bigint;
+  votesAbstain: bigint;
+  executed: boolean;
+  cancelled: boolean;
+  status: ProposalStatus;
+}
+
+// ── GovernanceClient ──────────────────────────────────────────────────────────
+
+export class GovernanceClient {
+  private readonly server: StellarRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(config: NetworkConfig) {
+    this.server = new StellarRpc.Server(config.rpcUrl);
+    this.contract = new Contract(config.contractId);
+    this.networkPassphrase = config.networkPassphrase;
+  }
+
+  get contractId(): string {
+    return this.contract.contractId();
+  }
+
+  private async simulate(method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const op = this.contract.call(method, ...args);
+    const tx = new (await import("@stellar/stellar-sdk")).TransactionBuilder(
+      await this.server.getAccount("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"),
+      { fee: "100", networkPassphrase: this.networkPassphrase }
+    )
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+    const result = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(result.error);
+    }
+    return (result as StellarRpc.Api.SimulateTransactionSuccessResponse).result!.retval;
+  }
+
+  // ── Read-only methods ──────────────────────────────────────────────────────
+
+  /** Returns the current governance configuration. */
+  async getParams(): Promise<GovernanceParams> {
+    const raw = await this.simulate("get_params");
+    const native = scValToNative(raw) as Record<string, unknown>;
+    return {
+      votingPeriodSecs: BigInt(String(native.voting_period_secs ?? 0)),
+      timelockSecs: BigInt(String(native.timelock_secs ?? 0)),
+      quorumBps: BigInt(String(native.quorum_bps ?? 0)),
+      minProposerStakeBps: BigInt(String(native.min_proposer_stake_bps ?? 0)),
+    };
+  }
+
+  /** Returns the total number of proposals created so far. */
+  async proposalCount(): Promise<number> {
+    const raw = await this.simulate("proposal_count");
+    return Number(scValToNative(raw));
+  }
+
+  /** Returns the on-chain data for `proposalId`. */
+  async getProposal(proposalId: number): Promise<Proposal> {
+    const raw = await this.simulate("get_proposal", u32(proposalId));
+    const native = scValToNative(raw) as Record<string, unknown>;
+    return {
+      id: Number(native.id ?? proposalId),
+      proposer: String(native.proposer ?? ""),
+      snapshotTotalSupply: BigInt(String(native.snapshot_total_supply ?? 0)),
+      voteStart: BigInt(String(native.vote_start ?? 0)),
+      voteEnd: BigInt(String(native.vote_end ?? 0)),
+      executeAfter: BigInt(String(native.execute_after ?? 0)),
+      expiresAt: BigInt(String(native.expires_at ?? 0)),
+      votesFor: BigInt(String(native.votes_for ?? 0)),
+      votesAgainst: BigInt(String(native.votes_against ?? 0)),
+      votesAbstain: BigInt(String(native.votes_abstain ?? 0)),
+      executed: Boolean(native.executed),
+      cancelled: Boolean(native.cancelled),
+      status: "Active",
+    };
+  }
+
+  /** Returns whether `voter` has voted on `proposalId`. */
+  async hasVoted(proposalId: number, voter: string): Promise<boolean> {
+    const raw = await this.simulate("has_voted", u32(proposalId), addr(voter));
+    return Boolean(scValToNative(raw));
+  }
+
+  /** Returns the vote record for `voter` on `proposalId`. */
+  async getVoteRecord(proposalId: number, voter: string): Promise<VoteRecord> {
+    const raw = await this.simulate("get_vote_record", u32(proposalId), addr(voter));
+    const native = scValToNative(raw);
+    return String(native) as VoteRecord;
+  }
+
+  /** Returns the delegation target for `from`, or `null` if not delegated. */
+  async getDelegate(from: string): Promise<string | null> {
+    const raw = await this.simulate("get_delegate", addr(from));
+    const native = scValToNative(raw);
+    return native !== null && native !== undefined ? String(native) : null;
+  }
+
+  // ── Write-method parameter types ───────────────────────────────────────────
+
+  /** Parameters for `propose(proposer, kind)` — returns the new proposal id. */
+  proposeUpdateFeeParams(proposer: string, newFeeBps: bigint): xdr.ScVal[] {
+    return [
+      addr(proposer),
+      nativeToScVal({ UpdateFee: newFeeBps }, { type: "map" }),
+    ];
+  }
+
+  /** Parameters for `vote(voter, proposal_id, vote_choice)`. */
+  voteParams(voter: string, proposalId: number, choice: VoteChoice): xdr.ScVal[] {
+    return [addr(voter), u32(proposalId), nativeToScVal(choice)];
+  }
+
+  /** Parameters for `execute(proposal_id)`. */
+  executeParams(proposalId: number): xdr.ScVal[] {
+    return [u32(proposalId)];
+  }
+
+  /** Parameters for `cancel(proposal_id, caller)`. */
+  cancelParams(proposalId: number, caller: string): xdr.ScVal[] {
+    return [u32(proposalId), addr(caller)];
+  }
+
+  /** Parameters for `unlock_vote(proposal_id, voter)`. */
+  unlockVoteParams(proposalId: number, voter: string): xdr.ScVal[] {
+    return [u32(proposalId), addr(voter)];
+  }
+
+  /** Parameters for `delegate(from, to)`. */
+  delegateParams(from: string, to: string): xdr.ScVal[] {
+    return [addr(from), addr(to)];
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,15 +1,26 @@
 /**
- * @soroban-amm/sdk — Issue #104
+ * @soroban-amm/sdk
  *
- * Typed TypeScript SDK for the Soroban AMM contract.
+ * Typed TypeScript SDK for all five Soroban AMM contracts.
  *
  * ```ts
- * import { AmmPool } from "@soroban-amm/sdk";
+ * import { AmmPool, TokenClient, FactoryClient, GovernanceClient, ConcentratedLiquidityClient } from "@soroban-amm/sdk";
+ *
  * const pool = new AmmPool({ rpcUrl, networkPassphrase, contractId });
- * const info  = await pool.getInfo();
+ * const info = await pool.getInfo();
  * const quote = await pool.simulateSwap(tokenIn, amountIn);
+ *
+ * const factory = new FactoryClient({ rpcUrl, networkPassphrase, contractId: factoryId });
+ * const pools = await factory.allPools();
  * ```
  */
 
 export { AmmPool } from "./AmmPool.js";
+export { TokenClient } from "./token.js";
+export { FactoryClient } from "./factory.js";
+export type { CreatePoolResult } from "./factory.js";
+export { GovernanceClient } from "./governance.js";
+export type { GovernanceParams, Proposal, ProposalStatus, VoteChoice, VoteRecord } from "./governance.js";
+export { ConcentratedLiquidityClient } from "./cl.js";
+export type { Position, ClPoolState, PositionQuote } from "./cl.js";
 export * from "./types.js";

--- a/packages/sdk/src/token.ts
+++ b/packages/sdk/src/token.ts
@@ -1,0 +1,131 @@
+/**
+ * TokenClient — typed client for the SEP-41 LP token contract.
+ *
+ * Covers the public interface of contracts/token/src/lib.rs.
+ */
+
+import {
+  Contract,
+  rpc as StellarRpc,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+  Address,
+} from "@stellar/stellar-sdk";
+import type { NetworkConfig } from "./types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function addr(address: string): xdr.ScVal {
+  return nativeToScVal(Address.fromString(address));
+}
+
+function i128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: "i128" });
+}
+
+// ── TokenClient ───────────────────────────────────────────────────────────────
+
+export class TokenClient {
+  private readonly server: StellarRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(config: NetworkConfig) {
+    this.server = new StellarRpc.Server(config.rpcUrl);
+    this.contract = new Contract(config.contractId);
+    this.networkPassphrase = config.networkPassphrase;
+  }
+
+  get contractId(): string {
+    return this.contract.contractId();
+  }
+
+  private async simulate(method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const op = this.contract.call(method, ...args);
+    const tx = new (await import("@stellar/stellar-sdk")).TransactionBuilder(
+      await this.server.getAccount("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"),
+      { fee: "100", networkPassphrase: this.networkPassphrase }
+    )
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+    const result = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(result.error);
+    }
+    return (result as StellarRpc.Api.SimulateTransactionSuccessResponse).result!.retval;
+  }
+
+  // ── Read-only methods ──────────────────────────────────────────────────────
+
+  /** Returns the token name. */
+  async name(): Promise<string> {
+    const raw = await this.simulate("name");
+    return String(scValToNative(raw));
+  }
+
+  /** Returns the token symbol. */
+  async symbol(): Promise<string> {
+    const raw = await this.simulate("symbol");
+    return String(scValToNative(raw));
+  }
+
+  /** Returns the number of decimal places used to represent token amounts. */
+  async decimals(): Promise<number> {
+    const raw = await this.simulate("decimals");
+    return Number(scValToNative(raw));
+  }
+
+  /** Returns the total number of tokens currently in circulation. */
+  async totalSupply(): Promise<bigint> {
+    const raw = await this.simulate("total_supply");
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  /** Returns the token balance of `address`. Returns `0n` if no balance. */
+  async balance(address: string): Promise<bigint> {
+    const raw = await this.simulate("balance", addr(address));
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  /**
+   * Returns the amount `spender` is allowed to transfer on behalf of `from`.
+   * Returns `0n` if no allowance has been set.
+   */
+  async allowance(from: string, spender: string): Promise<bigint> {
+    const raw = await this.simulate("allowance", addr(from), addr(spender));
+    return BigInt(String(scValToNative(raw)));
+  }
+
+  // ── Write-method parameter types ───────────────────────────────────────────
+  //
+  // These methods require a signed transaction envelope. The parameter types
+  // are provided here to support typed integration layers; submitting the
+  // transaction is the caller's responsibility using the Stellar SDK.
+
+  /** Parameters for `transfer(from, to, amount)`. */
+  transferParams(from: string, to: string, amount: bigint): xdr.ScVal[] {
+    return [addr(from), addr(to), i128(amount)];
+  }
+
+  /** Parameters for `transfer_from(spender, from, to, amount)`. */
+  transferFromParams(spender: string, from: string, to: string, amount: bigint): xdr.ScVal[] {
+    return [addr(spender), addr(from), addr(to), i128(amount)];
+  }
+
+  /** Parameters for `approve(from, spender, amount)`. */
+  approveParams(from: string, spender: string, amount: bigint): xdr.ScVal[] {
+    return [addr(from), addr(spender), i128(amount)];
+  }
+
+  /** Parameters for `mint(to, amount)` — admin only. */
+  mintParams(to: string, amount: bigint): xdr.ScVal[] {
+    return [addr(to), i128(amount)];
+  }
+
+  /** Parameters for `burn(from, amount)` — admin only. */
+  burnParams(from: string, amount: bigint): xdr.ScVal[] {
+    return [addr(from), i128(amount)];
+  }
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -163,11 +163,16 @@ invoke "$TOKEN_B_CONTRACT_ID" mint \
   --amount "$AMOUNT_B" >/dev/null
 pass "minted token B to test account"
 
+# Deadline is set 5 minutes in the future and recomputed before each call so it
+# remains valid even when the script is slow or paused between steps.
+DEADLINE=$(( $(date +%s) + 300 ))
+
 ADD_OUTPUT="$(invoke "$AMM_CONTRACT_ID" add_liquidity \
   --provider "$SOURCE_PUBLIC_KEY" \
   --amount_a "$AMOUNT_A" \
   --amount_b "$AMOUNT_B" \
-  --min_shares 0)"
+  --min_shares 0 \
+  --deadline "$DEADLINE")"
 LP_SHARES="$(printf '%s\n' "$ADD_OUTPUT" | parse_i128)"
 if [[ -z "$LP_SHARES" || "$LP_SHARES" -le 0 ]]; then
   die "add_liquidity did not return positive LP shares: $ADD_OUTPUT"
@@ -180,22 +185,28 @@ RESERVE_B="$(printf '%s\n' "$INFO_OUTPUT" | field_value reserve_b)"
 assert_eq "reserve A after add_liquidity" "$RESERVE_A" "$AMOUNT_A"
 assert_eq "reserve B after add_liquidity" "$RESERVE_B" "$AMOUNT_B"
 
+DEADLINE=$(( $(date +%s) + 300 ))
+
 SWAP_OUTPUT="$(invoke "$AMM_CONTRACT_ID" swap \
   --trader "$SOURCE_PUBLIC_KEY" \
   --token_in "$TOKEN_A_CONTRACT_ID" \
   --amount_in "$SWAP_AMOUNT_IN" \
-  --min_out 0)"
+  --min_out 0 \
+  --deadline "$DEADLINE")"
 SWAP_OUT="$(printf '%s\n' "$SWAP_OUTPUT" | parse_i128)"
 if [[ -z "$SWAP_OUT" ]]; then
   die "swap did not return an amount: $SWAP_OUTPUT"
 fi
 assert_between "swap output" "$SWAP_OUT" "$MIN_SWAP_OUT" "$MAX_SWAP_OUT"
 
+DEADLINE=$(( $(date +%s) + 300 ))
+
 invoke "$AMM_CONTRACT_ID" remove_liquidity \
   --provider "$SOURCE_PUBLIC_KEY" \
   --shares "$LP_SHARES" \
   --min_a 0 \
-  --min_b 0 >/dev/null
+  --min_b 0 \
+  --deadline "$DEADLINE" >/dev/null
 pass "removed all LP shares"
 
 FINAL_INFO_OUTPUT="$(invoke "$AMM_CONTRACT_ID" get_info)"


### PR DESCRIPTION
## Summary

- closes #199 — adds `test_remove_liquidity_one_sided` and `test_remove_liquidity_one_sided_slippage_fails` to `contracts/amm/src/lib.rs`. The two-LP fixture ensures residual pool reserves exist for the internal swap so the provider receives strictly more token_a than the proportional withdrawal alone, and the token_b balance is verified to be unchanged.

- closes #200 — extends `contracts/twap_consumer/src/lib.rs` with a `TrackedPools` storage key, updates `save_snapshot` to register each new pool address on first observation, and adds `get_tracked_pools()` and `get_twap_all(window_seconds)` view functions. A new test `test_get_tracked_pools_and_twap_all` creates two independent AMM pools, saves snapshots for both, advances the ledger, swaps in each pool, and verifies that `get_twap_all` returns the correct TWAPs for both.

- closes #201 — adds four typed contract client classes under `packages/sdk/src/`: `TokenClient` (SEP-41 LP token), `FactoryClient` (pool factory), `GovernanceClient` (LP-weighted voting), and `ConcentratedLiquidityClient` (tick-based CL AMM). A thin `amm.ts` re-exports the existing `AmmPool` class to complete the five-file layout. `index.ts` is updated to re-export all five clients and their associated types. Method signatures match the current Rust function signatures in each respective contract.

- closes #202 — updates `scripts/e2e.sh` to compute `DEADLINE=$(( $(date +%s) + 300 ))` dynamically (5 minutes ahead) immediately before each of the three affected calls (`add_liquidity`, `swap`, `remove_liquidity`) and passes `--deadline "$DEADLINE"` to each invocation.

## Test plan

- [ ] `cargo test -p amm` — verify `test_remove_liquidity_one_sided` and `test_remove_liquidity_one_sided_slippage_fails` pass
- [ ] `cargo test -p twap_consumer` — verify `test_get_tracked_pools_and_twap_all` passes alongside existing TWAP tests
- [ ] `cd packages/sdk && npm run build` — verify TypeScript compiles without errors
- [ ] Run `scripts/e2e.sh` against testnet — verify all three calls succeed and an expired deadline causes the call to fail (manual check)
