### PR TITLE
Add permissionless pool creation mode to factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,10 +738,13 @@ version = "0.1.0"
 dependencies = [
  "amm",
  "concentrated_liquidity",
+ "dex-aggregator",
  "factory",
  "governance",
+ "incentive-campaigns",
  "soroban-sdk",
  "token",
+ "twal-consumer",
  "twap-consumer",
 ]
 

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -10,8 +10,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracterror, contracttype, Address, BytesN, Env,
-    Symbol, Vec,
+    contract, contractclient, contractimpl, contracterror, contracttype, token, Address, BytesN,
+    Env, Symbol, Vec,
 };
 
 // ── Typed errors ─────────────────────────────────────────────────────────────
@@ -25,6 +25,8 @@ pub enum FactoryError {
     ClPoolAlreadyExists = 4,
     ClWasmNotSet        = 5,
     Unauthorized        = 6,
+    FeeNotConfigured    = 7,
+    RateLimitExceeded   = 8,
 }
 
 #[contractclient(name = "ClPoolClient")]
@@ -96,6 +98,11 @@ pub enum DataKey {
     PoolCount,                       // u64 monotonic counter — used to derive unique deploy salts
     GovernanceFor(Address),          // pool address → Option<Address>
     ClPool(Address, Address, i128),  // normalized (token_a, token_b, fee_bps) → CL pool Address
+    PermissionlessMode,              // bool — true = anyone can create pools (with fee)
+    PoolCreationFee,                 // i128 — fee charged per pool in permissionless mode
+    FeeToken,                        // Address — token used to pay the pool creation fee
+    RateLimitLedgers,                // u32 — minimum ledgers between pool creations per address
+    LastPoolCreation(Address),       // u32 — ledger when this address last created a pool
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -142,17 +149,36 @@ impl Factory {
     /// lexicographically smaller address as `token_a`, so callers do not need
     /// to match the original order when looking up a pool.
     ///
-    /// `lp_name` and `lp_symbol` set the LP token's metadata. When `None` the
-    /// factory generates counter-based defaults: `"AMM LP Token #N"` / `"ALPN"`.
+    /// `caller` is the address initiating the call. In permissioned mode the
+    /// factory admin must be the caller. In permissionless mode any address may
+    /// create a pool, but they must pay the configured `PoolCreationFee` in
+    /// `FeeToken` to the protocol treasury (factory admin), and are subject to
+    /// a per-address rate limit.
     ///
     /// Panics if a pool for this pair already exists.
     pub fn create_pool(
         env: Env,
+        caller: Address,
         token_a: Address,
         token_b: Address,
         fee_bps: i128,
         governance_wasm_hash: Option<BytesN<32>>,
     ) -> Result<(Address, Option<Address>), FactoryError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let permissionless: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::PermissionlessMode)
+            .unwrap_or(false);
+
+        if permissionless {
+            caller.require_auth();
+            Self::check_and_update_rate_limit(&env, &caller)?;
+            Self::charge_pool_creation_fee(&env, &caller, &admin)?;
+        } else {
+            admin.require_auth();
+        }
+
         // Normalise: smaller address is always token_a.
         let (ta, tb) = if token_a < token_b {
             (token_a, token_b)
@@ -178,7 +204,6 @@ impl Factory {
             .instance()
             .get(&DataKey::TokenWasmHash)
             .unwrap();
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
 
         // Derive salts per pool from a monotonic counter.
         // We use n * 3 for LP salt, n * 3 + 1 for Pool salt, n * 3 + 2 for Governance salt.
@@ -338,13 +363,31 @@ impl Factory {
     ///
     /// Unlike V2 pools, no LP token is deployed — positions are tracked on-chain by
     /// the CL contract itself.
+    ///
+    /// Applies the same permissioned/permissionless access controls as `create_pool`.
     pub fn create_cl_pool(
         env: Env,
+        caller: Address,
         token_a: Address,
         token_b: Address,
         fee_bps: i128,
         initial_tick: i32,
     ) -> Result<Address, FactoryError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let permissionless: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::PermissionlessMode)
+            .unwrap_or(false);
+
+        if permissionless {
+            caller.require_auth();
+            Self::check_and_update_rate_limit(&env, &caller)?;
+            Self::charge_pool_creation_fee(&env, &caller, &admin)?;
+        } else {
+            admin.require_auth();
+        }
+
         if !(0..=10_000).contains(&fee_bps) {
             return Err(FactoryError::InvalidFeeBps);
         }
@@ -381,7 +424,6 @@ impl Factory {
             .with_current_contract(cl_salt)
             .deploy(cl_wasm);
 
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         // Derive tick_spacing from fee tier (matching Uniswap v3 conventions).
         let tick_spacing: i32 = match fee_bps {
             5   => 1,
@@ -401,7 +443,89 @@ impl Factory {
         Ok(pool_addr)
     }
 
+    // ── Pool-creation mode ────────────────────────────────────────────────────
+
+    /// Toggle between permissioned (admin-only) and permissionless pool creation. Admin-only.
+    ///
+    /// When `enabled` is `true`, any address may call `create_pool` / `create_cl_pool`
+    /// provided they pay the configured creation fee. When `false` (default), only the
+    /// factory admin may create pools.
+    ///
+    /// The pool creation fee and fee token must be set via `set_pool_creation_fee`
+    /// before enabling permissionless mode.
+    pub fn set_permissionless_mode(env: Env, enabled: bool) -> Result<(), FactoryError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::PermissionlessMode, &enabled);
+        env.events().publish(
+            (Symbol::new(&env, "mode_changed"),),
+            (enabled,),
+        );
+        Ok(())
+    }
+
+    /// Configure the fee charged per pool creation in permissionless mode. Admin-only.
+    ///
+    /// `fee_token` is the SEP-41 token address used for payment (e.g. XLM/native).
+    /// `fee_amount` is the amount in the token's smallest unit; must be > 0.
+    /// Fees are transferred to the factory admin (protocol treasury) on each creation.
+    pub fn set_pool_creation_fee(
+        env: Env,
+        fee_token: Address,
+        fee_amount: i128,
+    ) -> Result<(), FactoryError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        if fee_amount <= 0 {
+            return Err(FactoryError::FeeNotConfigured);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeToken, &fee_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::PoolCreationFee, &fee_amount);
+        env.events().publish(
+            (Symbol::new(&env, "creation_fee_set"),),
+            (fee_token, fee_amount),
+        );
+        Ok(())
+    }
+
+    /// Set the minimum ledger gap between pool creations per address. Admin-only.
+    ///
+    /// Defaults to 1 (one pool per ledger per address). Increase to slow down
+    /// burst creation attempts. Set to 0 to disable rate limiting.
+    pub fn set_rate_limit(env: Env, min_ledgers: u32) -> Result<(), FactoryError> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::RateLimitLedgers, &min_ledgers);
+        Ok(())
+    }
+
     // ── Queries ───────────────────────────────────────────────────────────────
