### PR TITLE
feat(amm): reentrancy guards, Rust SDK, error docs, and circuit breaker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,12 @@
 resolver = "2"
 members = [
   "contracts/amm",
+  "contracts/amm-sdk",
   "contracts/concentrated_liquidity",
   "contracts/factory",
   "contracts/router",
   "contracts/batch_router",
   "contracts/token",
-  "contracts/factory",
-  "contracts/router",
   "contracts/reserve_manager",
   "contracts/amm-fuzz",
   "contracts/twap_consumer",

--- a/contracts/amm-sdk/Cargo.toml
+++ b/contracts/amm-sdk/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "soroban-amm-sdk"
+version = "0.1.0"
+edition = "2021"
+description = "Type-safe Rust SDK for the Soroban AMM contracts"
+license = "MIT"
+repository = "https://github.com/promisszn/soroban-amm"
+keywords = ["soroban", "stellar", "amm", "defi", "sdk"]
+categories = ["cryptography::cryptocurrencies"]
+readme = "README.md"
+
+[lib]
+name = "soroban_amm_sdk"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+amm           = { path = "../amm",           features = ["testutils"] }
+token         = { path = "../token",         features = ["testutils"] }

--- a/contracts/amm-sdk/src/client.rs
+++ b/contracts/amm-sdk/src/client.rs
@@ -1,0 +1,430 @@
+//! High-level AMM client wrapping every contract entry point.
+//!
+//! [`AmmPoolSdk`] is the primary entry point for on-chain usage (cross-contract
+//! calls from other Soroban contracts).  Off-chain callers using a language
+//! binding (e.g. stellar-sdk-rs) can use the same types for argument / return
+//! value construction.
+
+use soroban_sdk::{contractclient, Address, Bytes, BytesN, Env};
+
+use crate::types::{LiquidityQuote, PoolInfo, SdkAmmError, SwapInQuote, SwapOutQuote};
+
+// ── Re-export the auto-generated contract client ──────────────────────────────
+
+/// Auto-generated client bound to the deployed AMM pool contract.
+///
+/// Every method signature matches the contract entry point exactly, so all
+/// Rust type-checking guarantees apply before a transaction is submitted.
+#[contractclient(name = "AmmPoolClient")]
+pub trait AmmPoolInterface {
+    fn initialize(
+        env: Env,
+        admin: Address,
+        token_a: Address,
+        token_b: Address,
+        lp_token: Address,
+        fee_bps: i128,
+        fee_recipient: Address,
+        protocol_fee_bps: i128,
+    ) -> Result<(), SdkAmmError>;
+
+    fn pause(env: Env) -> Result<(), SdkAmmError>;
+    fn unpause(env: Env) -> Result<(), SdkAmmError>;
+    fn is_paused(env: Env) -> bool;
+    fn flash_loan_locked(env: Env) -> bool;
+
+    fn add_liquidity(
+        env: Env,
+        provider: Address,
+        amount_a: i128,
+        amount_b: i128,
+        min_shares: i128,
+        deadline: u64,
+    ) -> Result<i128, SdkAmmError>;
+
+    fn remove_liquidity(
+        env: Env,
+        provider: Address,
+        shares: i128,
+        min_a: i128,
+        min_b: i128,
+        deadline: u64,
+    ) -> Result<(i128, i128), SdkAmmError>;
+
+    fn swap(
+        env: Env,
+        trader: Address,
+        token_in: Address,
+        amount_in: i128,
+        min_out: i128,
+        deadline: u64,
+        referrer: Option<Address>,
+    ) -> Result<i128, SdkAmmError>;
+
+    fn swap_exact_out(
+        env: Env,
+        trader: Address,
+        token_out: Address,
+        amount_out: i128,
+        max_in: i128,
+        deadline: u64,
+        referrer: Option<Address>,
+    ) -> Result<i128, SdkAmmError>;
+
+    fn flash_loan(
+        env: Env,
+        receiver: Address,
+        token: Address,
+        amount: i128,
+        data: Bytes,
+    ) -> Result<i128, SdkAmmError>;
+
+    fn get_amount_out(env: Env, token_in: Address, amount_in: i128) -> Result<i128, SdkAmmError>;
+    fn get_amount_in(env: Env, token_out: Address, amount_out: i128) -> i128;
+    fn simulate_swap(env: Env, token_in: Address, amount_in: i128) -> Result<crate::types::PoolInfo, SdkAmmError>;
+    fn price_ratio(env: Env) -> Result<(i128, i128), SdkAmmError>;
+    fn get_info(env: Env) -> PoolInfo;
+    fn get_accrued_fees(env: Env) -> (i128, i128);
+    fn shares_of(env: Env, provider: Address) -> i128;
+    fn get_price_cumulative(env: Env) -> (i128, i128, u64);
+    fn withdraw_protocol_fees(env: Env) -> Result<(i128, i128), SdkAmmError>;
+
+    fn update_fee(env: Env, new_fee_bps: i128) -> Result<(), SdkAmmError>;
+    fn update_flash_loan_fee(env: Env, new_fee_bps: i128) -> Result<(), SdkAmmError>;
+    fn set_protocol_fee(env: Env, admin: Address, recipient: Address, protocol_fee_bps: i128) -> Result<(), SdkAmmError>;
+    fn get_protocol_fee(env: Env) -> (Option<Address>, i128);
+
+    fn propose_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), SdkAmmError>;
+    fn accept_admin(env: Env, new_admin: Address) -> Result<(), SdkAmmError>;
+    fn get_pending_admin(env: Env) -> Option<Address>;
+    fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), SdkAmmError>;
+}
+
+// ── High-level SDK wrapper ────────────────────────────────────────────────────
+
+/// A high-level wrapper around [`AmmPoolClient`] that adds validated quote
+/// helpers, liquidity estimation, and convenience constructors.
+///
+/// # Cross-contract usage
+/// ```rust,ignore
+/// use soroban_amm_sdk::client::AmmPoolSdk;
+///
+/// let sdk = AmmPoolSdk::new(&env, &pool_address);
+///
+/// // Validated quote — returns Err if pool is empty or token unknown
+/// let quote = sdk.quote_swap_in(&token_a, 1_000_000)?;
+/// if quote.price_impact_bps > 100 {
+///     return Err(MyError::TooMuchSlippage);
+/// }
+/// sdk.execute_swap(&trader, &token_a, 1_000_000, quote.amount_out * 99 / 100, deadline, None)?;
+/// ```
+pub struct AmmPoolSdk {
+    env: Env,
+    client: AmmPoolClient,
+}
+
+impl AmmPoolSdk {
+    /// Bind the SDK to a deployed pool at `pool_address`.
+    pub fn new(env: &Env, pool_address: &Address) -> Self {
+        Self {
+            env: env.clone(),
+            client: AmmPoolClient::new(env, pool_address),
+        }
+    }
+
+    // ── Read-only views ───────────────────────────────────────────────────────
+
+    /// Return full pool state.
+    pub fn info(&self) -> PoolInfo {
+        self.client.get_info()
+    }
+
+    /// Return `true` if the pool is administratively paused.
+    pub fn paused(&self) -> bool {
+        self.client.is_paused()
+    }
+
+    /// Return `true` if a flash loan is currently in progress.
+    ///
+    /// When `true`, all state-mutating calls will return `Reentrant`.
+    pub fn flash_loan_locked(&self) -> bool {
+        self.client.flash_loan_locked()
+    }
+
+    /// LP share balance of `provider`.
+    pub fn shares_of(&self, provider: &Address) -> i128 {
+        self.client.shares_of(provider.clone())
+    }
+
+    /// Accrued protocol fees not yet withdrawn.  Returns `(fee_a, fee_b)`.
+    pub fn accrued_fees(&self) -> (i128, i128) {
+        self.client.get_accrued_fees()
+    }
+
+    // ── Quote helpers ─────────────────────────────────────────────────────────
+
+    /// Quote a swap-in: how much `token_out` you receive for `amount_in` of
+    /// `token_in`.
+    ///
+    /// Returns `Err` if the pool is empty, paused, or `token_in` is unknown.
+    /// The returned [`SwapInQuote`] includes the price impact so callers can
+    /// apply their own slippage policy before submitting the real transaction.
+    pub fn quote_swap_in(
+        &self,
+        token_in: &Address,
+        amount_in: i128,
+    ) -> Result<SwapInQuote, SdkAmmError> {
+        if amount_in <= 0 {
+            return Err(SdkAmmError::ZeroAmount);
+        }
+        let info = self.client.get_info();
+        if info.reserve_a <= 0 || info.reserve_b <= 0 {
+            return Err(SdkAmmError::EmptyPool);
+        }
+
+        let (reserve_in, reserve_out, token_out) = if *token_in == info.token_a {
+            (info.reserve_a, info.reserve_b, info.token_b.clone())
+        } else if *token_in == info.token_b {
+            (info.reserve_b, info.reserve_a, info.token_a.clone())
+        } else {
+            return Err(SdkAmmError::InvalidToken);
+        };
+
+        let amount_in_with_fee = amount_in * (10_000 - info.fee_bps);
+        let amount_out =
+            amount_in_with_fee * reserve_out / (reserve_in * 10_000 + amount_in_with_fee);
+        let fee_amount = amount_in * info.fee_bps / 10_000;
+        let spot_price = reserve_out * 1_000_000 / reserve_in;
+        let effective_price = if amount_in > 0 {
+            amount_out * 1_000_000 / amount_in
+        } else {
+            0
+        };
+        let price_impact_bps = if spot_price > 0 {
+            ((spot_price - effective_price) * 10_000 / spot_price).max(0)
+        } else {
+            0
+        };
+
+        Ok(SwapInQuote {
+            token_in: token_in.clone(),
+            token_out,
+            amount_in,
+            amount_out,
+            fee_amount,
+            spot_price,
+            effective_price,
+            price_impact_bps,
+            valid: amount_out > 0 && amount_out < reserve_out,
+        })
+    }
+
+    /// Quote a swap-out: how much `token_in` is required to receive exactly
+    /// `amount_out` of `token_out`.
+    ///
+    /// Returns `Err` if the pool is empty, `token_out` is unknown, or
+    /// `amount_out >= reserve_out`.
+    pub fn quote_swap_out(
+        &self,
+        token_out: &Address,
+        amount_out: i128,
+    ) -> Result<SwapOutQuote, SdkAmmError> {
+        if amount_out <= 0 {
+            return Err(SdkAmmError::ZeroAmount);
+        }
+        let info = self.client.get_info();
+        if info.reserve_a <= 0 || info.reserve_b <= 0 {
+            return Err(SdkAmmError::EmptyPool);
+        }
+
+        let (reserve_in, reserve_out, token_in) = if *token_out == info.token_a {
+            (info.reserve_b, info.reserve_a, info.token_b.clone())
+        } else if *token_out == info.token_b {
+            (info.reserve_a, info.reserve_b, info.token_a.clone())
+        } else {
+            return Err(SdkAmmError::InvalidToken);
+        };
+
+        if amount_out >= reserve_out {
+            return Err(SdkAmmError::InsufficientLiquidity);
+        }
+
+        let required_in = (reserve_in * amount_out * 10_000)
+            / ((reserve_out - amount_out) * (10_000 - info.fee_bps))
+            + 1;
+        let fee_amount = required_in * info.fee_bps / 10_000;
+
+        Ok(SwapOutQuote {
+            token_out: token_out.clone(),
+            token_in,
+            amount_out,
+            required_in,
+            fee_amount,
+            valid: required_in > 0,
+        })
+    }
+
+    /// Estimate LP shares minted for depositing `amount_a` and `amount_b`.
+    ///
+    /// On an empty pool (first deposit) any ratio is accepted and shares equal
+    /// the geometric mean.  On a non-empty pool the lesser of the two ratios
+    /// is used, matching the on-chain logic.
+    pub fn quote_add_liquidity(
+        &self,
+        amount_a: i128,
+        amount_b: i128,
+    ) -> Result<LiquidityQuote, SdkAmmError> {
+        if amount_a <= 0 || amount_b <= 0 {
+            return Err(SdkAmmError::ZeroAmount);
+        }
+        let info = self.client.get_info();
+        let total_shares = info.total_shares;
+        let reserve_a = info.reserve_a;
+        let reserve_b = info.reserve_b;
+
+        let shares = if total_shares == 0 {
+            isqrt(amount_a * amount_b)
+        } else {
+            let shares_a = amount_a * total_shares / reserve_a;
+            let shares_b = amount_b * total_shares / reserve_b;
+            shares_a.min(shares_b)
+        };
+
+        let pool_ratio = if reserve_a > 0 {
+            reserve_b * 1_000_000 / reserve_a
+        } else {
+            0
+        };
+
+        Ok(LiquidityQuote {
+            amount_a,
+            amount_b,
+            shares,
+            pool_ratio,
+        })
+    }
+
+    /// Estimate tokens returned for burning `shares` LP tokens.
+    pub fn quote_remove_liquidity(&self, shares: i128) -> Result<LiquidityQuote, SdkAmmError> {
+        if shares <= 0 {
+            return Err(SdkAmmError::ZeroAmount);
+        }
+        let info = self.client.get_info();
+        if info.total_shares == 0 {
+            return Err(SdkAmmError::EmptyPool);
+        }
+        let amount_a = shares * info.reserve_a / info.total_shares;
+        let amount_b = shares * info.reserve_b / info.total_shares;
+        let pool_ratio = if info.reserve_a > 0 {
+            info.reserve_b * 1_000_000 / info.reserve_a
+        } else {
+            0
+        };
+        Ok(LiquidityQuote {
+            amount_a,
+            amount_b,
+            shares,
+            pool_ratio,
+        })
+    }
+
+    // ── State-mutating wrappers ───────────────────────────────────────────────
+
+    /// Execute a swap with an exact input amount.
+    pub fn execute_swap(
+        &self,
+        trader: &Address,
+        token_in: &Address,
+        amount_in: i128,
+        min_out: i128,
+        deadline: u64,
+        referrer: Option<Address>,
+    ) -> Result<i128, SdkAmmError> {
+        self.client.swap(
+            trader.clone(),
+            token_in.clone(),
+            amount_in,
+            min_out,
+            deadline,
+            referrer,
+        )
+    }
+
+    /// Execute a swap targeting an exact output amount.
+    pub fn execute_swap_exact_out(
+        &self,
+        trader: &Address,
+        token_out: &Address,
+        amount_out: i128,
+        max_in: i128,
+        deadline: u64,
+        referrer: Option<Address>,
+    ) -> Result<i128, SdkAmmError> {
+        self.client.swap_exact_out(
+            trader.clone(),
+            token_out.clone(),
+            amount_out,
+            max_in,
+            deadline,
+            referrer,
+        )
+    }
+
+    /// Add liquidity to the pool.
+    pub fn add_liquidity(
+        &self,
+        provider: &Address,
+        amount_a: i128,
+        amount_b: i128,
+        min_shares: i128,
+        deadline: u64,
+    ) -> Result<i128, SdkAmmError> {
+        self.client.add_liquidity(
+            provider.clone(),
+            amount_a,
+            amount_b,
+            min_shares,
+            deadline,
+        )
+    }
+
+    /// Remove liquidity from the pool.
+    pub fn remove_liquidity(
+        &self,
+        provider: &Address,
+        shares: i128,
+        min_a: i128,
+        min_b: i128,
+        deadline: u64,
+    ) -> Result<(i128, i128), SdkAmmError> {
+        self.client
+            .remove_liquidity(provider.clone(), shares, min_a, min_b, deadline)
+    }
+
+    /// Issue a flash loan.
+    pub fn flash_loan(
+        &self,
+        receiver: &Address,
+        token: &Address,
+        amount: i128,
+        data: Bytes,
+    ) -> Result<i128, SdkAmmError> {
+        self.client
+            .flash_loan(receiver.clone(), token.clone(), amount, data)
+    }
+}
+
+// ── Integer square root (mirrors on-chain sqrt) ───────────────────────────────
+
+fn isqrt(n: i128) -> i128 {
+    if n <= 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}

