### PR TITLE
feat: implement circuit breaker for extreme price movements

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -58,6 +58,8 @@ pub enum AmmError {
     InsufficientLiquidity = 11,
     NoPendingAdmin       = 12,
     WrongAdmin           = 13,
+    CircuitBreakerTripped = 14,
+    InvalidThreshold     = 15,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -83,6 +85,12 @@ pub enum DataKey {
     AccruedFeeB,    // i128 — protocol fees accrued in TokenB
     Paused,
     FlashLoanFeeBps,
+    // ── Circuit breaker ────────────────────────────────────────────────────
+    CircuitBreakerEnabled,   // bool
+    CircuitBreakerThreshold, // i128 — max price deviation in bps (e.g. 5000 = 50%)
+    CircuitBreakerCooldown,  // u64 — seconds before auto-recovery is allowed
+    CircuitBreakerPausedAt,  // u64 — timestamp when circuit breaker tripped
+    LastPrice,               // i128 — last recorded spot price (reserve_b * 1_000_000 / reserve_a)
 }
 
 // ── Pool info returned by `get_info` ─────────────────────────────────────────
@@ -248,6 +256,174 @@ impl AmmPool {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    // ── Circuit breaker ─────────────────────────────────────────────────────
+
+    /// Configure the circuit breaker. Admin-only.
+    ///
+    /// When enabled, any swap that would move the spot price by more than
+    /// `threshold_bps` (in basis points, e.g. 5000 = 50%) triggers an
+    /// automatic pool pause. The pool remains paused until `auto_unpause`
+    /// is called after `cooldown_secs` have elapsed.
+    ///
+    /// # Parameters
+    /// - `admin` – Must match the stored admin address.
+    /// - `enabled` – Toggle the circuit breaker on/off.
+    /// - `threshold_bps` – Maximum allowed price deviation in basis points (1..10_000).
+    /// - `cooldown_secs` – Seconds before auto-recovery is allowed (must be > 0).
+    pub fn set_circuit_breaker(
+        env: Env,
+        admin: Address,
+        enabled: bool,
+        threshold_bps: i128,
+        cooldown_secs: u64,
+    ) -> Result<(), AmmError> {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(AmmError::Unauthorized);
+        }
+        admin.require_auth();
+        if enabled {
+            if threshold_bps <= 0 || threshold_bps > 10_000 {
+                return Err(AmmError::InvalidThreshold);
+            }
+            if cooldown_secs == 0 {
+                return Err(AmmError::InvalidThreshold);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerEnabled, &enabled);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerThreshold, &threshold_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerCooldown, &cooldown_secs);
+        Ok(())
+    }
+
+    /// Return the current circuit breaker configuration.
+    ///
+    /// Returns `(enabled, threshold_bps, cooldown_secs)`.
+    pub fn get_circuit_breaker(env: Env) -> (bool, i128, u64) {
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerEnabled)
+            .unwrap_or(false);
+        let threshold: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerThreshold)
+            .unwrap_or(5_000);
+        let cooldown: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerCooldown)
+            .unwrap_or(300);
+        (enabled, threshold, cooldown)
+    }
+
+    /// Auto-unpause the pool after the circuit breaker cooldown has elapsed.
+    ///
+    /// Anyone can call this — the cooldown prevents premature recovery.
+    /// Returns `Ok(true)` if the pool was unpaused, `Ok(false)` if the
+    /// cooldown hasn't elapsed yet, or an error if the pool wasn't paused
+    /// by the circuit breaker.
+    pub fn auto_unpause(env: Env) -> Result<bool, AmmError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if !paused {
+            return Ok(false);
+        }
+        let paused_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerPausedAt)
+            .unwrap_or(0);
+        if paused_at == 0 {
+            return Err(AmmError::Unauthorized); // Not paused by circuit breaker.
+        }
+        let cooldown: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerCooldown)
+            .unwrap_or(300);
+        let now = env.ledger().timestamp();
+        if now < paused_at + cooldown {
+            return Ok(false); // Cooldown not elapsed.
+        }
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerPausedAt, &0u64);
+        // Record current price as new baseline after recovery.
+        let reserve_a = Self::get_reserve_a(env.clone());
+        let reserve_b = Self::get_reserve_b(env.clone());
+        if reserve_a > 0 && reserve_b > 0 {
+            let price = reserve_b * 1_000_000 / reserve_a;
+            env.storage()
+                .instance()
+                .set(&DataKey::LastPrice, &price);
+        }
+        Ok(true)
+    }
+
+    /// Internal: check price deviation and trip circuit breaker if threshold exceeded.
+    ///
+    /// Called after reserves are updated. Compares the new spot price against
+    /// `LastPrice`. If the absolute deviation exceeds `CircuitBreakerThreshold`,
+    /// pauses the pool and records the pause timestamp.
+    fn check_circuit_breaker(env: &Env, reserve_a: i128, reserve_b: i128) {
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerEnabled)
+            .unwrap_or(false);
+        if !enabled {
+            return;
+        }
+        if reserve_a <= 0 || reserve_b <= 0 {
+            return;
+        }
+        let last_price: Option<i128> = env.storage().instance().get(&DataKey::LastPrice);
+        if let Some(prev_price) = last_price {
+            if prev_price > 0 {
+                let new_price = reserve_b * 1_000_000 / reserve_a;
+                let threshold: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::CircuitBreakerThreshold)
+                    .unwrap_or(5_000);
+                // Deviation in bps relative to prev_price (scaled by 1_000_000).
+                let deviation = if new_price > prev_price {
+                    (new_price - prev_price) * 10_000 / prev_price
+                } else {
+                    (prev_price - new_price) * 10_000 / prev_price
+                };
+                if deviation > threshold {
+                    env.storage().instance().set(&DataKey::Paused, &true);
+                    env.storage().instance().set(
+                        &DataKey::CircuitBreakerPausedAt,
+                        &env.ledger().timestamp(),
+                    );
+                    env.events().publish(
+                        (Symbol::new(&env, "cb_trip"),),
+                        (prev_price, new_price, deviation),
+                    );
+                }
+            }
+        }
+        // Always update last price.
+        let price = reserve_b * 1_000_000 / reserve_a;
+        env.storage()
+            .instance()
+            .set(&DataKey::LastPrice, &price);
     }
 
     /// Update the protocol fee configuration. Admin-only.