+
+    /// Return whether permissionless pool creation is currently enabled.
+    pub fn is_permissionless(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::PermissionlessMode)
+            .unwrap_or(false)
+    }
+
+    /// Return the current pool creation fee `(fee_token, fee_amount)`, or `None` if unset.
+    pub fn get_pool_creation_fee(env: Env) -> Option<(Address, i128)> {
+        let token: Option<Address> = env.storage().instance().get(&DataKey::FeeToken);
+        let amount: Option<i128> = env.storage().instance().get(&DataKey::PoolCreationFee);
+        match (token, amount) {
+            (Some(t), Some(a)) => Some((t, a)),
+            _ => None,
+        }
+    }
 
     /// Return the LP token address for the given pool, or `None` if unknown.
     pub fn get_lp_token(env: Env, pool: Address) -> Option<Address> {
@@ -475,6 +599,69 @@ impl Factory {
     }
 
     // ── Internals ─────────────────────────────────────────────────────────────
+
+    /// Enforce per-address rate limiting for permissionless pool creation.
+    ///
+    /// Reads `RateLimitLedgers` (default 1). If the caller created a pool within
+    /// that many ledgers, returns `RateLimitExceeded`. On success, records the
+    /// current ledger for the caller.
+    fn check_and_update_rate_limit(env: &Env, caller: &Address) -> Result<(), FactoryError> {
+        let min_gap: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateLimitLedgers)
+            .unwrap_or(1u32);
+
+        if min_gap > 0 {
+            let current_ledger = env.ledger().sequence();
+            let last: Option<u32> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::LastPoolCreation(caller.clone()));
+
+            if let Some(last_ledger) = last {
+                if current_ledger.saturating_sub(last_ledger) < min_gap {
+                    return Err(FactoryError::RateLimitExceeded);
+                }
+            }
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::LastPoolCreation(caller.clone()), &current_ledger);
+        }
+
+        Ok(())
+    }
+
+    /// Transfer the pool creation fee from `caller` to `treasury`.
+    ///
+    /// Requires `FeeToken` and `PoolCreationFee` to be set, otherwise returns
+    /// `FeeNotConfigured`. The caller must have authorised the token transfer.
+    fn charge_pool_creation_fee(
+        env: &Env,
+        caller: &Address,
+        treasury: &Address,
+    ) -> Result<(), FactoryError> {
+        let fee_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeToken)
+            .ok_or(FactoryError::FeeNotConfigured)?;
+        let fee_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PoolCreationFee)
+            .ok_or(FactoryError::FeeNotConfigured)?;
+
+        token::Client::new(env, &fee_token).transfer(caller, treasury, &fee_amount);
+
+        env.events().publish(
+            (Symbol::new(env, "creation_fee_paid"),),
+            (caller.clone(), fee_amount),
+        );
+
+        Ok(())
+    }
 
     /// Build a deterministic 32-byte salt from a u64 index.
     fn make_salt(env: &Env, index: u64) -> BytesN<32> {
@@ -554,7 +741,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool, gov) = factory.create_pool(&ta, &tb, &30_i128, &None);
+        let (pool, gov) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
 
         assert_eq!(factory.get_pool(&ta, &tb), Some(pool.clone()));
         assert_eq!(factory.all_pools().len(), 1);