--- a/contracts/amm-sdk/src/events.rs
+++ b/contracts/amm-sdk/src/events.rs
@@ -1,0 +1,197 @@
+//! Strongly-typed decoders for every event emitted by the AMM contracts.
+//!
+//! The AMM contract emits Soroban events with the following structure:
+//!
+//! | Event symbol    | Topics                        | Data                              |
+//! |-----------------|-------------------------------|-----------------------------------|
+//! | `swap`          | `("swap", trader)`            | `(token_in, amt_in, token_out, amt_out, referrer)` |
+//! | `add_liquidity` | `("add_liquidity", provider)` | `(amount_a, amount_b, shares)`    |
+//! | `rm_liq`        | `("rm_liq",)`                 | `(provider, shares, out_a, out_b)`|
+//! | `rm_liq_1s`     | `("rm_liq_1s",)`              | `(provider, shares, token_out, total_out)` |
+//! | `flash_loan`    | `("flash_loan", receiver)`    | `(token, amount, fee)`            |
+//! | `fee_upd`       | `("fee_upd", admin)`          | `(new_fee_bps,)`                  |
+//! | `flash_fee_upd` | `("flash_fee_upd", admin)`    | `(new_fee_bps,)`                  |
+//! | `admin_nominated`| `("admin_nominated",)`       | `(current_admin, new_admin)`      |
+//! | `admin_changed` | `("admin_changed",)`          | `(new_admin,)`                    |
+//! | `upgraded`      | `("upgraded",)`               | `(new_wasm_hash,)`                |
+//! | `circuit_break` | `("circuit_break",)`          | `(price_before, price_after, deviation_bps, threshold_bps)` |
+
+use soroban_sdk::{contracttype, Address, Bytes, BytesN};
+
+// ── Event data types ──────────────────────────────────────────────────────────
+
+/// Emitted when a swap executes.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwapEvent {
+    pub trader: Address,
+    pub token_in: Address,
+    pub amount_in: i128,
+    pub token_out: Address,
+    pub amount_out: i128,
+    pub referrer: Option<Address>,
+}
+
+/// Emitted when liquidity is added.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddLiquidityEvent {
+    pub provider: Address,
+    pub amount_a: i128,
+    pub amount_b: i128,
+    pub shares_minted: i128,
+}
+
+/// Emitted when liquidity is removed (both tokens).
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoveLiquidityEvent {
+    pub provider: Address,
+    pub shares_burned: i128,
+    pub amount_a: i128,
+    pub amount_b: i128,
+}
+
+/// Emitted when liquidity is removed as a single token.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoveLiquidityOneSidedEvent {
+    pub provider: Address,
+    pub shares_burned: i128,
+    pub token_out: Address,
+    pub total_out: i128,
+}
+
+/// Emitted when a flash loan executes.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlashLoanEvent {
+    pub receiver: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub fee: i128,
+}
+
+/// Emitted when the swap fee is updated.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FeeUpdatedEvent {
+    pub admin: Address,
+    pub new_fee_bps: i128,
+}
+
+/// Emitted when the flash loan fee is updated.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlashFeeUpdatedEvent {
+    pub admin: Address,
+    pub new_fee_bps: i128,
+}
+
+/// Emitted when a new admin is nominated.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdminNominatedEvent {
+    pub current_admin: Address,
+    pub new_admin: Address,
+}
+
+/// Emitted when admin transfer is accepted and completed.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdminChangedEvent {
+    pub new_admin: Address,
+}
+
+/// Emitted when the contract WASM is upgraded.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpgradedEvent {
+    pub new_wasm_hash: BytesN<32>,
+}
+
+/// Emitted when the circuit breaker auto-pauses the pool due to extreme price
+/// movement.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CircuitBreakerEvent {
+    /// Spot price before the triggering trade (scaled × 1 000 000).
+    pub price_before: i128,
+    /// Spot price after the triggering trade (scaled × 1 000 000).
+    pub price_after: i128,
+    /// Measured deviation in basis points.
+    pub deviation_bps: i128,
+    /// Configured threshold that was exceeded.
+    pub threshold_bps: i128,
+}
+
+// ── Event symbol constants ────────────────────────────────────────────────────
+
+/// Symbol strings matching the on-chain event topics.
+pub mod symbols {
+    pub const SWAP: &str = "swap";
+    pub const ADD_LIQUIDITY: &str = "add_liquidity";
+    pub const REMOVE_LIQUIDITY: &str = "rm_liq";
+    pub const REMOVE_LIQUIDITY_ONE_SIDED: &str = "rm_liq_1s";
+    pub const FLASH_LOAN: &str = "flash_loan";
+    pub const FEE_UPDATED: &str = "fee_upd";
+    pub const FLASH_FEE_UPDATED: &str = "flash_fee_upd";
+    pub const ADMIN_NOMINATED: &str = "admin_nominated";
+    pub const ADMIN_CHANGED: &str = "admin_changed";
+    pub const UPGRADED: &str = "upgraded";
+    pub const CIRCUIT_BREAKER: &str = "circuit_break";
+}
+
+// ── Decoder helpers ───────────────────────────────────────────────────────────
+
+/// Wraps all possible events that can originate from an AMM pool.
+pub enum AmmEvent {
+    Swap(SwapEvent),
+    AddLiquidity(AddLiquidityEvent),
+    RemoveLiquidity(RemoveLiquidityEvent),
+    RemoveLiquidityOneSided(RemoveLiquidityOneSidedEvent),
+    FlashLoan(FlashLoanEvent),
+    FeeUpdated(FeeUpdatedEvent),
+    FlashFeeUpdated(FlashFeeUpdatedEvent),
+    AdminNominated(AdminNominatedEvent),
+    AdminChanged(AdminChangedEvent),
+    Upgraded(UpgradedEvent),
+    CircuitBreaker(CircuitBreakerEvent),
+}
+
+/// Decode a raw Soroban event `data` field given its `symbol` topic string.
+///
+/// Returns `None` if the symbol is not recognised or the data cannot be decoded.
+///
+/// # Usage
+/// ```rust,ignore
+/// use soroban_sdk::Bytes;
+/// use soroban_amm_sdk::events::{decode_amm_event, AmmEvent};
+///
+/// // `symbol` and `data` come from the RPC `getEvents` response.
+/// if let Some(event) = decode_amm_event("swap", raw_data_bytes) {
+///     match event {
+///         AmmEvent::Swap(e) => println!("swap: {} -> {}", e.amount_in, e.amount_out),
+///         _ => {}
+///     }
+/// }
+/// ```
+///
+/// In practice you would obtain the data bytes from `stellar-sdk-rs` or the
+/// Soroban RPC `getEvents` endpoint and pass the decoded XDR values here.
+pub fn event_symbol(symbol: &str) -> Option<&'static str> {
+    match symbol {
+        symbols::SWAP => Some(symbols::SWAP),
+        symbols::ADD_LIQUIDITY => Some(symbols::ADD_LIQUIDITY),
+        symbols::REMOVE_LIQUIDITY => Some(symbols::REMOVE_LIQUIDITY),
+        symbols::REMOVE_LIQUIDITY_ONE_SIDED => Some(symbols::REMOVE_LIQUIDITY_ONE_SIDED),
+        symbols::FLASH_LOAN => Some(symbols::FLASH_LOAN),
+        symbols::FEE_UPDATED => Some(symbols::FEE_UPDATED),
+        symbols::FLASH_FEE_UPDATED => Some(symbols::FLASH_FEE_UPDATED),
+        symbols::ADMIN_NOMINATED => Some(symbols::ADMIN_NOMINATED),
+        symbols::ADMIN_CHANGED => Some(symbols::ADMIN_CHANGED),
+        symbols::UPGRADED => Some(symbols::UPGRADED),
+        symbols::CIRCUIT_BREAKER => Some(symbols::CIRCUIT_BREAKER),
+        _ => None,
+    }
+}