@@ -999,6 +1175,11 @@ impl AmmPool {
             }
         }
 
+        // Check circuit breaker after reserve update.
+        let new_reserve_a = Self::get_reserve_a(env.clone());
+        let new_reserve_b = Self::get_reserve_b(env.clone());
+        Self::check_circuit_breaker(&env, new_reserve_a, new_reserve_b);
+
         env.events().publish(
             (Symbol::new(&env, "swap"), trader),
             (token_in, amount_in, token_out, amount_out, referrer),
@@ -1129,6 +1310,11 @@ impl AmmPool {
                     .set(&DataKey::AccruedFeeB, &(accrued + protocol_fee));
             }
         }
+
+        // Check circuit breaker after reserve update.
+        let new_reserve_a = Self::get_reserve_a(env.clone());
+        let new_reserve_b = Self::get_reserve_b(env.clone());
+        Self::check_circuit_breaker(&env, new_reserve_a, new_reserve_b);
 
         env.events().publish(
             (Symbol::new(&env, "swap"), trader),

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1394,7 +1394,12 @@ mod tests {
 #[cfg(test)]
 mod prop_tests {
     extern crate std;
+    use super::tests::{mint_lp, setup_suite};
+    use super::*;
     use proptest::prelude::*;
+    use soroban_sdk::{testutils::Address as _, Address};
+
+    // ── Pure-math properties (no contract interaction) ──────────────────────
 
     proptest! {
         /// Property 1: Quorum threshold never overflows or goes out of bounds.
@@ -1460,6 +1465,190 @@ mod prop_tests {
             let execute_after = vote_end + timelock;
             let expires_at = execute_after + timelock.max(voting_period);
             prop_assert!(expires_at >= execute_after);
+        }
+    }
+
+    // ── Contract-interaction property tests ────────────────────────────────
+
+    proptest! {
+        /// Property 7: Voting power conservation — total votes across For/Against/Abstain
+        /// always equal the sum of individual voter LP balances (no votes created or destroyed).
+        #[test]
+        fn voting_power_conservation(
+            bal1 in 1i128..10_000,
+            bal2 in 1i128..10_000,
+            bal3 in 1i128..10_000,
+        ) {
+            let s = setup_suite(30);
+            let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+            let lp1 = Address::generate(&s.env);
+            let lp2 = Address::generate(&s.env);
+            let lp3 = Address::generate(&s.env);
+            mint_lp(&s, &lp1, bal1);
+            mint_lp(&s, &lp2, bal2);
+            mint_lp(&s, &lp3, bal3);
+
+            // Need enough stake to propose (100 bps = 1% of total supply).
+            let total = bal1 + bal2 + bal3;
+            // lp1 must hold >= 1% to propose.
+            prop_assume!(bal1 * 10_000 >= total);
+
+            let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+            gov.vote(&lp1, &pid, &Vote::For);
+            gov.vote(&lp2, &pid, &Vote::Against);
+            gov.vote(&lp3, &pid, &Vote::Abstain);
+
+            let proposal = gov.get_proposal(&pid);
+            let total_votes =
+                proposal.votes_for + proposal.votes_against + proposal.votes_abstain;
+
+            // Conservation: sum of votes == sum of LP balances that voted.
+            prop_assert_eq!(total_votes, bal1 + bal2 + bal3);
+            // Each bucket matches its voter's balance.
+            prop_assert_eq!(proposal.votes_for, bal1);
+            prop_assert_eq!(proposal.votes_against, bal2);
+            prop_assert_eq!(proposal.votes_abstain, bal3);
+        }
+
+        /// Property 8: Lock/unlock consistency — after voting, LP balance is locked;
+        /// after unlock_vote, LP balance is fully restored. No tokens lost or created.
+        #[test]
+        fn lock_unlock_consistency(
+            bal1 in 100i128..10_000,
+            bal2 in 100i128..10_000,
+        ) {
+            let s = setup_suite(30);
+            let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+            let lp_client = token::LpTokenClient::new(&s.env, &s.lp_addr);
+
+            let lp1 = Address::generate(&s.env);
+            let lp2 = Address::generate(&s.env);
+            mint_lp(&s, &lp1, bal1);
+            mint_lp(&s, &lp2, bal2);
+
+            let total = bal1 + bal2;
+            prop_assume!(bal1 * 10_000 >= total);
+
+            // Record pre-vote balances.
+            let pre_bal1 = lp_client.balance(&lp1);
+            let pre_bal2 = lp_client.balance(&lp2);
+
+            let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+            gov.vote(&lp1, &pid, &Vote::For);
+            gov.vote(&lp2, &pid, &Vote::Against);
+
+            // After voting, balances should be 0 (locked).
+            prop_assert_eq!(lp_client.balance(&lp1), 0);
+            prop_assert_eq!(lp_client.balance(&lp2), 0);
+
+            // Advance past proposal lifecycle to Expired.
+            let proposal = gov.get_proposal(&pid);
+            s.env.ledger().set_timestamp(proposal.expires_at + 1);
+            assert_eq!(gov.proposal_status(&pid), ProposalStatus::Expired);
+
+            // Unlock both voters.
+            gov.unlock_vote(&lp1, &pid);
+            gov.unlock_vote(&lp2, &pid);
+
+            // Balances fully restored — no tokens lost or created.
+            prop_assert_eq!(lp_client.balance(&lp1), pre_bal1);
+            prop_assert_eq!(lp_client.balance(&lp2), pre_bal2);
+        }
+
+        /// Property 9: Double-vote is always rejected regardless of voter balance or choice.
+        #[test]
+        fn double_vote_always_rejected(
+            bal1 in 100i128..10_000,
+            choice_idx in 0u8..3,
+        ) {
+            let s = setup_suite(30);
+            let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+            let lp1 = Address::generate(&s.env);
+            let lp2 = Address::generate(&s.env);
+            mint_lp(&s, &lp1, bal1);
+            mint_lp(&s, &lp2, 10_000);
+
+            let total = bal1 + 10_000;
+            prop_assume!(bal1 * 10_000 >= total);
+
+            let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
+            let choice = match choice_idx {
+                0 => Vote::For,
+                1 => Vote::Against,
+                _ => Vote::Abstain,
+            };
+            gov.vote(&lp1, &pid, &choice);
+
+            // Second vote by same voter must fail with AlreadyVoted.
+            let result = gov.try_vote(&lp1, &pid, &Vote::For);
+            prop_assert!(result.is_err());
+            prop_assert_eq!(result.unwrap_err().unwrap(), GovernanceError::AlreadyVoted);
+        }
+
+        /// Property 10: Proposals can only be created by addresses with sufficient stake
+        /// (>= min_proposer_stake_bps % of total supply).
+        #[test]
+        fn insufficient_stake_cannot_propose(
+            bal1 in 1i128..100,
+            bal2 in 1_000i128..100_000,
+        ) {
+            let s = setup_suite(30);
+            let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+            let lp1 = Address::generate(&s.env);
+            let lp2 = Address::generate(&s.env);
+            mint_lp(&s, &lp1, bal1);
+            mint_lp(&s, &lp2, bal2);
+
+            // min_proposer_stake_bps is 100 (1%). lp1 must hold < 1% of total.
+            let total = bal1 + bal2;
+            prop_assume!(bal1 * 10_000 < total);
+
+            let result = gov.try_propose(&lp1, &ProposalKind::UpdateFee(50));
+            prop_assert!(result.is_err());
+            prop_assert_eq!(
+                result.unwrap_err().unwrap(),
+                GovernanceError::InsufficientStake
+            );
+        }
+
+        /// Property 11: Quorum enforcement — proposals below quorum are always defeated,
+        /// proposals at or above quorum with majority For are passable.
+        #[test]
+        fn quorum_enforcement(
+            voter_bal in 1i128..500,
+            total_supply in 1_000i128..10_000,
+        ) {
+            // quorum_bps is 100 (1% of total supply).
+            let quorum_threshold = total_supply * 100 / 10_000;
+
+            let s = setup_suite(30);
+            let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+
+            let proposer = Address::generate(&s.env);
+            let voter = Address::generate(&s.env);
+            // Give proposer enough to meet min stake (1% of their supply).
+            mint_lp(&s, &proposer, total_supply);
+            mint_lp(&s, &voter, voter_bal);
+
+            let pid = gov.propose(&proposer, &ProposalKind::UpdateFee(50));
+            gov.vote(&voter, &pid, &Vote::For);
+
+            let proposal = gov.get_proposal(&pid);
+            s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+            if voter_bal < quorum_threshold {
+                // Below quorum → defeated.
+                let status = gov.proposal_status(&pid);
+                prop_assert_eq!(status, ProposalStatus::Defeated);
+            } else {
+                // At or above quorum + majority For → can execute.
+                // (Note: proposer didn't vote, so only voter_bal votes exist.)
+                let status = gov.proposal_status(&pid);
+                prop_assert_eq!(status, ProposalStatus::Queued);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #247

Implements an automatic circuit breaker that pauses the AMM pool when a swap causes the spot price to deviate beyond a configurable threshold, preventing flash loan attacks and cascading liquidations.

## How It Works

1. **Admin configures** via `set_circuit_breaker(enabled, threshold_bps, cooldown_secs)`
2. **After each swap**, the contract compares the new spot price (`reserve_b * 1_000_000 / reserve_a`) against the last recorded price
3. **If deviation exceeds threshold** (e.g. 5000 bps = 50%), the pool is automatically paused and a `cb_trip` event is emitted
4. **After cooldown elapsed**, anyone can call `auto_unpause()` to resume — the current price becomes the new baseline

## New Public Functions

| Function | Access | Description |
|----------|--------|-------------|
| `set_circuit_breaker(admin, enabled, threshold_bps, cooldown_secs)` | Admin | Configure circuit breaker |
| `get_circuit_breaker()` | Public | Returns `(enabled, threshold_bps, cooldown_secs)` |
| `auto_unpause()` | Public | Unpause pool after cooldown; returns `Ok(true)` if unpaused |

## Integration Points

- `swap()` — circuit breaker check after reserve update
- `swap_exact_out()` — circuit breaker check after reserve update
- `remove_liquidity_single()` — no check needed (no price discovery)

## Storage Keys Added

- `CircuitBreakerEnabled` (bool)
- `CircuitBreakerThreshold` (i128, bps)
- `CircuitBreakerCooldown` (u64, seconds)
- `CircuitBreakerPausedAt` (u64, timestamp)
- `LastPrice` (i128, spot price scaled by 1_000_000)

## Error Codes Added

- `CircuitBreakerTripped = 14`
- `InvalidThreshold = 15`

## Security Considerations

- Price comparison uses integer arithmetic with 1M scaling to avoid floating point
- Cooldown prevents rapid pause/unpause oscillation
- `auto_unpause` resets price baseline to current reserves after recovery
- Admin-only configuration prevents unauthorized tampering

## Testing

```bash
cd contracts/amm && cargo test --features testutils
```