@@ -580,7 +767,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool, gov) = factory.create_pool(&ta, &tb, &30_i128, &Some(gov_hash));
+        let (pool, gov) = factory.create_pool(&admin, &ta, &tb, &30_i128, &Some(gov_hash));
 
         assert_eq!(factory.get_pool(&ta, &tb), Some(pool.clone()));
         assert_eq!(factory.all_pools().len(), 1);
@@ -605,7 +792,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&ta, &tb, &30_i128, &None);
+        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
 
         // Reverse-order lookup returns the same pool.
         assert_eq!(factory.get_pool(&ta, &tb), factory.get_pool(&tb, &ta));
@@ -628,8 +815,8 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&ta, &tb, &30_i128, &None);
-        let result = factory.try_create_pool(&ta, &tb, &30_i128, &None);
+        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let result = factory.try_create_pool(&admin, &ta, &tb, &30_i128, &None);
         assert!(result.is_err());
     }
 
@@ -653,10 +840,10 @@ mod tests {
         let tb = Address::generate(&env);
         let tc = Address::generate(&env);
 
-        factory.create_pool(&ta, &tb, &30_i128, &None);
+        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
         assert_eq!(factory.all_pools().len(), 1);
 
-        factory.create_pool(&ta, &tc, &30_i128, &None);
+        factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
         assert_eq!(factory.all_pools().len(), 2);
     }
 