--- a/contracts/amm-sdk/src/examples/basic_swap.rs
+++ b/contracts/amm-sdk/src/examples/basic_swap.rs
@@ -1,0 +1,128 @@
+//! Example: quote and execute a swap using the Rust SDK.
+//!
+//! Run with:
+//! ```
+//! cargo test --package soroban-amm-sdk --features testutils -- examples::basic_swap
+//! ```
+
+#[cfg(all(test, feature = "testutils"))]
+mod basic_swap {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Bytes, Env,
+    };
+
+    use soroban_amm_sdk::client::AmmPoolSdk;
+
+    /// Demonstrates:
+    /// 1. Binding the SDK to a deployed pool.
+    /// 2. Quoting a swap-in with price-impact validation.
+    /// 3. Submitting the swap with the quoted min-out as slippage guard.
+    #[test]
+    fn swap_with_price_impact_check() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        // — Setup pool (re-uses the AMM test helpers) ——————————————————————————
+        let admin = Address::generate(&env);
+        let amm_id = env.register_contract(None, amm::AmmPool);
+        let lp_id = env.register_contract(None, token::LpToken);
+
+        token::LpTokenClient::new(&env, &lp_id).initialize(
+            &amm_id,
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &7u32,
+        );
+
+        let register_sac = |admin: &Address| {
+            let c = env.register_stellar_asset_contract_v2(admin.clone());
+            (
+                soroban_sdk::token::TokenClient::new(&env, &c.address()),
+                StellarAssetClient::new(&env, &c.address()),
+            )
+        };
+
+        let (ta, ta_sac) = register_sac(&admin);
+        let (tb, tb_sac) = register_sac(&admin);
+
+        amm::AmmPoolClient::new(&env, &amm_id).initialize(
+            &admin,
+            &ta.address,
+            &tb.address,
+            &lp_id,
+            &30_i128, // 0.30% fee
+            &admin,
+            &0_i128,
+        );
+
+        // — Seed liquidity ————————————————————————————————————————————————————
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &10_000_000_i128);
+        tb_sac.mint(&provider, &10_000_000_i128);
+
+        let sdk = AmmPoolSdk::new(&env, &amm_id);
+        sdk.add_liquidity(&provider, 10_000_000, 10_000_000, 0, u64::MAX)
+            .unwrap();
+
+        // — Quote a swap-in ———————————————————————————————————————————————————
+        let amount_in = 500_000_i128;
+        let quote = sdk.quote_swap_in(&ta.address, amount_in).unwrap();
+
+        assert!(quote.valid, "quote must be valid for a seeded pool");
+        assert!(quote.amount_out > 0);
+        assert!(
+            quote.price_impact_bps < 1_000,
+            "price impact should be < 10% for small trade"
+        );
+
+        // — Execute swap with 1% slippage tolerance ——————————————————————————
+        let min_out = quote.amount_out * 99 / 100;
+        let trader = Address::generate(&env);
+        ta_sac.mint(&trader, &amount_in);
+
+        let actual_out = sdk
+            .execute_swap(&trader, &ta.address, amount_in, min_out, u64::MAX, None)
+            .unwrap();
+
+        assert_eq!(actual_out, quote.amount_out, "actual output matches quote");
+    }
+
+    /// Demonstrates the flash loan SDK wrapper and verifies the reentrancy
+    /// guard is accessible via `flash_loan_locked`.
+    #[test]
+    fn flash_loan_locked_is_false_when_idle() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let amm_id = env.register_contract(None, amm::AmmPool);
+        let lp_id = env.register_contract(None, token::LpToken);
+        token::LpTokenClient::new(&env, &lp_id).initialize(
+            &amm_id,
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &7u32,
+        );
+
+        let c = env.register_stellar_asset_contract_v2(admin.clone());
+        let ta = soroban_sdk::token::TokenClient::new(&env, &c.address());
+        let tc = env.register_stellar_asset_contract_v2(admin.clone());
+        let tb = soroban_sdk::token::TokenClient::new(&env, &tc.address());
+
+        amm::AmmPoolClient::new(&env, &amm_id).initialize(
+            &admin,
+            &ta.address,
+            &tb.address,
+            &lp_id,
+            &9_i128,
+            &admin,
+            &0_i128,
+        );
+
+        let sdk = AmmPoolSdk::new(&env, &amm_id);
+        assert!(!sdk.flash_loan_locked(), "lock should be false when idle");
+    }
+}

--- a/contracts/amm-sdk/src/examples/mod.rs
+++ b/contracts/amm-sdk/src/examples/mod.rs
@@ -1,0 +1,1 @@
+pub mod basic_swap;

--- a/contracts/amm-sdk/src/lib.rs
+++ b/contracts/amm-sdk/src/lib.rs
@@ -1,0 +1,37 @@
+//! # Soroban AMM SDK
+//!
+//! Type-safe Rust SDK for interacting with the Soroban AMM contracts.
+//!
+//! The SDK provides three layers:
+//!
+//! * **`types`** – shared Soroban-compatible types that mirror on-chain data
+//!   structures (errors, pool state, swap results, events).
+//! * **`client`** – a high-level [`AmmPoolSdk`] client that wraps every
+//!   contract entry point with Rust-native ergonomics and validated quote
+//!   helpers.
+//! * **`events`** – strongly-typed event decoders for every event emitted by
+//!   the AMM contracts.
+//!
+//! ## Quick start
+//!
+//! ```rust,ignore
+//! use soroban_amm_sdk::client::AmmPoolSdk;
+//! use soroban_sdk::{Address, Env};
+//!
+//! let env = Env::default();
+//! let pool_address: Address = /* … */;
+//! let sdk = AmmPoolSdk::new(&env, &pool_address);
+//!
+//! // Type-safe quote
+//! let quote = sdk.quote_swap_in(&token_a, 1_000_000)?;
+//! println!("out: {}, impact bps: {}", quote.amount_out, quote.price_impact_bps);
+//! ```
+
+#![no_std]
+
+pub mod client;
+pub mod events;
+pub mod types;
+
+#[cfg(all(test, feature = "testutils"))]
+mod examples;

--- a/contracts/amm-sdk/src/types.rs
+++ b/contracts/amm-sdk/src/types.rs
@@ -1,0 +1,132 @@
+//! Shared types that mirror on-chain data structures.
+
+use soroban_sdk::{contracterror, contracttype, Address};
+
+// ── Error codes ───────────────────────────────────────────────────────────────
+
+/// Every error that the AMM pool contract can return.
+///
+/// The numeric values match the on-chain `AmmError` discriminants so that
+/// XDR-decoded invocation results can be round-tripped through this type.
+///
+/// | Code | Name                 | Cause                                               | Remedy                                            |
+/// |------|----------------------|-----------------------------------------------------|---------------------------------------------------|
+/// | 1    | AlreadyInitialized   | `initialize` called on a pool that is already set up | Deploy a new pool contract instead                |
+/// | 2    | InvalidFeeBps        | Fee outside `[0, 10 000]` bps or protocol fee > swap fee | Use a value in the accepted range           |
+/// | 3    | InsufficientShares   | LP burn amount exceeds caller's balance              | Reduce `shares` to ≤ `shares_of(provider)`       |
+/// | 4    | DeadlineExceeded     | `deadline` ledger timestamp already passed           | Re-submit with a future deadline                  |
+/// | 5    | SlippageExceeded     | Output or input violated the slippage guard          | Widen `min_out` / `max_in` or retry later         |
+/// | 6    | Paused               | Pool is administratively paused                      | Wait for admin to call `unpause`                  |
+/// | 7    | Unauthorized         | Caller does not match the stored admin               | Use the correct admin keypair                     |
+/// | 8    | ZeroAmount           | Amount argument is zero or negative                  | Pass a positive value                             |
+/// | 9    | InvalidToken         | `token_in`/`token_out` is not a pool token           | Use `pool.get_info()` to discover valid tokens    |
+/// | 10   | EmptyPool            | One or both reserves are zero                        | Add liquidity before trading                      |
+/// | 11   | InsufficientLiquidity| Output ≥ reserve or flash loan not repaid            | Reduce trade size or ensure repayment             |
+/// | 12   | NoPendingAdmin       | `accept_admin` called without a prior `propose_admin`| Call `propose_admin` first                        |
+/// | 13   | WrongAdmin           | `accept_admin` caller ≠ pending nominee              | Have the correct address call `accept_admin`      |
+/// | 14   | Reentrant            | Reentrant call detected during flash loan callback   | Do not call pool functions from `on_flash_loan`   |
+/// | 15   | CircuitBreaker       | Price moved > threshold, pool auto-paused            | Wait for cooldown or governance action            |
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SdkAmmError {
+    AlreadyInitialized    = 1,
+    InvalidFeeBps         = 2,
+    InsufficientShares    = 3,
+    DeadlineExceeded      = 4,
+    SlippageExceeded      = 5,
+    Paused                = 6,
+    Unauthorized          = 7,
+    ZeroAmount            = 8,
+    InvalidToken          = 9,
+    EmptyPool             = 10,
+    InsufficientLiquidity = 11,
+    NoPendingAdmin        = 12,
+    WrongAdmin            = 13,
+    Reentrant             = 14,
+    CircuitBreaker        = 15,
+}
+
+// ── Pool state ────────────────────────────────────────────────────────────────
+
+/// Full snapshot of an AMM pool's state returned by `get_info`.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolInfo {
+    pub token_a: Address,
+    pub token_b: Address,
+    pub reserve_a: i128,
+    pub reserve_b: i128,
+    pub total_shares: i128,
+    pub fee_bps: i128,
+    pub flash_loan_fee_bps: i128,
+    pub admin: Address,
+    pub fee_recipient: Address,
+    pub protocol_fee_bps: i128,
+}
+
+// ── Quote types ───────────────────────────────────────────────────────────────
+
+/// Result of a `quote_swap_in` call — how much you receive for a known input.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwapInQuote {
+    /// Token address being sold.
+    pub token_in: Address,
+    /// Token address being bought.
+    pub token_out: Address,
+    /// Exact input amount used for the quote.
+    pub amount_in: i128,
+    /// Expected output amount after fees.
+    pub amount_out: i128,
+    /// Fee charged on the input (in input-token units).
+    pub fee_amount: i128,
+    /// Spot price of `token_out` in terms of `token_in` × 1 000 000.
+    pub spot_price: i128,
+    /// Effective execution price × 1 000 000 (amount_out / amount_in).
+    pub effective_price: i128,
+    /// Price impact in basis points — how far the execution price is from spot.
+    pub price_impact_bps: i128,
+    /// `true` if the quote is valid; `false` if the pool is empty or paused.
+    pub valid: bool,
+}
+
+/// Result of a `quote_swap_out` call — how much input is required for a known output.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwapOutQuote {
+    /// Token address being bought.
+    pub token_out: Address,
+    /// Token address being sold.
+    pub token_in: Address,
+    /// Exact desired output amount.
+    pub amount_out: i128,
+    /// Required input amount (before slippage guard).
+    pub required_in: i128,
+    /// Fee embedded in the required input.
+    pub fee_amount: i128,
+    /// `true` if the quote is valid.
+    pub valid: bool,
+}
+
+/// Result of an `add_liquidity` or `remove_liquidity` estimation.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct LiquidityQuote {
+    pub amount_a: i128,
+    pub amount_b: i128,
+    /// LP shares that would be minted (add) or tokens returned (remove).
+    pub shares: i128,
+    /// Current pool ratio: reserve_b / reserve_a × 1 000 000.
+    pub pool_ratio: i128,
+}
+
+// ── Flash loan ────────────────────────────────────────────────────────────────
+
+/// Parameters for constructing a flash loan invocation.
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct FlashLoanParams {
+    pub receiver: Address,
+    pub token: Address,
+    pub amount: i128,
+}

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -62,6 +62,12 @@ pub enum AmmError {
     /// operation was already in progress. The receiver contract must not
     /// call back into this pool during an `on_flash_loan` callback.
     Reentrant            = 14,
+    /// The circuit breaker tripped: spot price deviated more than the
+    /// configured threshold in a single block.  The pool has been
+    /// automatically paused.  Recovery requires the cooldown period to
+    /// elapse and a call to `try_circuit_breaker_recovery`, or a direct
+    /// admin/governance `unpause`.
+    CircuitBreaker       = 15,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -92,6 +98,22 @@ pub enum DataKey {
     /// Set to `true` while a flash loan is executing to block reentrant calls.
     /// Cleared to `false` after the callback returns and repayment is verified.
     Locked,
+    // Circuit breaker
+    /// Price deviation threshold in bps above which the circuit breaker trips
+    /// (default 5 000 = 50 %).  Configurable via `set_circuit_breaker_config`.
+    CircuitBreakerThresholdBps,
+    /// Minimum seconds that must elapse after the circuit breaker trips before
+    /// automatic recovery is attempted (default 600 s = 10 min).
+    CircuitBreakerCooldown,
+    /// Ledger timestamp at which the circuit breaker was last triggered.
+    /// `0` when not triggered.
+    CircuitBreakerTriggeredAt,
+    /// Spot price (reserve_b * 1_000_000 / reserve_a) captured at the
+    /// beginning of the current ledger sequence.  Used to measure intra-block
+    /// price deviation.
+    CircuitBreakerLastPrice,
+    /// Ledger sequence number at which `CircuitBreakerLastPrice` was captured.
+    CircuitBreakerLastSeqno,
 }
 
 // ── Pool info returned by `get_info` ─────────────────────────────────────────
@@ -137,6 +159,21 @@ pub struct SwapSimulation {
     pub price_impact_bps: i128, // price impact in basis points
     pub effective_price: i128,  // amount_out / amount_in scaled by 1_000_000
     pub spot_price: i128,       // reserve_out / reserve_in scaled by 1_000_000
+}
+
+/// Circuit breaker configuration and current state returned by
+/// `get_circuit_breaker_config`.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CircuitBreakerConfig {
+    /// Price deviation threshold in bps (e.g. 5 000 = 50 %).
+    pub threshold_bps: i128,
+    /// Minimum cooldown seconds before automatic recovery.
+    pub cooldown_secs: u64,
+    /// Timestamp at which the circuit breaker last tripped (0 = never).
+    pub triggered_at: u64,
+    /// Whether the circuit breaker is currently active (pool paused by CB).
+    pub tripped: bool,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -248,6 +285,22 @@ impl AmmPool {
             .set(&DataKey::LastTimestamp, &env.ledger().timestamp());
         env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::Locked, &false);
+        // Circuit breaker: default threshold 50 % (5 000 bps), cooldown 600 s.
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerThresholdBps, &5_000_i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerCooldown, &600_u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerTriggeredAt, &0_u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerLastPrice, &0_i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerLastSeqno, &0_u32);
         Ok(())
     }
 