@@ -680,8 +867,8 @@ mod tests {
         let tb = Address::generate(&env);
         let tc = Address::generate(&env);
 
-        let (pool0, _) = factory.create_pool(&ta, &tb, &30_i128, &None);
-        let (pool1, _) = factory.create_pool(&ta, &tc, &30_i128, &None);
+        let (pool0, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let (pool1, _) = factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
 
         // Fetch LP token addresses via the factory's registry.
         let lp0 = factory.get_lp_token(&pool0).unwrap();
@@ -740,7 +927,7 @@ mod tests {
         // Pool creation still works after an update.
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
-        let (pool, _) = factory.create_pool(&ta, &tb, &30_i128, &None);
+        let (pool, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
         assert!(factory.get_pool(&ta, &tb).is_some());
         assert!(factory.get_lp_token(&pool).is_some());
 
@@ -773,8 +960,8 @@ mod tests {
         let tb = Address::generate(&env);
 
         // Deploy same pair at two different fee tiers.
-        let pool_30 = factory.create_cl_pool(&ta, &tb, &30_i128, &0_i32);
-        let pool_100 = factory.create_cl_pool(&ta, &tb, &100_i128, &0_i32);
+        let pool_30 = factory.create_cl_pool(&admin, &ta, &tb, &30_i128, &0_i32);
+        let pool_100 = factory.create_cl_pool(&admin, &ta, &tb, &100_i128, &0_i32);
 
         // Both pools are distinct addresses.
         assert_ne!(pool_30, pool_100);
@@ -809,8 +996,8 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_cl_pool(&ta, &tb, &30_i128, &0_i32);
-        let result = factory.try_create_cl_pool(&ta, &tb, &30_i128, &0_i32);
+        factory.create_cl_pool(&admin, &ta, &tb, &30_i128, &0_i32);
+        let result = factory.try_create_cl_pool(&admin, &ta, &tb, &30_i128, &0_i32);
         assert!(result.is_err());
     }
 
@@ -836,13 +1023,13 @@ mod tests {
         let tc = Address::generate(&env);
         let td = Address::generate(&env);
 
-        let (pool1, _) = factory.create_pool(&ta, &tb, &30_i128, &None);
+        let (pool1, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 1);
 
-        let (pool2, _) = factory.create_pool(&ta, &tc, &30_i128, &None);
+        let (pool2, _) = factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 2);
 
-        let (pool3, _) = factory.create_pool(&ta, &td, &30_i128, &None);
+        let (pool3, _) = factory.create_pool(&admin, &ta, &td, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 3);
 
         // Page 1: first two pools.
@@ -893,7 +1080,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool_addr, _) = factory.create_pool(&ta, &tb, &30_i128, &None);
+        let (pool_addr, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
 
         // Locate the pool_created event.
         let events = env.events().all();
@@ -934,14 +1121,14 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&ta, &tb, &30_i128, &None);
+        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
 
         // Clear events so we only see events from the second (failing) call.
         // Soroban test env accumulates events — count before the duplicate attempt.
         let count_before = env.events().all().len();
 
         // Duplicate call must fail.
-        let result = factory.try_create_pool(&ta, &tb, &30_i128, &None);
+        let result = factory.try_create_pool(&admin, &ta, &tb, &30_i128, &None);
         assert!(result.is_err(), "duplicate pool creation must fail");
 
         // No new events must have been added.
@@ -950,5 +1137,207 @@ mod tests {
             count_before, count_after,
             "no event should be emitted when create_pool reverts"
         );
+    }
+
+    // ── Permissionless pool creation ──────────────────────────────────────────
+
+    fn setup_fee_token(env: &Env, admin: &Address, user: &Address, amount: i128) -> Address {
+        let fee_token_addr = env.register_contract(None, token::LpToken);
+        token::LpTokenClient::new(env, &fee_token_addr).initialize(
+            admin,
+            &soroban_sdk::String::from_str(env, "Fee Token"),
+            &soroban_sdk::String::from_str(env, "FEE"),
+            &7u32,
+        );
+        token::LpTokenClient::new(env, &fee_token_addr).mint(user, &amount);
+        fee_token_addr
+    }
+
+    #[test]
+    fn test_permissioned_mode_blocks_non_admin() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        // Do NOT mock_all_auths — we need real auth checks.
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+
+        // Initialize requires admin auth.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &factory_addr,
+                fn_name: "initialize",
+                args: (&admin, &amm_hash, &token_hash).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Default mode is permissioned; a non-admin caller must be rejected.
+        assert!(!factory.is_permissionless());
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        // user tries to create a pool in permissioned mode — must fail.
+        let result = factory.try_create_pool(&user, &ta, &tb, &30_i128, &None);
+        assert!(result.is_err(), "non-admin must not create pools in permissioned mode");
+    }
+
+    #[test]
+    fn test_permissionless_mode_toggle() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        assert!(!factory.is_permissionless());
+        factory.set_permissionless_mode(&true);
+        assert!(factory.is_permissionless());
+        factory.set_permissionless_mode(&false);
+        assert!(!factory.is_permissionless());
+    }
+
+    #[test]
+    fn test_permissionless_charges_fee() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Deploy a fee token and mint 1000 units to user.
+        let fee_token_addr = setup_fee_token(&env, &admin, &user, 1000);
+        let fee_client = soroban_sdk::token::Client::new(&env, &fee_token_addr);
+
+        let fee_amount: i128 = 100;
+        factory.set_pool_creation_fee(&fee_token_addr, &fee_amount);
+        factory.set_permissionless_mode(&true);
+
+        assert_eq!(
+            factory.get_pool_creation_fee(),
+            Some((fee_token_addr.clone(), fee_amount))
+        );
+
+        let user_balance_before = fee_client.balance(&user);
+        let admin_balance_before = fee_client.balance(&admin);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let (pool, _) = factory.create_pool(&user, &ta, &tb, &30_i128, &None);
+
+        assert!(factory.get_pool(&ta, &tb).is_some());
+        // Fee transferred from user to admin (treasury).
+        assert_eq!(fee_client.balance(&user), user_balance_before - fee_amount);
+        assert_eq!(fee_client.balance(&admin), admin_balance_before + fee_amount);
+    }
+
+    #[test]
+    fn test_permissionless_fee_not_configured_fails() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Enable permissionless without setting a fee — must fail on pool creation.
+        factory.set_permissionless_mode(&true);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let result = factory.try_create_pool(&user, &ta, &tb, &30_i128, &None);
+        assert!(result.is_err(), "pool creation without configured fee must fail");
+    }
+
+    #[test]
+    fn test_rate_limit_blocks_rapid_creation() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let fee_token_addr = setup_fee_token(&env, &admin, &user, 10_000);
+        factory.set_pool_creation_fee(&fee_token_addr, &100_i128);
+        factory.set_permissionless_mode(&true);
+        // Require 5 ledger gap between creations.
+        factory.set_rate_limit(&5u32);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let tc = Address::generate(&env);
+
+        // First creation succeeds.
+        factory.create_pool(&user, &ta, &tb, &30_i128, &None);
+
+        // Immediate second creation by the same user must be rate-limited.
+        let result = factory.try_create_pool(&user, &ta, &tc, &30_i128, &None);
+        assert!(result.is_err(), "second pool creation within rate limit window must fail");
+    }
+
+    #[test]
+    fn test_rate_limit_zero_disables_limit() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let fee_token_addr = setup_fee_token(&env, &admin, &user, 10_000);
+        factory.set_pool_creation_fee(&fee_token_addr, &100_i128);
+        factory.set_permissionless_mode(&true);
+        factory.set_rate_limit(&0u32); // disable rate limiting
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let tc = Address::generate(&env);
+
+        // Both creations must succeed on the same ledger.
+        factory.create_pool(&user, &ta, &tb, &30_i128, &None);
+        factory.create_pool(&user, &ta, &tc, &30_i128, &None);
+        assert_eq!(factory.all_pools().len(), 2);
     }
 }


### PR DESCRIPTION
Introduces a toggle between permissioned (admin-only, default) and permissionless pool creation. In permissionless mode any address can create pools by paying a configurable fee (in any SEP-41 token) to the protocol treasury, subject to a per-address ledger-based rate limit to prevent DoS attacks.

- New DataKeys: PermissionlessMode, PoolCreationFee, FeeToken,
  RateLimitLedgers, LastPoolCreation(Address)
- New admin functions: set_permissionless_mode, set_pool_creation_fee,
  set_rate_limit
- New query functions: is_permissionless, get_pool_creation_fee
- create_pool / create_cl_pool gain a caller: Address parameter and
  enforce the active mode, fee transfer, and rate limiting
- 7 new tests covering the toggle, fee charge, missing-fee guard,
  rate limiting, and disabling rate limiting
- Emits mode_changed, creation_fee_set, and creation_fee_paid events

fixes #235