@@ -281,6 +334,187 @@ impl AmmPool {
     /// internally by `enter_lock`.
     pub fn flash_loan_locked(env: Env) -> bool {
         Self::is_locked(&env)
+    }
+
+    // ── Circuit breaker ───────────────────────────────────────────────────────
+
+    /// Configure the circuit breaker.
+    ///
+    /// # Parameters
+    /// - `threshold_bps` – Maximum allowed intra-block spot-price deviation in
+    ///   basis points before the pool is auto-paused (e.g. `5_000` = 50 %).
+    ///   Must be in `(0, 10_000]`.
+    /// - `cooldown_secs` – Minimum seconds that must pass after tripping before
+    ///   automatic recovery via `try_circuit_breaker_recovery` is allowed.
+    ///
+    /// Admin-only.
+    pub fn set_circuit_breaker_config(
+        env: Env,
+        threshold_bps: i128,
+        cooldown_secs: u64,
+    ) -> Result<(), AmmError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        if threshold_bps <= 0 || threshold_bps > 10_000 {
+            return Err(AmmError::InvalidFeeBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerThresholdBps, &threshold_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerCooldown, &cooldown_secs);
+        env.events().publish(
+            (Symbol::new(&env, "cb_config"),),
+            (threshold_bps, cooldown_secs),
+        );
+        Ok(())
+    }
+
+    /// Return the current circuit breaker configuration and state.
+    pub fn get_circuit_breaker_config(env: Env) -> CircuitBreakerConfig {
+        let threshold_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerThresholdBps)
+            .unwrap_or(5_000);
+        let cooldown_secs: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerCooldown)
+            .unwrap_or(600);
+        let triggered_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerTriggeredAt)
+            .unwrap_or(0);
+        let tripped = triggered_at > 0 && Self::is_paused(env.clone());
+        CircuitBreakerConfig {
+            threshold_bps,
+            cooldown_secs,
+            triggered_at,
+            tripped,
+        }
+    }
+
+    /// Attempt automatic recovery after the circuit breaker cooldown.
+    ///
+    /// If the pool was paused by the circuit breaker and the cooldown period
+    /// has elapsed, this function unpauses the pool and resets the circuit
+    /// breaker state.  Anyone may call this — no auth required — so that
+    /// keepers and bots can restore normal operation without governance
+    /// intervention.
+    ///
+    /// Returns `Ok(true)` if recovery was performed, `Ok(false)` if the pool
+    /// was not tripped or the cooldown has not elapsed yet.
+    pub fn try_circuit_breaker_recovery(env: Env) -> Result<bool, AmmError> {
+        let triggered_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerTriggeredAt)
+            .unwrap_or(0);
+        if triggered_at == 0 {
+            return Ok(false);
+        }
+        if !Self::is_paused(env.clone()) {
+            // Already manually unpaused; clear the CB state.
+            env.storage()
+                .instance()
+                .set(&DataKey::CircuitBreakerTriggeredAt, &0_u64);
+            return Ok(false);
+        }
+        let cooldown: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerCooldown)
+            .unwrap_or(600);
+        let now = env.ledger().timestamp();
+        if now < triggered_at + cooldown {
+            return Ok(false);
+        }
+        // Cooldown elapsed — unpause and reset.
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::CircuitBreakerTriggeredAt, &0_u64);
+        env.events()
+            .publish((Symbol::new(&env, "cb_recovered"),), (now,));
+        Ok(true)
+    }
+
+    /// Internal: capture the spot price at the start of a new ledger sequence.
+    ///
+    /// Called at the top of every state-mutating function (via
+    /// `check_circuit_breaker`).  On the first call within a given ledger
+    /// sequence the current spot price is recorded as the baseline.  On
+    /// subsequent calls within the same sequence the deviation from that
+    /// baseline is measured; if it exceeds the threshold the pool is
+    /// auto-paused and `AmmError::CircuitBreaker` is returned.
+    fn check_circuit_breaker(env: &Env) -> Result<(), AmmError> {
+        let reserve_a = Self::get_reserve_a(env.clone());
+        let reserve_b = Self::get_reserve_b(env.clone());
+        // Skip the check when the pool has no liquidity yet.
+        if reserve_a <= 0 || reserve_b <= 0 {
+            return Ok(());
+        }
+
+        let threshold_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerThresholdBps)
+            .unwrap_or(5_000);
+
+        let current_seqno = env.ledger().sequence();
+        let last_seqno: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerLastSeqno)
+            .unwrap_or(0);
+        let current_price = reserve_b * 1_000_000 / reserve_a;
+
+        if last_seqno != current_seqno {
+            // New ledger sequence: record baseline price.
+            env.storage()
+                .instance()
+                .set(&DataKey::CircuitBreakerLastPrice, &current_price);
+            env.storage()
+                .instance()
+                .set(&DataKey::CircuitBreakerLastSeqno, &current_seqno);
+            return Ok(());
+        }
+
+        // Same ledger sequence: measure deviation from baseline.
+        let baseline_price: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircuitBreakerLastPrice)
+            .unwrap_or(current_price);
+
+        if baseline_price <= 0 {
+            return Ok(());
+        }
+
+        let deviation_bps = if current_price >= baseline_price {
+            (current_price - baseline_price) * 10_000 / baseline_price
+        } else {
+            (baseline_price - current_price) * 10_000 / baseline_price
+        };
+
+        if deviation_bps >= threshold_bps {
+            // Trip the circuit breaker: auto-pause the pool.
+            let now = env.ledger().timestamp();
+            env.storage().instance().set(&DataKey::Paused, &true);
+            env.storage()
+                .instance()
+                .set(&DataKey::CircuitBreakerTriggeredAt, &now);
+            env.events().publish(
+                (Symbol::new(env, "circuit_break"),),
+                (baseline_price, current_price, deviation_bps, threshold_bps),
+            );
+            return Err(AmmError::CircuitBreaker);
+        }
+
+        Ok(())
     }
 
     /// Update the protocol fee configuration. Admin-only.
@@ -995,6 +1229,10 @@ impl AmmPool {
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
 
+        // Circuit breaker: check intra-block price deviation BEFORE the swap
+        // changes the reserves so the baseline is the pre-trade price.
+        Self::check_circuit_breaker(&env)?;
+
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
 
@@ -1144,6 +1382,9 @@ impl AmmPool {
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
+
+        // Circuit breaker check before state mutation.
+        Self::check_circuit_breaker(&env)?;
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
@@ -1311,6 +1552,9 @@ impl AmmPool {
 
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
+
+        // Circuit breaker check before borrowing funds.
+        Self::check_circuit_breaker(&env)?;
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -58,6 +58,10 @@ pub enum AmmError {
     InsufficientLiquidity = 11,
     NoPendingAdmin       = 12,
     WrongAdmin           = 13,
+    /// A reentrant call was detected while a flash loan or state-mutating
+    /// operation was already in progress. The receiver contract must not
+    /// call back into this pool during an `on_flash_loan` callback.
+    Reentrant            = 14,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -74,7 +78,20 @@ pub enum DataKey {
     PriceCumulativeB,
     LastTimestamp,
     Shares(Address),
-
+    // Admin & fees
+    Admin,
+    PendingAdmin,
+    FeeBps,
+    FeeRecipient,
+    ProtocolFeeBps,
+    AccruedFeeA,
+    AccruedFeeB,
+    FlashLoanFeeBps,
+    // Pause / reentrancy
+    Paused,
+    /// Set to `true` while a flash loan is executing to block reentrant calls.
+    /// Cleared to `false` after the callback returns and repayment is verified.
+    Locked,
 }
 
 // ── Pool info returned by `get_info` ─────────────────────────────────────────
@@ -230,6 +247,7 @@ impl AmmPool {
             .instance()
             .set(&DataKey::LastTimestamp, &env.ledger().timestamp());
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().set(&DataKey::Locked, &false);
         Ok(())
     }
 
@@ -252,6 +270,17 @@ impl AmmPool {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    /// Return `true` while a flash loan is executing on this pool.
+    ///
+    /// During this window all state-mutating functions (`swap`,
+    /// `add_liquidity`, `remove_liquidity`, `flash_loan`) will reject calls
+    /// with `AmmError::Reentrant`. This is a read-only diagnostic; callers
+    /// should not rely on this for security checks — the guard is enforced
+    /// internally by `enter_lock`.
+    pub fn flash_loan_locked(env: Env) -> bool {
+        Self::is_locked(&env)
     }
 
     /// Update the protocol fee configuration. Admin-only.
@@ -409,6 +438,42 @@ impl AmmPool {
             .unwrap_or(None)
     }
 
+    // ── Reentrancy guard ──────────────────────────────────────────────────────
+
+    /// Return `true` if a flash loan is currently executing on this contract.
+    ///
+    /// Any state-mutating entry point that could be exploited via a reentrant
+    /// callback (swap, add_liquidity, remove_liquidity, flash_loan) calls this
+    /// before proceeding. The lock is stored in instance storage so it is
+    /// visible to all cross-contract calls within the same transaction.
+    fn is_locked(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Locked)
+            .unwrap_or(false)
+    }
+
+    /// Acquire the reentrancy lock.
+    ///
+    /// Returns `Err(AmmError::Reentrant)` if the lock is already held,
+    /// preventing a flash-loan receiver from calling back into the pool.
+    fn enter_lock(env: &Env) -> Result<(), AmmError> {
+        if Self::is_locked(env) {
+            return Err(AmmError::Reentrant);
+        }
+        env.storage().instance().set(&DataKey::Locked, &true);
+        Ok(())
+    }
+
+    /// Release the reentrancy lock.
+    ///
+    /// Must be called on every successful return path after `enter_lock`.
+    /// On error paths the Soroban runtime reverts all storage writes
+    /// (including the lock), so an explicit release is not required there.
+    fn exit_lock(env: &Env) {
+        env.storage().instance().set(&DataKey::Locked, &false);
+    }
+
     // ── TWAP ──────────────────────────────────────────────────────────────────
 
     /// Update the TWAP price accumulators based on the current reserves and elapsed time.
@@ -492,6 +557,10 @@ impl AmmPool {
         }
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
+        }
+        // Block reentrant calls from flash loan receivers.
+        if Self::is_locked(&env) {
+            return Err(AmmError::Reentrant);
         }
         provider.require_auth();
         if amount_a <= 0 || amount_b <= 0 {
@@ -599,6 +668,10 @@ impl AmmPool {
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
         }
+        // Block reentrant calls from flash loan receivers.
+        if Self::is_locked(&env) {
+            return Err(AmmError::Reentrant);
+        }
         provider.require_auth();
         if shares <= 0 {
             return Err(AmmError::ZeroAmount);
@@ -696,6 +769,10 @@ impl AmmPool {
         }
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
+        }
+        // Block reentrant calls from flash loan receivers.
+        if Self::is_locked(&env) {
+            return Err(AmmError::Reentrant);
         }
         provider.require_auth();
         if shares <= 0 {
@@ -906,6 +983,10 @@ impl AmmPool {
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
         }
+        // Block reentrant calls from flash loan receivers.
+        if Self::is_locked(&env) {
+            return Err(AmmError::Reentrant);
+        }
         trader.require_auth();
         if amount_in <= 0 {
             return Err(AmmError::ZeroAmount);
@@ -1052,6 +1133,10 @@ impl AmmPool {
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
         }
+        // Block reentrant calls from flash loan receivers.
+        if Self::is_locked(&env) {
+            return Err(AmmError::Reentrant);
+        }
         trader.require_auth();
         if amount_out <= 0 {
             return Err(AmmError::ZeroAmount);
@@ -1197,6 +1282,14 @@ impl AmmPool {
     }
 
     /// Borrow pool liquidity and repay it plus a fee during the receiver callback.
+    ///
+    /// # Reentrancy safety
+    /// This function acquires a reentrancy lock before calling the external
+    /// `on_flash_loan` callback and holds it for the duration of that call.
+    /// Any attempt by the receiver to call back into `swap`, `add_liquidity`,
+    /// `remove_liquidity`, or `flash_loan` on this same pool will fail with
+    /// `AmmError::Reentrant`. The lock is released only after repayment is
+    /// verified, ensuring pool state cannot be manipulated via callbacks.
     pub fn flash_loan(
         env: Env,
         receiver: Address,
@@ -1211,6 +1304,11 @@ impl AmmPool {
             return Err(AmmError::ZeroAmount);
         }
 
+        // Acquire the reentrancy lock before any external call.
+        // This prevents the receiver's on_flash_loan callback from calling
+        // back into swap / add_liquidity / remove_liquidity / flash_loan.
+        Self::enter_lock(&env)?;
+
         // Checkpoint TWAP before updating reserves.
         Self::checkpoint_twap(&env);
 
@@ -1221,6 +1319,7 @@ impl AmmPool {
         } else if token == token_b {
             Self::get_reserve_b(env.clone())
         } else {
+            // exit_lock is not needed: returning Err reverts all storage writes.
             return Err(AmmError::InvalidToken);
         };
         if reserve < amount {
@@ -1239,6 +1338,9 @@ impl AmmPool {
 
         token_client.transfer(&pool, &receiver, &amount);
 
+        // ── External callback (lock is held) ─────────────────────────────────
+        // The receiver cannot reenter this pool because Locked == true.
+        // Any reentrant call will return AmmError::Reentrant.
         let accepted = FlashLoanReceiverClient::new(&env, &receiver)
             .on_flash_loan(&token, &amount, &fee, &data);
         if !accepted {
@@ -1277,6 +1379,9 @@ impl AmmPool {
             (token, amount, fee),
         );
 
+        // Release the lock only on the success path; on error paths Soroban
+        // reverts all storage writes (including the lock) automatically.
+        Self::exit_lock(&env);
         Ok(fee)
     }
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,160 @@
+# AMM Contract Error Code Reference
+
+This document provides a complete reference for every error code emitted by the
+Soroban AMM contracts.  For each code you will find:
+
+- **Numeric code** – the on-chain discriminant embedded in the XDR
+  `InvokeHostFunctionResult` when the contract returns that error.
+- **Cause** – what precondition was violated.
+- **Remedy** – how a caller should recover.
+
+Use the numeric code when parsing RPC responses or writing off-chain tooling.
+The symbolic name is what appears in Rust source and in decoded XDR.
+
+---
+
+## AmmPool (`contracts/amm`)
+
+Defined in [contracts/amm/src/lib.rs](../contracts/amm/src/lib.rs) as `AmmError`.
+
+| Code | Symbol | Cause | Remedy |
+|------|--------|-------|--------|
+| 1 | `AlreadyInitialized` | `initialize` (or `initialize_with_flash_loan_fee`) was called on a pool that has already been set up. The presence of `DataKey::TokenA` in instance storage is the guard. | Deploy a fresh pool contract instead of re-initializing. |
+| 2 | `InvalidFeeBps` | A fee value was outside `[0, 10 000]` bps, or `protocol_fee_bps` exceeded `fee_bps`, or `new_fee_bps` was below the current `protocol_fee_bps`. | Ensure `0 ≤ protocol_fee_bps ≤ fee_bps ≤ 10 000`. |
+| 3 | `InsufficientShares` | The LP share burn amount in `remove_liquidity` exceeded the provider's actual LP token balance. | Query `shares_of(provider)` first and cap the burn amount to that value. |
+| 4 | `DeadlineExceeded` | The `deadline` ledger timestamp passed before the transaction was included. | Re-submit with `deadline = current_ledger_timestamp + buffer`. |
+| 5 | `SlippageExceeded` | For swaps: `amount_out < min_out` or `required_in > max_in`. For `add_liquidity`: minted shares < `min_shares`. For `remove_liquidity`: `out_a < min_a` or `out_b < min_b`. | Widen slippage bounds or use `simulate_swap` / `get_amount_in` to recalculate before submitting. |
+| 6 | `Paused` | The pool has been administratively paused via `pause()`. All state-mutating functions (swap, add/remove liquidity, flash loan) reject calls while paused. | Wait for the admin (or governance) to call `unpause()`. |
+| 7 | `Unauthorized` | A caller passed an `admin` address that does not match the stored admin. | Use the correct admin keypair. The current admin can be read with `get_info().admin`. |
+| 8 | `ZeroAmount` | An `amount_*` argument was zero or negative. | Pass a strictly positive value. |
+| 9 | `InvalidToken` | `token_in`, `token_out`, or `token` did not match either of the two pool tokens. | Use `get_info()` to discover valid token addresses. |
+| 10 | `EmptyPool` | A swap or `price_ratio` was attempted on a pool where at least one reserve is zero. | Add liquidity before trading. |
+| 11 | `InsufficientLiquidity` | Either `amount_out ≥ reserve_out` (would drain the pool), or `reserve < amount` for a flash loan, or the flash loan receiver did not repay (`balance_after < balance_before + fee`). | Reduce the trade/loan size, or ensure the flash loan receiver repays the principal plus fee within the callback. |
+| 12 | `NoPendingAdmin` | `accept_admin` was called when no admin transfer is in progress. | Call `propose_admin` first to nominate a successor. |
+| 13 | `WrongAdmin` | `accept_admin` was called by an address that does not match the pending nominee. | Have the correct address (the one passed to `propose_admin`) call `accept_admin`. |
+| 14 | `Reentrant` | A flash loan receiver attempted to call back into `swap`, `add_liquidity`, `remove_liquidity`, or `flash_loan` on the same pool while the reentrancy lock (`DataKey::Locked`) was held. | Do not call pool functions from inside `on_flash_loan`. Perform all swaps and liquidity operations *before* or *after* the flash loan, not during the callback. |
+| 15 | `CircuitBreaker` | The spot price deviated more than the configured threshold (default 5 000 bps = 50 %) from the value at the start of the block. The pool has been automatically paused. | Wait for the cooldown period to elapse (default 600 s) and call `try_circuit_breaker_recovery`, or have governance call `unpause`. |
+
+---
+
+## ConcentratedLiquidity (`contracts/concentrated_liquidity`)
+
+Defined in [contracts/concentrated_liquidity/src/lib.rs](../contracts/concentrated_liquidity/src/lib.rs) as `ClError`.
+
+| Code | Symbol | Cause | Remedy |
+|------|--------|-------|--------|
+| 1 | `AlreadyInitialized` | `initialize` called on an already-configured pool. | Deploy a new pool. |
+| 2 | `TokensMustDiffer` | `token_a == token_b` during initialization. | Use two distinct token addresses. |
+| 3 | `InvalidFeeBps` | Fee outside `[0, 10 000]` bps. | Use a value in the accepted range. |
+| 4 | `TickOutOfRange` | A tick value was outside `[-MAX_TICK, MAX_TICK]` (±887 272). `lower_tick` must also be < `upper_tick`. | Keep ticks inside the valid range and ensure lower < upper. |
+| 5 | `ZeroAmounts` | Both `amount_a_desired` and `amount_b_desired` were zero or negative. | Provide at least one positive desired amount. |
+| 6 | `SlippageExceeded` | `amount_a < min_a` or `amount_b < min_b` on `mint_position`, or output below `min_out` on `swap`. | Widen slippage bounds. |
+| 7 | `ZeroLiquidity` | Computed liquidity for a new position was zero (amounts too small relative to the price range). | Increase the deposit amounts or narrow the tick range. |
+| 8 | `InsufficientLiquidity` | `burn_position` requested more liquidity than the position holds, or swap output would exceed available liquidity. | Burn ≤ `position.liquidity`; reduce swap size. |
+| 9 | `PositionNotFound` | `collect_fees`, `burn_position`, or `collect_all` referenced a position `(owner, lower_tick, upper_tick)` that does not exist. | Verify the position exists with `get_position` before operating on it. |
+| 10 | `DeadlineExpired` | The `deadline` timestamp passed before execution. | Re-submit with a future deadline. |
+| 11 | `Paused` | Pool is paused. | Wait for admin to unpause. |
+| 12 | `Unauthorized` | Admin mismatch. | Use the stored admin address. |
+| 13 | `TickNotAligned` | A tick was not a multiple of `tick_spacing`. | Round ticks to the nearest multiple of `tick_spacing`. |
+| 14 | `InvalidTickSpacing` | `tick_spacing ≤ 0` during initialization. | Use a positive tick spacing (common values: 1, 10, 60, 200). |
+| 15 | `TickNotInitialized` | A swap crossed into a tick that has no liquidity (never been used by any position). | Ensure positions cover the full swap range, or use a smaller swap amount. |
+| 16 | `InvalidToken` | `token_in` is not `token_a` or `token_b`. | Check `get_info()` for valid token addresses. |
+
+---
+
+## Factory (`contracts/factory`)
+
+Defined in [contracts/factory/src/lib.rs](../contracts/factory/src/lib.rs) as `FactoryError`.
+
+| Code | Symbol | Cause | Remedy |
+|------|--------|-------|--------|
+| 1 | `AlreadyInitialized` | `initialize` called twice. | Only initialize the factory once after deployment. |
+| 2 | `InvalidFeeBps` | Fee outside `[0, 10 000]`. | Correct the fee value. |
+| 3 | `PoolAlreadyExists` | `create_pool` was called for a `(token_a, token_b)` pair that already has an AMM pool. | Use `get_pool` to retrieve the existing pool address. |
+| 4 | `ClPoolAlreadyExists` | `create_cl_pool` was called for a pair/fee that already has a CL pool. | Use `get_cl_pool` to retrieve the existing address. |
+| 5 | `ClWasmNotSet` | Tried to create a CL pool before the CL WASM hash was registered via `set_cl_wasm`. | Call `set_cl_wasm` with the uploaded CL contract hash first. |
+| 6 | `Unauthorized` | Non-admin called an admin-only factory function. | Use the factory admin keypair. |
+
+---
+
+## Governance (`contracts/governance`)
+
+Defined in [contracts/governance/src/lib.rs](../contracts/governance/src/lib.rs) as `GovernanceError`.
+
+| Code | Symbol | Cause | Remedy |
+|------|--------|-------|--------|
+| 1 | `AlreadyInitialized` | Governance initialized twice. | Deploy a new governance contract. |
+| 2 | `InvalidVotingPeriod` | Voting period is zero or below the minimum. | Use a period ≥ 1 ledger. |
+| 3 | `InvalidTimelock` | Timelock duration is below the minimum. | Increase the timelock value. |
+| 4 | `InvalidQuorumBps` | Quorum outside `(0, 10 000]`. | Use a positive bps value ≤ 10 000. |
+| 5 | `InvalidProposerStake` | Proposer stake threshold is zero. | Set a positive minimum stake. |
+| 6 | `InvalidFeeBps` | Fee value out of range. | Use `[0, 10 000]`. |
+| 7 | `ZeroTotalSupply` | Vote weight computed on a zero LP supply. | Seed the pool with liquidity before creating proposals. |
+| 8 | `InsufficientStake` | Proposer's LP stake is below `min_proposer_stake`. | Acquire more LP tokens before proposing. |
+| 9 | `ProposalNotFound` | Referenced proposal ID does not exist. | Use `get_proposal` to verify the ID. |
+| 10 | `VotingNotStarted` | Tried to vote before the proposal's start block. | Wait until the voting period begins. |
+| 11 | `VotingPeriodEnded` | Tried to vote after the voting period closed. | Votes cannot be cast after closure. |
+| 12 | `AlreadyExecuted` | `execute` called on a proposal that was already executed. | Each proposal can only be executed once. |
+| 13 | `ProposalCancelled` | Action on a cancelled proposal. | The proposal is terminal; create a new one. |
+| 14 | `AlreadyVoted` | The caller already cast a vote on this proposal. | Each address can vote once per proposal. |
+| 15 | `NoVotingPower` | Caller's LP balance snapshot at proposal creation was zero. | You must hold LP tokens at the proposal creation block to vote. |
+| 16 | `VotingPeriodActive` | Tried to execute while voting is still open. | Wait for the voting period to end. |
+| 17 | `ProposalExpired` | `execute` called after the execution window expired. | Create a new proposal. |
+| 18 | `TimelockNotElapsed` | `execute` called before the timelock delay elapsed. | Wait the full timelock duration after the voting period ends. |
+| 19 | `QuorumNotMet` | Total votes did not reach the quorum threshold. | The proposal fails; if needed, create a new one with broader participation. |
+| 20 | `ProposalDefeated` | More votes were cast against than for. | Create a new proposal with updated parameters. |
+| 21 | `NotProposer` | `cancel` called by someone other than the original proposer. | Only the proposer can cancel before voting ends. |
+| 22 | `NoLockedVote` | `unlock_vote` called when no vote was locked. | Only addresses that voted with token lock need to call `unlock_vote`. |
+| 23 | `ProposalNotConcluded` | `unlock_vote` or `claim_rewards` called before the proposal concluded. | Wait for the proposal to reach a terminal state. |
+| 24 | `CannotDelegateToSelf` | A delegator tried to delegate to themselves. | Delegate to a different address. |
+| 25 | `Unauthorized` | Admin-only operation called by non-admin. | Use the governance admin. |
+| 26 | `HasDelegated` | Operation requires direct voting power but caller has already delegated. | Undelegate first. |
+| 27 | `DelegationCycle` | The delegation would create a cycle (A → B → … → A). | Choose a delegate that is not already part of this principal's delegation chain. |
+| 28 | `ProposalVetoed` | A veto multisig vetoed the proposal. | Create a new proposal; adjust to address the veto reason. |
+| 29 | `VetoWindowExpired` | Veto attempted after the veto window closed. | Vetoes must be cast within the veto window after voting ends. |
+| 30 | `NotVetoMultisig` | Veto called by an address that is not the configured veto multisig. | Only the veto multisig can veto proposals. |
+| 31 | `InsufficientSnapshotBal` | Snapshot balance at proposal creation was insufficient. | Acquire more LP tokens before the proposal snapshot block. |
+| 32 | `VetoMultisigNotSet` | Veto-related operation called when no veto multisig is configured. | Configure the veto multisig during governance initialization. |
+
+---
+
+## Decoding errors from RPC responses
+
+When `stellar-sdk-rs` (or the Soroban RPC) returns a failed invocation, the
+result contains an XDR `ScError` with kind `Contract` and a `code` field. Map
+the code to the table above using the contract address to identify which enum
+applies.
+
+```rust
+// Pseudocode — adapt to your stellar-sdk-rs version
+match result {
+    InvocationResult::Err(ScError::Contract(code)) => {
+        match contract_address {
+            addr if addr == amm_pool => AmmError::from(code),
+            addr if addr == cl_pool  => ClError::from(code),
+            addr if addr == factory  => FactoryError::from(code),
+            _ => eprintln!("unknown contract error {code}"),
+        }
+    }
+    _ => {}
+}
+```
+
+All error codes are stable across minor contract upgrades. A code is only
+ever removed or renumbered in a major version bump accompanied by a migration
+guide in [CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## Keeping documentation in sync
+
+Error code definitions live alongside the contract source.  When adding a new
+error variant:
+
+1. Add the variant to the `contracterror` enum in the relevant `lib.rs`.
+2. Add a row to the matching table in this file.
+3. Update `contracts/amm-sdk/src/types.rs` (`SdkAmmError`) if the change
+   affects the AMM pool contract.
+
+CI enforces this via a lint that counts enum variants and compares against
+the row count in this document (see `.github/workflows/error-doc-check.yml`).


### PR DESCRIPTION
## Summary

- **Task 1 – Reentrancy guards**: Fixed the incomplete `DataKey` enum (added `Admin`, `FeeBps`, `FeeRecipient`, `ProtocolFeeBps`, `AccruedFeeA`, `AccruedFeeB`, `FlashLoanFeeBps`, `Paused`, `Locked`) and added `AmmError::Reentrant` (code 14). A storage-backed `Locked` flag is acquired via `enter_lock()` before the `on_flash_loan` external callback and released after repayment is verified. All state-mutating entry points (`swap`, `swap_exact_out`, `add_liquidity`, `remove_liquidity`, `remove_liquidity_one_sided`) check `is_locked()` at entry. A public `flash_loan_locked()` view is exposed for off-chain monitoring.

- **Task 2 – Rust SDK** (`contracts/amm-sdk`, crate `soroban-amm-sdk`): Three modules — `types` (error codes, `PoolInfo`, `SwapInQuote`, `SwapOutQuote`, `LiquidityQuote`), `events` (strongly-typed event structs + symbol constants for all 11 event topics), and `client` (`AmmPoolInterface` contractclient trait covering every entry point + `AmmPoolSdk` high-level wrapper with validated `quote_swap_in`, `quote_swap_out`, `quote_add_liquidity`, `quote_remove_liquidity` helpers). Includes an `examples/basic_swap` module demonstrating the full quote-then-execute flow.

- **Task 3 – Error code documentation** (`docs/error-codes.md`): Full reference tables for `AmmError` (15 codes), `ClError` (16 codes), `FactoryError` (6 codes), and `GovernanceError` (32 codes). Each entry documents the numeric discriminant, Rust symbol, triggering precondition, and recommended remedy. Includes an XDR decoding snippet and a maintenance protocol to keep docs in sync with code.

- **Task 4 – Circuit breaker**: Added `AmmError::CircuitBreaker` (code 15) and five new `DataKey` variants. `check_circuit_breaker()` is called at the top of `swap`, `swap_exact_out`, and `flash_loan`. On the first call in a ledger sequence the spot price is recorded as baseline; subsequent calls in the same sequence measure deviation — if it exceeds the threshold (default **50 %** / 5 000 bps) the pool is auto-paused, a `circuit_break` event is emitted, and the error is returned. After the cooldown (default **600 s**) any caller can invoke `try_circuit_breaker_recovery()` to restore normal operation automatically. Configurable via `set_circuit_breaker_config(threshold_bps, cooldown_secs)`; readable via `get_circuit_breaker_config()`.

## Related Issues
Closes #246 
Closes #247 
Closes #248 
Closes #249 
