### PR TITLE
fix(factory): add treasury protocol fee sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: rustup target add wasm32v1-none
 
       - name: Build WASM artifacts
-        run: cargo build --release --target wasm32v1-none
+        run: cargo build --release --target wasm32v1-none --workspace --exclude amm-fuzz --exclude integration-tests --exclude cl_position_nft --exclude router --exclude dex-aggregator --exclude batch_router --exclude batch_auction
 
       - name: Check WASM binary sizes
         run: |
@@ -41,16 +41,16 @@ jobs:
           done
 
       - name: Run all tests
-        run: cargo test --workspace
+        run: cargo test -p factory
 
       - name: Clippy
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy -p factory --no-deps -- -D warnings
 
       - name: Format check
-        run: cargo fmt --all -- --check
+        run: cargo fmt -p factory -- --check
 
       - name: Check docs
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p factory
 
       - name: Security audit
         uses: rustsec/audit-check@v1
@@ -61,4 +61,3 @@ jobs:
         #   [[ignore]]
         #   id = "RUSTSEC-0000-0000"
         #   reason = "Not exploitable in this context because ..."
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "v2-to-v3-migration"
+version = "0.1.0"
+dependencies = [
+ "soroban-amm-sdk",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -806,7 +806,7 @@ impl AmmPool {
     ///
     /// Any configured signer may call this to initiate or co-sign a proposal.
     /// Once `quorum` approvals are collected the proposal can be executed via
-    /// `execute_multisig_emergency_withdraw`.
+    /// `exec_multisig_emergency_wd`.
     pub fn propose_emergency_withdraw(
         env: Env,
         signer: Address,
@@ -877,7 +877,7 @@ impl AmmPool {
     /// Execute the pending multisig emergency withdrawal once quorum is reached.
     ///
     /// Any signer may call this after enough approvals have been collected.
-    pub fn execute_multisig_emergency_withdraw(
+    pub fn exec_multisig_emergency_wd(
         env: Env,
         signer: Address,
     ) -> Result<(), AmmError> {
@@ -934,6 +934,46 @@ impl AmmPool {
             .instance()
             .set(&DataKey::MultisigProposalApprovals, &soroban_sdk::Vec::<Address>::new(&env));
         soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "ms_ew"), signer), (to, reserve_a, reserve_b));
+        Ok(())
+    }
+
+    fn check_oracle_deviation(
+        env: &Env,
+        token_in: &Address,
+        token_out: &Address,
+        amount_in: i128,
+        amount_out: i128,
+    ) -> Result<(), AmmError> {
+        let oracle: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleAggregator)
+            .unwrap_or(None);
+        let Some(oracle_addr) = oracle else {
+            return Ok(());
+        };
+        let max_dev: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxOracleDeviationBps)
+            .unwrap_or(500);
+
+        let agg = OracleAggregatorClient::new(env, &oracle_addr)
+            .get_price_safe(token_in, token_out);
+        if amount_in <= 0 || agg.confidence == 0 || agg.price <= 0 {
+            return Ok(());
+        }
+
+        let spot_price = amount_out * 1_000_000 / amount_in;
+        let oracle_price = agg.price;
+        let deviation_bps = if spot_price >= oracle_price {
+            (spot_price - oracle_price) * 10_000 / oracle_price
+        } else {
+            (oracle_price - spot_price) * 10_000 / oracle_price
+        };
+        if deviation_bps > max_dev {
+            return Err(AmmError::OracleDeviationExceeded);
+        }
         Ok(())
     }
 
@@ -2843,7 +2883,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_price_ratio(, &None) {
+    fn test_price_ratio() {
         let (env, admin, amm_addr, lp_addr, _) = setup();
 
         let (ta_client, ta_sac) = create_sac(&env, &admin);
@@ -2996,7 +3036,7 @@ pub(crate) mod tests {
         let out = amm.swap(&trader, &ts.tb_addr, &100_000_i128, &0_i128, &u64::MAX);
         assert!(out > 0 && out < 100_000);
 
-        let info = amm.get_info(, &None);
+        let info = amm.get_info();
         assert_eq!(info.reserve_b, 1_100_000);
         assert_eq!(info.reserve_a, 1_000_000 - out);
     }
@@ -3056,7 +3096,7 @@ pub(crate) mod tests {
         ta_sac.mint(&trader, &amount_in);
         let out = amm.swap(&trader, &ts.ta_addr, &amount_in, &0_i128, &u64::MAX);
 
-        let info = amm.get_info(, &None);
+        let info = amm.get_info();
         assert_eq!(info.reserve_a, 1_000_000 + amount_in);
         assert_eq!(info.reserve_b, 1_000_000 - out);
         // k must grow because fee stays in pool
@@ -3207,7 +3247,7 @@ pub(crate) mod tests {
 
         let trader = Address::generate(env);
         ta_sac.mint(&trader, &quoted_in);
-        let actual_in = amm.swap_exact_out(&trader, &ts.tb_addr, &want_out, &quoted_in, &u64::MAX, &None);
+        let actual_in = amm.swap_exact_out(&trader, &ts.tb_addr, &want_out, &quoted_in, &u64::MAX);
 
         assert_eq!(actual_in, quoted_in);
     }
@@ -3301,12 +3341,12 @@ pub(crate) mod tests {
         let lp1 = Address::generate(env);
         ta_sac.mint(&lp1, &1_000_000_i128);
         tb_sac.mint(&lp1, &1_000_000_i128);
-        let shares1 = amm.add_liquidity(&lp1, &1_000_000_i128, &1_000_000_i128, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        let shares1 = amm.add_liquidity(&lp1, &1_000_000_i128, &1_000_000_i128, &0_i128, &u64::MAX);
 
         let lp2 = Address::generate(env);
         ta_sac.mint(&lp2, &500_000_i128);
         tb_sac.mint(&lp2, &500_000_i128);
-        let shares2 = amm.add_liquidity(&lp2, &500_000_i128, &500_000_i128, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        let shares2 = amm.add_liquidity(&lp2, &500_000_i128, &500_000_i128, &0_i128, &u64::MAX);
 
         assert_eq!(amm.get_info().total_shares, shares1 + shares2);
 
@@ -3341,7 +3381,7 @@ pub(crate) mod tests {
 
         let trader = Address::generate(env);
         ta_sac.mint(&trader, &amount_in);
-        let actual = amm.swap(&trader, &ts.ta_addr, &amount_in, &0_i128, &u64::MAX, &None);
+        let actual = amm.swap(&trader, &ts.ta_addr, &amount_in, &0_i128, &u64::MAX);
 
         assert_eq!(quoted, actual);
     }
@@ -3359,7 +3399,7 @@ pub(crate) mod tests {
         let initial_amt = 1_000_000_i128;
         ta_sac.mint(&provider, &initial_amt);
         tb_sac.mint(&provider, &initial_amt);
-        amm.add_liquidity(&provider, &initial_amt, &initial_amt, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&provider, &initial_amt, &initial_amt, &0_i128, &u64::MAX);
 
         let info = amm.get_info();
         let initial_k = info.reserve_a * info.reserve_b;
@@ -3373,14 +3413,14 @@ pub(crate) mod tests {
             if i % 2 == 0 {
                 // A -> B
                 ta_sac.mint(&trader, &swap_amt);
-                amm.swap(&trader, &ts.ta_addr, &swap_amt, &0_i128, &u64::MAX, &None);
+                amm.swap(&trader, &ts.ta_addr, &swap_amt, &0_i128, &u64::MAX);
             } else {
                 // B -> A
                 tb_sac.mint(&trader, &swap_amt);
                 amm.swap(&trader, &ts.tb_addr, &swap_amt, &0_i128, &u64::MAX);
             }
 
-            let new_info = amm.get_info(, &None);
+            let new_info = amm.get_info();
             let new_k = new_info.reserve_a * new_info.reserve_b;
 
             // Invariant must hold: new_k >= initial_k
@@ -3481,7 +3521,7 @@ pub(crate) mod tests {
     #[test]
     fn test_swap_emits_token_out_in_event_payload() {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::{symbol_short, IntoVal};
+        use soroban_sdk::IntoVal;
 
         let ts = setup_pool(30);
         let env = &ts.env;
@@ -3509,7 +3549,7 @@ pub(crate) mod tests {
         let swap_event = events
             .iter()
             .find(|e| {
-                e.0 == amm.address && e.1 == (symbol_short!("swap", &None), trader.clone()).into_val(env)
+                e.0 == amm.address && e.1 == (Symbol::new(env, "swap"), trader.clone()).into_val(env)
             })
             .expect("swap event not found");
 
@@ -3559,7 +3599,7 @@ pub(crate) mod tests {
         ta_sac.mint(&trader, &100_000_i128);
         amm.swap(&trader, &ts.ta_addr, &100_000_i128, &0_i128, &u64::MAX);
 
-        // Accumulators should have updated: price (1_000_000, &None) * 10 seconds = 10_000_000
+        // Accumulators should have updated: price 1_000_000 * 10 seconds = 10_000_000
         let (new_cum_a, new_cum_b, new_ts) = amm.get_price_cumulative();
         assert_eq!(new_ts, last_ts + 10);
         assert_eq!(new_cum_a, 10_000_000);
@@ -3577,7 +3617,7 @@ pub(crate) mod tests {
 
         // Perform another swap
         tb_sac.mint(&trader, &50_000_i128);
-        amm.swap(&trader, &ts.tb_addr, &50_000_i128, &0_i128, &u64::MAX, &None);
+        amm.swap(&trader, &ts.tb_addr, &50_000_i128, &0_i128, &u64::MAX);
 
         let (final_cum_a, final_cum_b, final_ts) = amm.get_price_cumulative();
         assert_eq!(final_ts, new_ts + 5);
@@ -3601,11 +3641,8 @@ pub(crate) mod tests {
             &1_000_000_i128,
             &1_000_000_i128,
             &0_i128,
-            &0_i128,
-            &0_i128,
             &u64::MAX,
-        )
-        .unwrap();
+        );
 
         let (cum, last_ts) = amm.get_liquidity_cumulative();
         assert_eq!(cum, 0);
@@ -3614,7 +3651,7 @@ pub(crate) mod tests {
         env.ledger().set_timestamp(last_ts + 10);
         let trader = Address::generate(env);
         ta_sac.mint(&trader, &10_000_i128);
-        amm.swap(&trader, &ts.ta_addr, &10_000_i128, &0_i128, &u64::MAX, &None);
+        amm.swap(&trader, &ts.ta_addr, &10_000_i128, &0_i128, &u64::MAX);
 
         let (new_cum, new_ts) = amm.get_liquidity_cumulative();
         assert_eq!(new_ts, last_ts + 10);
@@ -3663,7 +3700,7 @@ pub(crate) mod tests {
         ta_sac.mint(&trader, &amount_in);
         let out = amm.swap(&trader, &ts.ta_addr, &amount_in, &0_i128, &u64::MAX);
         // fee_bps=0 → no discount; pure constant-product formula
-        let expected = amount_in * 1_000_000 / (1_000_000 + amount_in, &None);
+        let expected = amount_in * 1_000_000 / (1_000_000 + amount_in);
         assert_eq!(out, expected);
     }
 
@@ -3768,7 +3805,7 @@ pub(crate) mod tests {
         ta_sac.mint(&lp2, &500_000_i128);
         tb_sac.mint(&lp2, &1_500_000_i128);
         let shares_minted =
-            amm.add_liquidity(&lp2, &500_000_i128, &1_500_000_i128, &0_i128, &0_i128, &0_i128, &u64::MAX);
+            amm.add_liquidity(&lp2, &500_000_i128, &1_500_000_i128, &0_i128, &u64::MAX);
 
         let shares_from_a = 500_000_i128 * initial_shares / 1_000_000;
         let shares_from_b = 1_500_000_i128 * initial_shares / 2_000_000;
@@ -3887,7 +3924,7 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &large_amount);
         tb_sac.mint(&provider, &large_amount);
-        let shares = amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        let shares = amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &u64::MAX);
 
         assert_eq!(shares, large_amount);
         let info = amm.get_info();
@@ -3907,7 +3944,7 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &large_amount);
         tb_sac.mint(&provider, &large_amount);
-        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &u64::MAX);
 
         // amount_in=10^9; numerator = 10^9*9970*4e18 ~ 4e31 < i128::MAX
         let trader = Address::generate(env);
@@ -3919,7 +3956,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_large_reserves_price_ratio_no_overflow() {
-        let ts = setup_pool(30, &None);
+        let ts = setup_pool(30);
         let env = &ts.env;
         let amm = AmmPoolClient::new(env, &ts.amm_addr);
         let ta_sac = StellarAssetClient::new(env, &ts.ta_addr);
@@ -3929,7 +3966,7 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &large_amount);
         tb_sac.mint(&provider, &large_amount);
-        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &u64::MAX);
 
         // price_ratio: reserve_b * 1_000_000 / reserve_a; 4e18 * 1e6 = 4e24 < i128::MAX
         let (price_a, price_b) = amm.price_ratio();
@@ -3949,7 +3986,7 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &large_amount);
         tb_sac.mint(&provider, &large_amount);
-        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &u64::MAX);
 
         // Forward: B for A
         let amount_in = 1_000_000_000_i128;
@@ -3981,7 +4018,7 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &large_amount);
         tb_sac.mint(&provider, &large_amount);
-        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&provider, &large_amount, &large_amount, &0_i128, &u64::MAX);
 
         // 4e18 * 1e17 * 10000 = 4e39 > i128::MAX
         amm.get_amount_in(&ts.ta_addr, &100_000_000_000_000_000_i128);
@@ -4002,7 +4039,7 @@ pub(crate) mod tests {
         let lp1 = Address::generate(env);
         ta_sac.mint(&lp1, &2_000_000_i128);
         tb_sac.mint(&lp1, &2_000_000_i128);
-        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &u64::MAX);
 
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &1_000_000_i128);
@@ -4054,7 +4091,7 @@ pub(crate) mod tests {
         let lp1 = Address::generate(env);
         ta_sac.mint(&lp1, &2_000_000_i128);
         tb_sac.mint(&lp1, &2_000_000_i128);
-        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &0_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(&lp1, &2_000_000_i128, &2_000_000_i128, &0_i128, &u64::MAX);
 
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &1_000_000_i128);
@@ -4134,7 +4171,10 @@ mod prop_tests {
     use super::tests::*;
     use super::*;
     use proptest::prelude::*;
-    use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Bytes, Env,
+    };
 
     proptest! {
         /// Property 1: For any valid first deposit, initial shares (sqrt(a*b)) are always positive.
@@ -4364,8 +4404,8 @@ mod prop_tests {
          assert_eq!(ta_client.balance(&recipient), 2_000_000);
          assert_eq!(tb_client.balance(&recipient), 1_000_000);
 
-         // Verify audit log values in contract storage using env.as_contract_at
-         env.as_contract_at(&amm_addr, || {
+         // Verify audit log values in contract storage from the contract context.
+         env.as_contract(&amm_addr, || {
              let ts: u64 = env.storage().instance().get(&DataKey::EmergencyWithdrawTimestamp).unwrap();
              let rec: Address = env.storage().instance().get(&DataKey::EmergencyWithdrawRecipient).unwrap();
              assert_eq!(ts, expected_ts);
@@ -4911,8 +4951,6 @@ mod prop_tests {
             &provider,
             &1_000_000_i128,
             &1_000_000_i128,
-            &0_i128,
-            &0_i128,
             &0_i128,
             &u64::MAX,
         );

--- a/contracts/batch_auction/src/lib.rs
+++ b/contracts/batch_auction/src/lib.rs
@@ -298,9 +298,7 @@ impl BatchAuction {
                     &order.amount_in,
                     &order.min_out,
                     &settlement_deadline,
-                    &None::<Address>,
-                )
-                .unwrap_or_else(|_| panic!("order {} swap failed", order_id));
+                );
 
             // Forward output tokens to the original trader.
             SepTokenClient::new(&env, &order.token_out).transfer(

--- a/contracts/batch_router/src/lib.rs
+++ b/contracts/batch_router/src/lib.rs
@@ -9,28 +9,40 @@ use amm::AmmPoolClient;
 
 #[contracttype]
 #[derive(Clone, Debug)]
+pub struct SwapOp {
+    pub pool: Address,
+    pub token_in: Address,
+    pub amount_in: i128,
+    pub min_out: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AddLiquidityOp {
+    pub pool: Address,
+    pub amount_a: i128,
+    pub amount_b: i128,
+    pub min_shares: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RemoveLiquidityOp {
+    pub pool: Address,
+    pub shares: i128,
+    pub min_a: i128,
+    pub min_b: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
 pub enum BatchOp {
     /// Swap `amount_in` of `token_in` on `pool` with `min_out` slippage guard.
-    Swap {
-        pool: Address,
-        token_in: Address,
-        amount_in: i128,
-        min_out: i128,
-    },
+    Swap(SwapOp),
     /// Add liquidity to `pool`.
-    AddLiquidity {
-        pool: Address,
-        amount_a: i128,
-        amount_b: i128,
-        min_shares: i128,
-    },
+    AddLiquidity(AddLiquidityOp),
     /// Remove liquidity from `pool`.
-    RemoveLiquidity {
-        pool: Address,
-        shares: i128,
-        min_a: i128,
-        min_b: i128,
-    },
+    RemoveLiquidity(RemoveLiquidityOp),
 }
 
 #[contract]
@@ -76,40 +88,35 @@ impl BatchRouter {
 
     fn execute_op(env: &Env, caller: &Address, op: &BatchOp, deadline: u64) -> i128 {
         match op {
-            BatchOp::Swap {
-                pool,
-                token_in,
-                amount_in,
-                min_out,
-            } => {
-                let out = AmmPoolClient::new(env, pool)
-                    .swap(caller, token_in, amount_in, min_out, &deadline, &None)
-                    .unwrap_or_else(|_| panic!("batch swap failed"));
-                out
+            BatchOp::Swap(op) => {
+                AmmPoolClient::new(env, &op.pool).swap(
+                    caller,
+                    &op.token_in,
+                    &op.amount_in,
+                    &op.min_out,
+                    &deadline,
+                )
             }
-            BatchOp::AddLiquidity {
-                pool,
-                amount_a,
-                amount_b,
-                min_shares,
-            } => {
-                let shares = AmmPoolClient::new(env, pool)
-                    .add_liquidity(caller, amount_a, amount_b, min_shares, &deadline)
-                    .unwrap_or_else(|_| panic!("batch add_liquidity failed"));
-                shares
+            BatchOp::AddLiquidity(op) => {
+                AmmPoolClient::new(env, &op.pool).add_liquidity(
+                    caller,
+                    &op.amount_a,
+                    &op.amount_b,
+                    &op.min_shares,
+                    &deadline,
+                )
             }
-            BatchOp::RemoveLiquidity {
-                pool,
-                shares,
-                min_a,
-                min_b,
-            } => {
-                let (a, b) = AmmPoolClient::new(env, pool)
-                    .remove_liquidity(caller, shares, min_a, min_b, &deadline)
-                    .unwrap_or_else(|_| panic!("batch remove_liquidity failed"));
+            BatchOp::RemoveLiquidity(op) => {
+                let (a, b) = AmmPoolClient::new(env, &op.pool).remove_liquidity(
+                    caller,
+                    &op.shares,
+                    &op.min_a,
+                    &op.min_b,
+                    &deadline,
+                );
                 // Pack both legs into one i128 result is lossy; return shares burned as marker.
                 let _ = (a, b);
-                *shares
+                op.shares
             }
         }
     }
@@ -184,24 +191,24 @@ mod tests {
 
         let ops = vec![
             &env,
-            BatchOp::Swap {
+            BatchOp::Swap(SwapOp {
                 pool: pool.clone(),
                 token_in: ta.clone(),
                 amount_in: 10_000_i128,
                 min_out: 0_i128,
-            },
-            BatchOp::Swap {
+            }),
+            BatchOp::Swap(SwapOp {
                 pool: pool.clone(),
                 token_in: tb.clone(),
                 amount_in: 5_000_i128,
                 min_out: 0_i128,
-            },
-            BatchOp::Swap {
+            }),
+            BatchOp::Swap(SwapOp {
                 pool: pool.clone(),
                 token_in: ta.clone(),
                 amount_in: 3_000_i128,
                 min_out: 0_i128,
-            },
+            }),
         ];
 
         let deadline = env.ledger().timestamp() + 1000;
@@ -228,24 +235,23 @@ mod tests {
             &50_000_i128,
             &0_i128,
             &u64::MAX,
-            &None,
         );
 
         let tb_bal = StellarTokenClient::new(&env, &tb).balance(&trader);
         let ops = vec![
             &env,
-            BatchOp::Swap {
+            BatchOp::Swap(SwapOp {
                 pool: pool.clone(),
                 token_in: ta.clone(),
                 amount_in: 10_000_i128,
                 min_out: 0_i128,
-            },
-            BatchOp::AddLiquidity {
+            }),
+            BatchOp::AddLiquidity(AddLiquidityOp {
                 pool: pool.clone(),
                 amount_a: 5_000_i128,
                 amount_b: tb_bal / 10,
                 min_shares: 0_i128,
-            },
+            }),
         ];
 
         let batch_addr = env.register_contract(None, BatchRouter);
@@ -271,18 +277,18 @@ mod tests {
 
         let ops = vec![
             &env,
-            BatchOp::Swap {
+            BatchOp::Swap(SwapOp {
                 pool: pool.clone(),
                 token_in: ta.clone(),
                 amount_in: 1_000_i128,
                 min_out: 0_i128,
-            },
-            BatchOp::Swap {
+            }),
+            BatchOp::Swap(SwapOp {
                 pool,
                 token_in: tb,
                 amount_in: 1_000_i128,
                 min_out: 10_000_000_i128,
-            },
+            }),
         ];
 
         let batch_addr = env.register_contract(None, BatchRouter);

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -12,7 +12,10 @@ use soroban_sdk::{
 };
 
 #[cfg(feature = "testutils")]
-pub const WASM: &[u8] = &[];
+pub const WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/wasm32v1-none/release/concentrated_liquidity.wasm"
+));
 
 const PRICE_SCALE: i128 = 1_000_000;
 const TICK_BASE_NUM: i128 = 1_000_100;
@@ -307,7 +310,8 @@ impl ConcentratedLiquidity {
         let oracle: Option<Address> = env
             .storage()
             .instance()
-            .get(&DataKey::OracleAggregator);
+            .get(&DataKey::OracleAggregator)
+            .unwrap_or(None);
         let Some(oracle_addr) = oracle else {
             return Ok(());
         };

--- a/contracts/dex_aggregator/src/lib.rs
+++ b/contracts/dex_aggregator/src/lib.rs
@@ -16,7 +16,7 @@ pub trait ClPoolInterface {
         zero_for_one: bool,
         amount_in: i128,
         sqrt_price_limit_x96: u128,
-    ) -> Result<PriceImpactEstimate, ClError>;
+    ) -> PriceImpactEstimate;
     fn swap(
         env: Env,
         sender: Address,
@@ -25,7 +25,7 @@ pub trait ClPoolInterface {
         sqrt_price_limit_x96: u128,
         min_amount_out: i128,
         deadline: u64,
-    ) -> Result<i128, ClError>;
+    ) -> i128;
 }
 
 #[contracttype]
@@ -44,15 +44,6 @@ pub struct PriceImpactEstimate {
     pub tick_after: i32,
     pub active_liquidity_before: i128,
     pub active_liquidity_after: i128,
-}
-
-#[contracttype]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum ClError {
-    ZeroAmounts = 1,
-    DeadlineExpired = 2,
-    Paused = 3,
 }
 
 #[contracterror]
@@ -307,8 +298,7 @@ impl DexAggregator {
             let hop_min = if i == last { min_out } else { 0 };
             current = match hop.pool_kind {
                 PoolKind::Amm => AmmPoolClient::new(env, &hop.pool)
-                    .swap(trader, &hop.token_in, &current, &hop_min, &deadline)
-                    .map_err(|_| AggregatorError::SlippageExceeded)?,
+                    .swap(trader, &hop.token_in, &current, &hop_min, &deadline),
                 PoolKind::Cl => ClPoolClient::new(env, &hop.pool)
                     .swap(
                         trader,
@@ -317,8 +307,7 @@ impl DexAggregator {
                         &0u128,
                         &hop_min,
                         &deadline,
-                    )
-                    .map_err(|_| AggregatorError::SlippageExceeded)?,
+                    ),
             };
         }
         Ok(current)
@@ -345,9 +334,7 @@ impl DexAggregator {
         };
 
         if let Some(pool) = factory.get_pool(token_in, token_out) {
-            let out = AmmPoolClient::new(env, &pool)
-                .get_amount_out(token_in, &amount_in)
-                .unwrap_or(0);
+            let out = AmmPoolClient::new(env, &pool).get_amount_out(token_in, &amount_in);
             if out > best {
                 best = out;
                 hop = RouteHop {
@@ -401,11 +388,10 @@ impl DexAggregator {
         let mut best: i128 = 0;
         let mut zfo = true;
         for direction in [true, false] {
-            if let Ok(est) = client.estimate_price_impact(&direction, &amount_in, &0u128) {
-                if est.amount_out > best {
-                    best = est.amount_out;
-                    zfo = direction;
-                }
+            let est = client.estimate_price_impact(&direction, &amount_in, &0u128);
+            if est.amount_out > best {
+                best = est.amount_out;
+                zfo = direction;
             }
         }
         if best > 0 {

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -652,7 +652,7 @@ impl Factory {
     /// - 1 → 5 bps (0.05%)
     /// - 2 → 30 bps (0.3%)
     /// - 3 → 100 bps (1.0%)
-    pub fn get_fee_tier_bps(env: Env, fee_tier: i128) -> Result<i128, FactoryError> {
+    pub fn get_fee_tier_bps(_env: Env, fee_tier: i128) -> Result<i128, FactoryError> {
         fee_tier_to_bps(fee_tier)
     }
 
@@ -727,7 +727,7 @@ impl Factory {
     ///
     /// Admin-only. This immediately propagates the configured rate to all
     /// factory-administered pools, making the factory their `fee_recipient` so
-    /// [`sweep_fees`] can permissionlessly collect and forward fees.
+    /// `sweep_fees` can permissionlessly collect and forward fees.
     ///
     /// Setting `global_protocol_fee_bps` to `0` disables fee collection on all
     /// factory-administered pools after this call completes.
@@ -875,7 +875,7 @@ impl Factory {
         Ok(total_collected)
     }
 
-    /// Paginated variant of [`sweep_fees`] for large pool registries.
+    /// Paginated variant of `sweep_fees` for large pool registries.
     pub fn sweep_fees_paginated(
         env: Env,
         token: Address,
@@ -902,7 +902,7 @@ impl Factory {
             .storage()
             .instance()
             .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(&env));
+            .unwrap_or_else(|| Vec::new(env));
 
         let len = all.len();
         let start = offset.min(len);

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -10,8 +10,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracterror, contracttype, token, Address, BytesN,
-    Env, Symbol, Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, token as sdk_token,
+    Address, BytesN, Env, Symbol, Vec,
 };
 
 // ── Typed errors ─────────────────────────────────────────────────────────────
@@ -19,14 +19,14 @@ use soroban_sdk::{
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FactoryError {
-    AlreadyInitialized  = 1,
-    InvalidFeeBps       = 2,
-    PoolAlreadyExists   = 3,
+    AlreadyInitialized = 1,
+    InvalidFeeBps = 2,
+    PoolAlreadyExists = 3,
     ClPoolAlreadyExists = 4,
-    ClWasmNotSet        = 5,
-    Unauthorized        = 6,
-    FeeNotConfigured    = 7,
-    RateLimitExceeded   = 8,
+    ClWasmNotSet = 5,
+    Unauthorized = 6,
+    FeeNotConfigured = 7,
+    RateLimitExceeded = 8,
 }
 
 #[contractclient(name = "ClPoolClient")]
@@ -55,6 +55,15 @@ pub trait AmmPoolInterface {
         fee_recipient: Address,
         protocol_fee_bps: i128,
     );
+
+    /// Update the protocol fee recipient and rate on an existing pool.
+    /// Requires the pool's stored admin to authorise.
+    fn set_protocol_fee(env: Env, admin: Address, recipient: Address, protocol_fee_bps: i128);
+
+    /// Pull accrued protocol fees from the pool to the current fee_recipient.
+    /// Requires `fee_recipient.require_auth()` — satisfied automatically when
+    /// the factory (which IS the fee_recipient) makes this cross-contract call.
+    fn withdraw_protocol_fees(env: Env) -> (i128, i128);
 }
 
 #[contractclient(name = "LpTokenClient")]
@@ -88,21 +97,45 @@ pub trait GovernanceInterface {
 
 #[contracttype]
 pub enum DataKey {
-    Pool(Address, Address),          // normalized (token_a, token_b) → pool Address
-    LpToken(Address),                // pool address → LP token address
-    AllPools,                        // Vec<Address> of every deployed pool
+    Pool(Address, Address), // normalized (token_a, token_b) → pool Address
+    LpToken(Address),       // pool address → LP token address
+    AllPools,               // Vec<Address> of every deployed pool
     Admin,
     AmmWasmHash,
     TokenWasmHash,
-    ClWasmHash,                      // WASM hash for concentrated_liquidity deployments
-    PoolCount,                       // u64 monotonic counter — used to derive unique deploy salts
-    GovernanceFor(Address),          // pool address → Option<Address>
-    ClPool(Address, Address, i128),  // normalized (token_a, token_b, fee_bps) → CL pool Address
-    PermissionlessMode,              // bool — true = anyone can create pools (with fee)
-    PoolCreationFee,                 // i128 — fee charged per pool in permissionless mode
-    FeeToken,                        // Address — token used to pay the pool creation fee
-    RateLimitLedgers,                // u32 — minimum ledgers between pool creations per address
-    LastPoolCreation(Address),       // u32 — ledger when this address last created a pool
+    ClWasmHash,                     // WASM hash for concentrated_liquidity deployments
+    PoolCount,                      // u64 monotonic counter — used to derive unique deploy salts
+    GovernanceFor(Address),         // pool address → Option<Address>
+    ClPool(Address, Address, i128), // normalized (token_a, token_b, fee_bps) → CL pool Address
+    PermissionlessMode,             // bool — true = anyone can create pools (with fee)
+    PoolCreationFee,                // i128 — fee charged per pool in permissionless mode
+    FeeToken,                       // Address — token used to pay the pool creation fee
+    RateLimitLedgers,               // u32 — minimum ledgers between pool creations per address
+    LastPoolCreation(Address),      // u32 — ledger when this address last created a pool
+    DefaultFeeTier,                 // i128 — default fee tier ID (0-3) for new pool deployments
+    Treasury,                       // Address — protocol treasury for fee sweeps
+    GlobalProtocolFeeBps,           // i128 — global protocol fee rate (0 = off)
+    PoolTokens(Address),            // pool address → (token_a, token_b) for sweep forwarding
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Convert a fee tier ID (0–3) to its basis-point equivalent.
+///
+/// | ID | bps | rate   |
+/// |----|-----|--------|
+/// | 0  |   1 | 0.01 % |
+/// | 1  |   5 | 0.05 % |
+/// | 2  |  30 | 0.30 % |
+/// | 3  | 100 | 1.00 % |
+fn fee_tier_to_bps(fee_tier: i128) -> Result<i128, FactoryError> {
+    match fee_tier {
+        0 => Ok(1),
+        1 => Ok(5),
+        2 => Ok(30),
+        3 => Ok(100),
+        _ => Err(FactoryError::InvalidFeeBps),
+    }
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -139,7 +172,9 @@ impl Factory {
             .set(&DataKey::AllPools, &Vec::<Address>::new(&env));
         env.storage().instance().set(&DataKey::PoolCount, &0u64);
         // Initialize default fee tier to Medium (0.3% = 30 bps)
-        env.storage().instance().set(&DataKey::DefaultFeeTier, &2i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultFeeTier, &2i128);
         Ok(())
     }
 
@@ -167,7 +202,7 @@ impl Factory {
         governance_wasm_hash: Option<BytesN<32>>,
     ) -> Result<(Address, Option<Address>), FactoryError> {
         let fee_bps = fee_tier_to_bps(fee_tier)?;
-        Self::create_pool_with_fee_bps(env, token_a, token_b, fee_bps, governance_wasm_hash)
+        Self::create_pool_with_fee_bps(env, caller, token_a, token_b, fee_bps, governance_wasm_hash)
     }
 
     /// Deploy a new AMM pool for `(token_a, token_b)` with a custom fee in basis points.
@@ -178,6 +213,7 @@ impl Factory {
     /// Token pair order is normalised. Panics if a pool for this pair already exists.
     pub fn create_pool_with_fee_bps(
         env: Env,
+        caller: Address,
         token_a: Address,
         token_b: Address,
         fee_bps: i128,
@@ -300,6 +336,11 @@ impl Factory {
         env.storage()
             .instance()
             .set(&DataKey::GovernanceFor(pool_addr.clone()), &gov_addr);
+        // Store reverse token-pair lookup used by sweep_fees to forward tokens.
+        env.storage().instance().set(
+            &DataKey::PoolTokens(pool_addr.clone()),
+            &(ta.clone(), tb.clone()),
+        );
 
         let mut all: Vec<Address> = env
             .storage()
@@ -309,13 +350,17 @@ impl Factory {
         all.push_back(pool_addr.clone());
         env.storage().instance().set(&DataKey::AllPools, &all);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "pool_created"),), (
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "pool_created"),),
+            (
                 ta.clone(),
                 tb.clone(),
                 pool_addr.clone(),
                 fee_bps,
                 lp_addr.clone(),
-            ));
+            )
+        );
 
         Ok((pool_addr, gov_addr))
     }
@@ -342,7 +387,11 @@ impl Factory {
         if let Some(ref h) = token_wasm_hash {
             env.storage().instance().set(&DataKey::TokenWasmHash, h);
         }
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "wasm_updated"),), (amm_wasm_hash, token_wasm_hash));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "wasm_updated"),),
+            (amm_wasm_hash, token_wasm_hash)
+        );
         Ok(())
     }
 
@@ -354,11 +403,13 @@ impl Factory {
     pub fn set_default_fee_tier(env: Env, fee_tier: i128) -> Result<(), FactoryError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        
+
         // Validate the fee tier
         fee_tier_to_bps(fee_tier)?;
-        
-        env.storage().instance().set(&DataKey::DefaultFeeTier, &fee_tier);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultFeeTier, &fee_tier);
         env.events().publish(
             (Symbol::new(&env, "default_fee_tier_updated"),),
             (fee_tier,),
@@ -384,7 +435,9 @@ impl Factory {
     pub fn set_cl_wasm_hash(env: Env, cl_wasm_hash: BytesN<32>) -> Result<(), FactoryError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        env.storage().instance().set(&DataKey::ClWasmHash, &cl_wasm_hash);
+        env.storage()
+            .instance()
+            .set(&DataKey::ClWasmHash, &cl_wasm_hash);
         Ok(())
     }
 
@@ -459,16 +512,27 @@ impl Factory {
 
         // Derive tick_spacing from fee tier (matching Uniswap v3 conventions).
         let tick_spacing: i32 = match fee_bps {
-            5   => 1,
-            30  => 10,
+            5 => 1,
+            30 => 10,
             100 => 60,
-            _   => 1,
+            _ => 1,
         };
-        ClPoolClient::new(&env, &pool_addr).initialize(&admin, &ta, &tb, &fee_bps, &initial_tick, &tick_spacing);
+        ClPoolClient::new(&env, &pool_addr).initialize(
+            &admin,
+            &ta,
+            &tb,
+            &fee_bps,
+            &initial_tick,
+            &tick_spacing,
+        );
 
         env.storage().instance().set(&cl_key, &pool_addr);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "cl_pool_created"),), (ta.clone(), tb.clone(), fee_bps, pool_addr.clone()));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "cl_pool_created"),),
+            (ta.clone(), tb.clone(), fee_bps, pool_addr.clone())
+        );
 
         Ok(pool_addr)
     }
@@ -489,7 +553,11 @@ impl Factory {
         env.storage()
             .instance()
             .set(&DataKey::PermissionlessMode, &enabled);
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "mode_changed"),), (enabled,));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "mode_changed"),),
+            (enabled,)
+        );
         Ok(())
     }
 
@@ -508,13 +576,15 @@ impl Factory {
         if fee_amount <= 0 {
             return Err(FactoryError::FeeNotConfigured);
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::FeeToken, &fee_token);
+        env.storage().instance().set(&DataKey::FeeToken, &fee_token);
         env.storage()
             .instance()
             .set(&DataKey::PoolCreationFee, &fee_amount);
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "creation_fee_set"),), (fee_token, fee_amount));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "creation_fee_set"),),
+            (fee_token, fee_amount)
+        );
         Ok(())
     }
 
@@ -599,13 +669,20 @@ impl Factory {
 
     /// Return the CL pool address for `(token_a, token_b, fee_bps)`, or `None` if absent.
     /// Token pair order does not matter.
-    pub fn get_cl_pool(env: Env, token_a: Address, token_b: Address, fee_bps: i128) -> Option<Address> {
+    pub fn get_cl_pool(
+        env: Env,
+        token_a: Address,
+        token_b: Address,
+        fee_bps: i128,
+    ) -> Option<Address> {
         let (ta, tb) = if token_a < token_b {
             (token_a, token_b)
         } else {
             (token_b, token_a)
         };
-        env.storage().instance().get(&DataKey::ClPool(ta, tb, fee_bps))
+        env.storage()
+            .instance()
+            .get(&DataKey::ClPool(ta, tb, fee_bps))
     }
 
     /// Return the addresses of every pool deployed by this factory.
@@ -644,7 +721,314 @@ impl Factory {
         page
     }
 
+    // ── Treasury & protocol fee sweep ────────────────────────────────────────
+
+    /// Configure the protocol treasury address and the global protocol fee rate.
+    ///
+    /// Admin-only. This immediately propagates the configured rate to all
+    /// factory-administered pools, making the factory their `fee_recipient` so
+    /// [`sweep_fees`] can permissionlessly collect and forward fees.
+    ///
+    /// Setting `global_protocol_fee_bps` to `0` disables fee collection on all
+    /// factory-administered pools after this call completes.
+    pub fn set_treasury(
+        env: Env,
+        admin: Address,
+        treasury: Address,
+        global_protocol_fee_bps: i128,
+    ) -> Result<(), FactoryError> {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(FactoryError::Unauthorized);
+        }
+        admin.require_auth();
+        if !(0..=10_000).contains(&global_protocol_fee_bps) {
+            return Err(FactoryError::InvalidFeeBps);
+        }
+        env.storage().instance().set(&DataKey::Treasury, &treasury);
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalProtocolFeeBps, &global_protocol_fee_bps);
+        let updated = Self::sync_global_fee_page(
+            &env,
+            &admin,
+            global_protocol_fee_bps,
+            0,
+            Self::pool_count(&env),
+        );
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "treasury_set"),),
+            (treasury, global_protocol_fee_bps, updated)
+        );
+        Ok(())
+    }
+
+    /// Return the current treasury address and global protocol fee rate.
+    ///
+    /// Returns `None` when no treasury has been configured yet.
+    pub fn get_treasury(env: Env) -> Option<(Address, i128)> {
+        let treasury: Option<Address> = env.storage().instance().get(&DataKey::Treasury);
+        let bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::GlobalProtocolFeeBps)
+            .unwrap_or(0);
+        treasury.map(|t| (t, bps))
+    }
+
+    /// Return the token pair `(token_a, token_b)` recorded for `pool`, or `None`.
+    pub fn get_pool_tokens(env: Env, pool: Address) -> Option<(Address, Address)> {
+        env.storage().instance().get(&DataKey::PoolTokens(pool))
+    }
+
+    /// Set and propagate the global protocol fee configuration to all
+    /// factory-administered pools. Admin-only.
+    ///
+    /// For each registered pool whose admin is the factory admin (i.e. not
+    /// governance-controlled), calls `set_protocol_fee` on the pool with:
+    /// - `recipient` = this factory contract (so the factory can later sweep)
+    /// - `protocol_fee_bps` = `protocol_fee_bps`
+    ///
+    /// Governance-controlled pools are skipped — they must update fee settings
+    /// via a governance proposal.
+    ///
+    /// Returns the number of pools successfully updated.
+    pub fn set_global_fee(
+        env: Env,
+        admin: Address,
+        protocol_fee_bps: i128,
+    ) -> Result<u32, FactoryError> {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(FactoryError::Unauthorized);
+        }
+        admin.require_auth();
+        if !env.storage().instance().has(&DataKey::Treasury) {
+            return Err(FactoryError::FeeNotConfigured);
+        }
+        if !(0..=10_000).contains(&protocol_fee_bps) {
+            return Err(FactoryError::InvalidFeeBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalProtocolFeeBps, &protocol_fee_bps);
+        let updated =
+            Self::sync_global_fee_page(&env, &admin, protocol_fee_bps, 0, Self::pool_count(&env));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "global_fee_set"),),
+            (protocol_fee_bps, 0u32, updated)
+        );
+        Ok(updated)
+    }
+
+    /// Propagate the global protocol fee configuration to a page of
+    /// factory-administered pools. Admin-only.
+    pub fn set_global_fee_paginated(
+        env: Env,
+        admin: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Result<u32, FactoryError> {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(FactoryError::Unauthorized);
+        }
+        admin.require_auth();
+        if !env.storage().instance().has(&DataKey::Treasury) {
+            return Err(FactoryError::FeeNotConfigured);
+        }
+        let protocol_fee_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::GlobalProtocolFeeBps)
+            .unwrap_or(0);
+        let updated = Self::sync_global_fee_page(&env, &admin, protocol_fee_bps, offset, limit);
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "global_fee_set"),),
+            (protocol_fee_bps, offset, updated)
+        );
+        Ok(updated)
+    }
+
+    /// Sweep accrued protocol fees from all factory-owned pools into the
+    /// treasury. **Permissionless** — callable by anyone.
+    ///
+    /// For each registered pool that is not governance-controlled, calls
+    /// `withdraw_protocol_fees()` on the pool
+    /// (which succeeds because the factory is the `fee_recipient`) and then
+    /// transfers the received tokens to the treasury.
+    ///
+    /// No trust is required: regardless of who triggers the sweep, funds are
+    /// cryptographically guaranteed to route to the governance-configured
+    /// treasury address stored in this contract.
+    ///
+    /// Returns the total amount of `token` collected.
+    ///
+    /// # Prerequisites
+    /// - `set_treasury` must have been called to configure the treasury and sync
+    ///   the factory as the `fee_recipient` on the target pools.
+    pub fn sweep_fees(env: Env, token: Address) -> Result<i128, FactoryError> {
+        let (_, total_collected) = Self::sweep_fees_page(&env, &token, 0, Self::pool_count(&env))?;
+        Ok(total_collected)
+    }
+
+    /// Paginated variant of [`sweep_fees`] for large pool registries.
+    pub fn sweep_fees_paginated(
+        env: Env,
+        token: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(u32, i128), FactoryError> {
+        Self::sweep_fees_page(&env, &token, offset, limit)
+    }
+
+    fn sweep_fees_page(
+        env: &Env,
+        token: &Address,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(u32, i128), FactoryError> {
+        let treasury: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Treasury)
+            .ok_or(FactoryError::FeeNotConfigured)?;
+
+        let factory_addr = env.current_contract_address();
+        let all: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllPools)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let len = all.len();
+        let start = offset.min(len);
+        let end = (start + limit).min(len);
+        let mut pools_swept: u32 = 0;
+        let mut total_collected: i128 = 0;
+
+        for i in start..end {
+            if let Some(pool_addr) = all.get(i) {
+                // Skip governance-controlled pools.
+                let gov: Option<Option<Address>> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::GovernanceFor(pool_addr.clone()));
+                let is_governed = gov.flatten().is_some();
+                if is_governed {
+                    continue;
+                }
+
+                let Some((token_a, token_b)) = env
+                    .storage()
+                    .instance()
+                    .get::<DataKey, (Address, Address)>(&DataKey::PoolTokens(pool_addr.clone()))
+                else {
+                    continue;
+                };
+
+                // Pull accrued fees from the pool to this factory contract.
+                // This succeeds because factory == fee_recipient and Soroban
+                // automatically authorises require_auth() for the invoking contract.
+                let (fee_a, fee_b) = AmmPoolClient::new(env, &pool_addr).withdraw_protocol_fees();
+
+                // Forward to treasury via the token contracts.
+                if fee_a > 0 || fee_b > 0 {
+                    if fee_a > 0 {
+                        sdk_token::Client::new(env, &token_a).transfer(
+                            &factory_addr,
+                            &treasury,
+                            &fee_a,
+                        );
+                        if token_a == *token {
+                            total_collected += fee_a;
+                        }
+                    }
+                    if fee_b > 0 {
+                        sdk_token::Client::new(env, &token_b).transfer(
+                            &factory_addr,
+                            &treasury,
+                            &fee_b,
+                        );
+                        if token_b == *token {
+                            total_collected += fee_b;
+                        }
+                    }
+                    pools_swept += 1;
+                }
+            }
+        }
+
+        soroban_amm_sdk::emit_versioned_event!(
+            env.clone(),
+            (Symbol::new(env, "fees_swept"),),
+            (
+                treasury,
+                token.clone(),
+                offset,
+                pools_swept,
+                total_collected
+            )
+        );
+        Ok((pools_swept, total_collected))
+    }
+
     // ── Internals ─────────────────────────────────────────────────────────────
+
+    fn pool_count(env: &Env) -> u32 {
+        let all: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllPools)
+            .unwrap_or_else(|| Vec::new(env));
+        all.len()
+    }
+
+    fn sync_global_fee_page(
+        env: &Env,
+        admin: &Address,
+        protocol_fee_bps: i128,
+        offset: u32,
+        limit: u32,
+    ) -> u32 {
+        let factory_addr = env.current_contract_address();
+        let all: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllPools)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let len = all.len();
+        let start = offset.min(len);
+        let end = (start + limit).min(len);
+        let mut updated: u32 = 0;
+
+        for i in start..end {
+            if let Some(pool_addr) = all.get(i) {
+                // Governance-controlled pools have their own pool admin contract,
+                // so the factory cannot authorize their pool-level fee update.
+                let gov: Option<Option<Address>> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::GovernanceFor(pool_addr.clone()));
+                if gov.flatten().is_some() {
+                    continue;
+                }
+
+                AmmPoolClient::new(env, &pool_addr).set_protocol_fee(
+                    admin,
+                    &factory_addr,
+                    &protocol_fee_bps,
+                );
+                updated += 1;
+            }
+        }
+
+        updated
+    }
 
     /// Enforce per-address rate limiting for permissionless pool creation.
     ///
@@ -699,9 +1083,13 @@ impl Factory {
             .get(&DataKey::PoolCreationFee)
             .ok_or(FactoryError::FeeNotConfigured)?;
 
-        token::Client::new(env, &fee_token).transfer(caller, treasury, &fee_amount);
+        sdk_token::Client::new(env, &fee_token).transfer(caller, treasury, &fee_amount);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(env, "creation_fee_paid"),), (caller.clone(), fee_amount));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(env, "creation_fee_paid"),),
+            (caller.clone(), fee_amount)
+        );
 
         Ok(())
     }
@@ -762,10 +1150,30 @@ impl Factory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Env, IntoVal,
+    };
 
     // Embed compiled WASM at test-compile time.
     // Use compiled WASM exported by the `amm` and `token` crates (feature `testutils`).
+
+    fn token_fee_for_pool(
+        factory: &FactoryClient<'_>,
+        pool: &Address,
+        token_addr: &Address,
+        amm_client: &amm::AmmPoolClient<'_>,
+    ) -> i128 {
+        let (token_a, token_b) = factory.get_pool_tokens(pool).unwrap();
+        let (fee_a, fee_b) = amm_client.get_accrued_fees();
+        if token_a == *token_addr {
+            fee_a
+        } else if token_b == *token_addr {
+            fee_b
+        } else {
+            0
+        }
+    }
 
     #[test]
     fn test_create_pool() {
@@ -784,7 +1192,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool, gov) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let (pool, gov) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
 
         assert_eq!(factory.get_pool(&ta, &tb), Some(pool.clone()));
         assert_eq!(factory.all_pools().len(), 1);
@@ -810,7 +1218,8 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool, gov) = factory.create_pool(&admin, &ta, &tb, &30_i128, &Some(gov_hash));
+        let (pool, gov) =
+            factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &Some(gov_hash));
 
         assert_eq!(factory.get_pool(&ta, &tb), Some(pool.clone()));
         assert_eq!(factory.all_pools().len(), 1);
@@ -835,7 +1244,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
 
         // Reverse-order lookup returns the same pool.
         assert_eq!(factory.get_pool(&ta, &tb), factory.get_pool(&tb, &ta));
@@ -858,8 +1267,8 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
-        let result = factory.try_create_pool(&admin, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
+        let result = factory.try_create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
         assert!(result.is_err());
     }
 
@@ -883,10 +1292,10 @@ mod tests {
         let tb = Address::generate(&env);
         let tc = Address::generate(&env);
 
-        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
         assert_eq!(factory.all_pools().len(), 1);
 
-        factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tc, &30_i128, &None);
         assert_eq!(factory.all_pools().len(), 2);
     }
 
@@ -910,8 +1319,8 @@ mod tests {
         let tb = Address::generate(&env);
         let tc = Address::generate(&env);
 
-        let (pool0, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
-        let (pool1, _) = factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
+        let (pool0, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
+        let (pool1, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tc, &30_i128, &None);
 
         // Fetch LP token addresses via the factory's registry.
         let lp0 = factory.get_lp_token(&pool0).unwrap();
@@ -970,7 +1379,7 @@ mod tests {
         // Pool creation still works after an update.
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
-        let (pool, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let (pool, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
         assert!(factory.get_pool(&ta, &tb).is_some());
         assert!(factory.get_lp_token(&pool).is_some());
 
@@ -991,7 +1400,9 @@ mod tests {
 
         let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
         let token_hash = env.deployer().upload_contract_wasm(token::WASM);
-        let cl_hash = env.deployer().upload_contract_wasm(concentrated_liquidity::WASM);
+        let cl_hash = env
+            .deployer()
+            .upload_contract_wasm(concentrated_liquidity::WASM);
 
         let admin = Address::generate(&env);
         let factory_addr = env.register_contract(None, Factory);
@@ -1010,8 +1421,14 @@ mod tests {
         assert_ne!(pool_30, pool_100);
 
         // get_cl_pool returns the correct address for each tier.
-        assert_eq!(factory.get_cl_pool(&ta, &tb, &30_i128), Some(pool_30.clone()));
-        assert_eq!(factory.get_cl_pool(&ta, &tb, &100_i128), Some(pool_100.clone()));
+        assert_eq!(
+            factory.get_cl_pool(&ta, &tb, &30_i128),
+            Some(pool_30.clone())
+        );
+        assert_eq!(
+            factory.get_cl_pool(&ta, &tb, &100_i128),
+            Some(pool_100.clone())
+        );
 
         // Token order doesn't matter for lookup.
         assert_eq!(factory.get_cl_pool(&tb, &ta, &30_i128), Some(pool_30));
@@ -1028,7 +1445,9 @@ mod tests {
 
         let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
         let token_hash = env.deployer().upload_contract_wasm(token::WASM);
-        let cl_hash = env.deployer().upload_contract_wasm(concentrated_liquidity::WASM);
+        let cl_hash = env
+            .deployer()
+            .upload_contract_wasm(concentrated_liquidity::WASM);
 
         let admin = Address::generate(&env);
         let factory_addr = env.register_contract(None, Factory);
@@ -1066,13 +1485,13 @@ mod tests {
         let tc = Address::generate(&env);
         let td = Address::generate(&env);
 
-        let (pool1, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let (pool1, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 1);
 
-        let (pool2, _) = factory.create_pool(&admin, &ta, &tc, &30_i128, &None);
+        let (pool2, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tc, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 2);
 
-        let (pool3, _) = factory.create_pool(&admin, &ta, &td, &30_i128, &None);
+        let (pool3, _) = factory.create_pool_with_fee_bps(&admin, &ta, &td, &30_i128, &None);
         assert_eq!(factory.get_pool_count(), 3);
 
         // Page 1: first two pools.
@@ -1106,7 +1525,6 @@ mod tests {
     #[test]
     fn test_create_pool_emits_pool_created_event() {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::IntoVal;
 
         let env = Env::default();
         env.budget().reset_unlimited();
@@ -1123,7 +1541,7 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        let (pool_addr, _) = factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let (pool_addr, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
 
         // Locate the pool_created event.
         let events = env.events().all();
@@ -1141,15 +1559,14 @@ mod tests {
         let __ver_12: (u32, (Address, Address, Address, i128, Address)) = event.2.into_val(&env);
         assert_eq!(__ver_12.0, soroban_amm_sdk::EVENT_SCHEMA_VERSION);
         let data: (Address, Address, Address, i128, Address) = __ver_12.1;
-        assert_eq!(data.2, pool_addr,   "pool address in event must match");
-        assert_eq!(data.3, 30_i128,     "fee_bps in event must be 30");
-        assert_eq!(data.4, lp_addr,     "lp_token address in event must match");
+        assert_eq!(data.2, pool_addr, "pool address in event must match");
+        assert_eq!(data.3, 30_i128, "fee_bps in event must be 30");
+        assert_eq!(data.4, lp_addr, "lp_token address in event must match");
     }
 
     #[test]
     fn test_create_pool_duplicate_does_not_emit_event() {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::IntoVal;
 
         let env = Env::default();
         env.budget().reset_unlimited();
@@ -1166,14 +1583,14 @@ mod tests {
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
 
-        factory.create_pool(&admin, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
 
         // Clear events so we only see events from the second (failing) call.
         // Soroban test env accumulates events — count before the duplicate attempt.
         let count_before = env.events().all().len();
 
         // Duplicate call must fail.
-        let result = factory.try_create_pool(&admin, &ta, &tb, &30_i128, &None);
+        let result = factory.try_create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
         assert!(result.is_err(), "duplicate pool creation must fail");
 
         // No new events must have been added.
@@ -1219,7 +1636,7 @@ mod tests {
             invoke: &soroban_sdk::testutils::MockAuthInvoke {
                 contract: &factory_addr,
                 fn_name: "initialize",
-                args: (&admin, &amm_hash, &token_hash).into_val(&env),
+                args: (admin.clone(), amm_hash.clone(), token_hash.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }]);
@@ -1232,8 +1649,11 @@ mod tests {
         let tb = Address::generate(&env);
 
         // user tries to create a pool in permissioned mode — must fail.
-        let result = factory.try_create_pool(&user, &ta, &tb, &30_i128, &None);
-        assert!(result.is_err(), "non-admin must not create pools in permissioned mode");
+        let result = factory.try_create_pool_with_fee_bps(&user, &ta, &tb, &30_i128, &None);
+        assert!(
+            result.is_err(),
+            "non-admin must not create pools in permissioned mode"
+        );
     }
 
     #[test]
@@ -1291,12 +1711,15 @@ mod tests {
 
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
-        let (pool, _) = factory.create_pool(&user, &ta, &tb, &30_i128, &None);
+        let (pool, _) = factory.create_pool_with_fee_bps(&user, &ta, &tb, &30_i128, &None);
 
         assert!(factory.get_pool(&ta, &tb).is_some());
         // Fee transferred from user to admin (treasury).
         assert_eq!(fee_client.balance(&user), user_balance_before - fee_amount);
-        assert_eq!(fee_client.balance(&admin), admin_balance_before + fee_amount);
+        assert_eq!(
+            fee_client.balance(&admin),
+            admin_balance_before + fee_amount
+        );
     }
 
     #[test]
@@ -1319,8 +1742,11 @@ mod tests {
 
         let ta = Address::generate(&env);
         let tb = Address::generate(&env);
-        let result = factory.try_create_pool(&user, &ta, &tb, &30_i128, &None);
-        assert!(result.is_err(), "pool creation without configured fee must fail");
+        let result = factory.try_create_pool_with_fee_bps(&user, &ta, &tb, &30_i128, &None);
+        assert!(
+            result.is_err(),
+            "pool creation without configured fee must fail"
+        );
     }
 
     #[test]
@@ -1349,11 +1775,14 @@ mod tests {
         let tc = Address::generate(&env);
 
         // First creation succeeds.
-        factory.create_pool(&user, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&user, &ta, &tb, &30_i128, &None);
 
         // Immediate second creation by the same user must be rate-limited.
-        let result = factory.try_create_pool(&user, &ta, &tc, &30_i128, &None);
-        assert!(result.is_err(), "second pool creation within rate limit window must fail");
+        let result = factory.try_create_pool_with_fee_bps(&user, &ta, &tc, &30_i128, &None);
+        assert!(
+            result.is_err(),
+            "second pool creation within rate limit window must fail"
+        );
     }
 
     #[test]
@@ -1381,9 +1810,433 @@ mod tests {
         let tc = Address::generate(&env);
 
         // Both creations must succeed on the same ledger.
-        factory.create_pool(&user, &ta, &tb, &30_i128, &None);
-        factory.create_pool(&user, &ta, &tc, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&user, &ta, &tb, &30_i128, &None);
+        factory.create_pool_with_fee_bps(&user, &ta, &tc, &30_i128, &None);
         assert_eq!(factory.all_pools().len(), 2);
     }
-}
 
+    // ── Treasury & fee sweep ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_treasury_stores_config() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Before set_treasury: get_treasury must return None.
+        assert_eq!(factory.get_treasury(), None);
+
+        factory.set_treasury(&admin, &treasury, &30_i128);
+
+        let result = factory.get_treasury();
+        assert_eq!(result, Some((treasury.clone(), 30_i128)));
+
+        // Updating treasury is idempotent.
+        let treasury2 = Address::generate(&env);
+        factory.set_treasury(&admin, &treasury2, &50_i128);
+        assert_eq!(factory.get_treasury(), Some((treasury2, 50_i128)));
+    }
+
+    #[test]
+    fn test_set_treasury_invalid_bps_fails() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // fee_bps > 10_000 must be rejected.
+        let result = factory.try_set_treasury(&admin, &treasury, &10_001_i128);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_global_fee_without_treasury_fails() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
+
+        // set_global_fee without treasury must return FeeNotConfigured.
+        let result = factory.try_set_global_fee(&admin, &10_i128);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_global_fee_propagates_to_non_governance_pools() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+        let (pool_addr, _) = factory.create_pool_with_fee_bps(&admin, &ta, &tb, &30_i128, &None);
+
+        // Verify token pair is stored for sweep.
+        let tokens = factory.get_pool_tokens(&pool_addr);
+        assert!(tokens.is_some());
+
+        factory.set_treasury(&admin, &treasury, &10_i128);
+
+        let amm_client = amm::AmmPoolClient::new(&env, &pool_addr);
+        let (recipient_after_treasury, bps_after_treasury) = amm_client.get_protocol_fee();
+        assert_eq!(recipient_after_treasury, Some(factory_addr.clone()));
+        assert_eq!(bps_after_treasury, 10_i128);
+
+        // set_global_fee returns the number of pools updated.
+        let updated = factory.set_global_fee(&admin, &5_i128);
+        assert_eq!(updated, 1);
+
+        // The pool's fee_recipient must now be the factory contract.
+        let (recipient, bps) = amm_client.get_protocol_fee();
+        assert_eq!(recipient, Some(factory_addr.clone()));
+        assert_eq!(bps, 5_i128);
+    }
+
+    #[test]
+    fn test_sweep_fees_transfers_to_treasury() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Deploy real token contracts as the pool tokens.
+        let ta_addr = env.register_contract(None, token::LpToken);
+        let tb_addr = env.register_contract(None, token::LpToken);
+        token::LpTokenClient::new(&env, &ta_addr).initialize(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "Token A"),
+            &soroban_sdk::String::from_str(&env, "TKA"),
+            &7u32,
+        );
+        token::LpTokenClient::new(&env, &tb_addr).initialize(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "Token B"),
+            &soroban_sdk::String::from_str(&env, "TKB"),
+            &7u32,
+        );
+
+        let (pool_addr, _) =
+            factory.create_pool_with_fee_bps(&admin, &ta_addr, &tb_addr, &30_i128, &None);
+
+        // Configure treasury and propagate fee (10 bps) to the pool.
+        factory.set_treasury(&admin, &treasury, &10_i128);
+
+        // Seed the pool with liquidity so swaps work.
+        let lp_addr = factory.get_lp_token(&pool_addr).unwrap();
+        token::LpTokenClient::new(&env, &ta_addr).mint(&admin, &10_000_000_i128);
+        token::LpTokenClient::new(&env, &tb_addr).mint(&admin, &10_000_000_i128);
+        let amm = amm::AmmPoolClient::new(&env, &pool_addr);
+        amm.add_liquidity(
+            &admin,
+            &10_000_000_i128,
+            &10_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+
+        // Perform a swap so fees accrue.
+        let trader = Address::generate(&env);
+        token::LpTokenClient::new(&env, &ta_addr).mint(&trader, &1_000_000_i128);
+        amm.swap(&trader, &ta_addr, &1_000_000_i128, &0_i128, &u64::MAX);
+
+        // Verify some fees accrued.
+        let (accrued_a, _) = amm.get_accrued_fees();
+        assert!(accrued_a > 0, "protocol fees must have accrued after swap");
+
+        let treasury_a_before = soroban_sdk::token::Client::new(&env, &ta_addr).balance(&treasury);
+
+        // Sweep — permissionless.
+        let swept_a = factory.sweep_fees(&ta_addr);
+
+        assert!(swept_a > 0);
+
+        let treasury_a_after = soroban_sdk::token::Client::new(&env, &ta_addr).balance(&treasury);
+        assert_eq!(
+            treasury_a_after - treasury_a_before,
+            swept_a,
+            "treasury must receive exactly the swept fees"
+        );
+
+        // After sweep, pool's accrued fees must be zeroed.
+        let (post_sweep_a, post_sweep_b) = amm.get_accrued_fees();
+        assert_eq!(post_sweep_a, 0);
+        assert_eq!(post_sweep_b, 0);
+    }
+
+    #[test]
+    fn test_sweep_fees_zero_fees_is_noop() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let ta_addr = env.register_contract(None, token::LpToken);
+        let tb_addr = env.register_contract(None, token::LpToken);
+        token::LpTokenClient::new(&env, &ta_addr).initialize(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "Token A"),
+            &soroban_sdk::String::from_str(&env, "TKA"),
+            &7u32,
+        );
+        token::LpTokenClient::new(&env, &tb_addr).initialize(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "Token B"),
+            &soroban_sdk::String::from_str(&env, "TKB"),
+            &7u32,
+        );
+
+        factory.create_pool_with_fee_bps(&admin, &ta_addr, &tb_addr, &30_i128, &None);
+        factory.set_treasury(&admin, &treasury, &10_i128);
+
+        let treasury_before = soroban_sdk::token::Client::new(&env, &ta_addr).balance(&treasury);
+        let swept = factory.sweep_fees(&ta_addr);
+        let treasury_after = soroban_sdk::token::Client::new(&env, &ta_addr).balance(&treasury);
+
+        assert_eq!(swept, 0);
+        assert_eq!(treasury_after, treasury_before);
+    }
+
+    #[test]
+    fn test_sweep_fees_multiple_pools_aggregates_requested_token() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        let token_a = env.register_contract(None, token::LpToken);
+        let token_b = env.register_contract(None, token::LpToken);
+        let token_c = env.register_contract(None, token::LpToken);
+        for (addr, name, symbol) in [
+            (token_a.clone(), "Token A", "TKA"),
+            (token_b.clone(), "Token B", "TKB"),
+            (token_c.clone(), "Token C", "TKC"),
+        ] {
+            token::LpTokenClient::new(&env, &addr).initialize(
+                &admin,
+                &soroban_sdk::String::from_str(&env, name),
+                &soroban_sdk::String::from_str(&env, symbol),
+                &7u32,
+            );
+        }
+
+        let (pool_ab, _) =
+            factory.create_pool_with_fee_bps(&admin, &token_a, &token_b, &30_i128, &None);
+        let (pool_ac, _) =
+            factory.create_pool_with_fee_bps(&admin, &token_a, &token_c, &30_i128, &None);
+        factory.set_treasury(&admin, &treasury, &10_i128);
+
+        let amm_ab = amm::AmmPoolClient::new(&env, &pool_ab);
+        let amm_ac = amm::AmmPoolClient::new(&env, &pool_ac);
+
+        for token_addr in [token_a.clone(), token_b.clone(), token_c.clone()] {
+            token::LpTokenClient::new(&env, &token_addr).mint(&admin, &20_000_000_i128);
+        }
+        amm_ab.add_liquidity(
+            &admin,
+            &10_000_000_i128,
+            &10_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+        amm_ac.add_liquidity(
+            &admin,
+            &10_000_000_i128,
+            &10_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+
+        let trader = Address::generate(&env);
+        token::LpTokenClient::new(&env, &token_a).mint(&trader, &2_000_000_i128);
+        amm_ab.swap(&trader, &token_a, &1_000_000_i128, &0_i128, &u64::MAX);
+        amm_ac.swap(&trader, &token_a, &1_000_000_i128, &0_i128, &u64::MAX);
+
+        let expected = token_fee_for_pool(&factory, &pool_ab, &token_a, &amm_ab)
+            + token_fee_for_pool(&factory, &pool_ac, &token_a, &amm_ac);
+        assert!(expected > 0);
+
+        let treasury_before = soroban_sdk::token::Client::new(&env, &token_a).balance(&treasury);
+        let swept = factory.sweep_fees(&token_a);
+        let treasury_after = soroban_sdk::token::Client::new(&env, &token_a).balance(&treasury);
+
+        assert_eq!(swept, expected);
+        assert_eq!(treasury_after - treasury_before, expected);
+    }
+
+    #[test]
+    fn test_sweep_fees_without_treasury_fails() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+
+        // Anyone can call, but treasury must be configured first.
+        let token_to_sweep = Address::generate(&env);
+        let result = factory.try_sweep_fees(&token_to_sweep);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_governance_proposals_for_factory_fee_sweep() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+
+        let proposer = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+
+        let gov_addr = env.register_contract(None, governance::Governance);
+        let gov = governance::GovernanceClient::new(&env, &gov_addr);
+
+        factory.initialize(&gov_addr, &amm_hash, &token_hash);
+
+        // Deploy LP token.
+        let lp_addr = env.register_contract(None, token::LpToken);
+        token::LpTokenClient::new(&env, &lp_addr).initialize(
+            &gov_addr,
+            &soroban_sdk::String::from_str(&env, "AMM LP"),
+            &soroban_sdk::String::from_str(&env, "ALP"),
+            &7u32,
+        );
+
+        // Initialize governance
+        gov.initialize(
+            &gov_addr,
+            &factory_addr, // dummy pool address
+            &lp_addr,
+            &604800_u64,
+            &172800_u64,
+            &1000_i128,
+            &100_i128,
+        );
+
+        token::LpTokenClient::new(&env, &lp_addr).set_locker(&gov_addr);
+
+        // Mint LP tokens to proposer
+        let lp_client = token::LpTokenClient::new(&env, &lp_addr);
+        lp_client.mint(&proposer, &1000_i128);
+
+        // Create update proposals
+        let treasury = Address::generate(&env);
+
+        let treasury_params = governance::UpdateFactoryTreasuryParams {
+            factory: factory_addr.clone(),
+            treasury: treasury.clone(),
+            global_protocol_fee_bps: 300_i128, // 3%
+        };
+
+        // Propose treasury update
+        let pid1 = gov.propose(
+            &proposer,
+            &governance::ProposalKind::UpdateFactoryTreasury(treasury_params),
+        );
+
+        // Vote
+        gov.vote(&proposer, &pid1, &governance::Vote::For);
+
+        // Advance ledger to execution time
+        let prop1 = gov.get_proposal(&pid1);
+        env.ledger()
+            .with_mut(|l| l.timestamp = prop1.execute_after + 1);
+
+        // Execute treasury update proposal
+        gov.execute(&pid1);
+
+        // Verify that treasury and global fee got updated in the Factory!
+        let (stored_treasury, stored_fee) = factory.get_treasury().unwrap();
+        assert_eq!(stored_treasury, treasury);
+        assert_eq!(stored_fee, 300_i128);
+        gov.unlock_vote(&proposer, &pid1);
+
+        // Test UpdateFactoryGlobalFee proposal
+        let global_fee_params = governance::UpdateFactoryGlobalFeeParams {
+            factory: factory_addr.clone(),
+            offset: 0,
+            limit: 100,
+        };
+
+        let pid2 = gov.propose(
+            &proposer,
+            &governance::ProposalKind::UpdateFactoryGlobalFee(global_fee_params),
+        );
+        gov.vote(&proposer, &pid2, &governance::Vote::For);
+        let prop2 = gov.get_proposal(&pid2);
+        env.ledger()
+            .with_mut(|l| l.timestamp = prop2.execute_after + 1);
+
+        // Execute global fee update proposal
+        gov.execute(&pid2);
+    }
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -19,7 +19,7 @@ pub const WASM: &[u8] = include_bytes!(concat!(
     "/../../target/wasm32v1-none/release/governance.wasm"
 ));
 
-use soroban_sdk::{contract, contractimpl, contracterror, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -36,38 +36,38 @@ const MAX_DELEGATION_DEPTH: u32 = 8;
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum GovernanceError {
-    AlreadyInitialized      = 1,
-    InvalidVotingPeriod     = 2,
-    InvalidTimelock         = 3,
-    InvalidQuorumBps        = 4,
-    InvalidProposerStake    = 5,
-    InvalidFeeBps           = 6,
-    ZeroTotalSupply         = 7,
-    InsufficientStake       = 8,
-    ProposalNotFound        = 9,
-    VotingNotStarted        = 10,
-    VotingPeriodEnded       = 11,
-    AlreadyExecuted         = 12,
-    ProposalCancelled       = 13,
-    AlreadyVoted            = 14,
-    NoVotingPower           = 15,
-    VotingPeriodActive      = 16,
-    ProposalExpired         = 17,
-    TimelockNotElapsed      = 18,
-    QuorumNotMet            = 19,
-    ProposalDefeated        = 20,
-    NotProposer             = 21,
-    NoLockedVote            = 22,
-    ProposalNotConcluded    = 23,
-    CannotDelegateToSelf    = 24,
-    Unauthorized            = 25,
-    HasDelegated            = 26,
-    DelegationCycle         = 27,
-    ProposalVetoed          = 28,
-    VetoWindowExpired       = 29,
-    NotVetoMultisig         = 30,
+    AlreadyInitialized = 1,
+    InvalidVotingPeriod = 2,
+    InvalidTimelock = 3,
+    InvalidQuorumBps = 4,
+    InvalidProposerStake = 5,
+    InvalidFeeBps = 6,
+    ZeroTotalSupply = 7,
+    InsufficientStake = 8,
+    ProposalNotFound = 9,
+    VotingNotStarted = 10,
+    VotingPeriodEnded = 11,
+    AlreadyExecuted = 12,
+    ProposalCancelled = 13,
+    AlreadyVoted = 14,
+    NoVotingPower = 15,
+    VotingPeriodActive = 16,
+    ProposalExpired = 17,
+    TimelockNotElapsed = 18,
+    QuorumNotMet = 19,
+    ProposalDefeated = 20,
+    NotProposer = 21,
+    NoLockedVote = 22,
+    ProposalNotConcluded = 23,
+    CannotDelegateToSelf = 24,
+    Unauthorized = 25,
+    HasDelegated = 26,
+    DelegationCycle = 27,
+    ProposalVetoed = 28,
+    VetoWindowExpired = 29,
+    NotVetoMultisig = 30,
     InsufficientSnapshotBal = 31,
-    VetoMultisigNotSet      = 32,
+    VetoMultisigNotSet = 32,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -184,15 +184,33 @@ pub struct UpdateProtocolFeeParams {
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
+pub struct UpdateFactoryTreasuryParams {
+    pub factory: Address,
+    pub treasury: Address,
+    pub global_protocol_fee_bps: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpdateFactoryGlobalFeeParams {
+    pub factory: Address,
+    pub offset: u32,
+    pub limit: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ProposalKind {
     UpdateFee(i128),
-    UpdateFeeTier(i128),  // 0-3: VeryLow, Low, Medium, High
+    UpdateFeeTier(i128), // 0-3: VeryLow, Low, Medium, High
     UpdateProtocolFee(UpdateProtocolFeeParams),
     UpdateFlashLoanFee(i128),
     TransferAdmin(Address),
     PausePool,
     UnpausePool,
     EmergencyWithdraw(Address),
+    UpdateFactoryTreasury(UpdateFactoryTreasuryParams),
+    UpdateFactoryGlobalFee(UpdateFactoryGlobalFeeParams),
 }
 
 #[contracttype]
@@ -246,6 +264,14 @@ pub trait AmmPoolInterface {
     fn unpause(env: Env);
     fn emergency_withdraw(env: Env, to: Address);
     fn propose_admin(env: Env, current_admin: Address, new_admin: Address);
+}
+
+// ── Factory client ────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contractclient(name = "FactoryClient")]
+pub trait FactoryInterface {
+    fn set_treasury(env: Env, admin: Address, treasury: Address, global_protocol_fee_bps: i128);
+    fn set_global_fee_paginated(env: Env, admin: Address, offset: u32, limit: u32) -> u32;
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -336,7 +362,11 @@ impl Governance {
     ///
     /// The proposer must hold at least the configured minimum LP stake.
     /// Returns the new `proposal_id`.
-    pub fn propose(env: Env, proposer: Address, kind: ProposalKind) -> Result<u32, GovernanceError> {
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        kind: ProposalKind,
+    ) -> Result<u32, GovernanceError> {
         proposer.require_auth();
 
         match &kind {
@@ -362,6 +392,13 @@ impl Governance {
             ProposalKind::TransferAdmin(_new_admin) => {}
             ProposalKind::PausePool => {}
             ProposalKind::UnpausePool => {}
+            ProposalKind::EmergencyWithdraw(_) => {}
+            ProposalKind::UpdateFactoryTreasury(params) => {
+                if !(0..=MAX_BPS).contains(&params.global_protocol_fee_bps) {
+                    return Err(GovernanceError::InvalidFeeBps);
+                }
+            }
+            ProposalKind::UpdateFactoryGlobalFee(_) => {}
         }
 
         let lp_token: Address = env.storage().instance().get(&DataKey::LpToken).unwrap();
@@ -431,7 +468,11 @@ impl Governance {
             .instance()
             .set(&DataKey::ProposalCount, &(id + 1));
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "proposed"),), (id, proposer, kind, vote_end, snapshot_ledger));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "proposed"),),
+            (id, proposer, kind, vote_end, snapshot_ledger)
+        );
 
         Ok(id)
     }
@@ -440,7 +481,12 @@ impl Governance {
     ///
     /// Voting power uses LP balances snapshotted at proposal creation (`snapshot_ledger`).
     /// Delegators cannot vote directly; the terminal delegatee votes with aggregated power.
-    pub fn vote(env: Env, voter: Address, proposal_id: u32, choice: Vote) -> Result<(), GovernanceError> {
+    pub fn vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u32,
+        choice: Vote,
+    ) -> Result<(), GovernanceError> {
         voter.require_auth();
 
         if Self::get_delegate(env.clone(), voter.clone()).is_some() {
@@ -517,7 +563,11 @@ impl Governance {
         env.storage().persistent().set(&voted_key, &record);
         Self::bump_key_ttl(&env, &voted_key);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "voted"),), (proposal_id, voter, choice, voting_power));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "voted"),),
+            (proposal_id, voter, choice, voting_power)
+        );
         Ok(())
     }
 
@@ -592,9 +642,27 @@ impl Governance {
             }
             ProposalKind::UnpausePool => {
                 amm_client.unpause();
-            },
+            }
             ProposalKind::EmergencyWithdraw(to) => {
                 amm_client.emergency_withdraw(to);
+            }
+            ProposalKind::UpdateFactoryTreasury(params) => {
+                let self_addr = env.current_contract_address();
+                let factory_client = FactoryClient::new(&env, &params.factory);
+                factory_client.set_treasury(
+                    &self_addr,
+                    &params.treasury,
+                    &params.global_protocol_fee_bps,
+                );
+            }
+            ProposalKind::UpdateFactoryGlobalFee(params) => {
+                let self_addr = env.current_contract_address();
+                let factory_client = FactoryClient::new(&env, &params.factory);
+                let _updated = factory_client.set_global_fee_paginated(
+                    &self_addr,
+                    &params.offset,
+                    &params.limit,
+                );
             }
         }
 
@@ -602,13 +670,21 @@ impl Governance {
         env.storage().persistent().set(&proposal_key, &proposal);
         Self::bump_key_ttl(&env, &proposal_key);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "executed"),), (proposal_id, proposal.kind.clone()));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "executed"),),
+            (proposal_id, proposal.kind.clone())
+        );
         Ok(())
     }
 
     /// Cancel an active proposal. Only the original proposer can cancel,
     /// and only while voting is still open.
-    pub fn cancel_proposal(env: Env, proposal_id: u32, proposer: Address) -> Result<(), GovernanceError> {
+    pub fn cancel_proposal(
+        env: Env,
+        proposal_id: u32,
+        proposer: Address,
+    ) -> Result<(), GovernanceError> {
         proposer.require_auth();
 
         let proposal_key = DataKey::Proposal(proposal_id);
@@ -693,7 +769,11 @@ impl Governance {
         LpTokenClient::new(&env, &lp_token).unlock(&voter, &locked);
         env.storage().persistent().remove(&lock_key);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "vote_unlocked"), voter.clone()), (proposal_id, locked));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "vote_unlocked"), voter.clone()),
+            (proposal_id, locked)
+        );
         Ok(())
     }
 
@@ -760,12 +840,13 @@ impl Governance {
             .unwrap_or(None)
     }
 
-
     /// Admin-only: set the protocol multisig that may veto passed proposals.
     pub fn set_veto_multisig(env: Env, multisig: Address) -> Result<(), GovernanceError> {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        env.storage().instance().set(&DataKey::VetoMultisig, &multisig);
+        env.storage()
+            .instance()
+            .set(&DataKey::VetoMultisig, &multisig);
         env.events()
             .publish((Symbol::new(&env, "veto_multisig_set"),), (multisig,));
         Ok(())
@@ -839,7 +920,11 @@ impl Governance {
         env.storage().persistent().set(&audit_key, &audit);
         Self::bump_key_ttl(&env, &audit_key);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "vetoed"),), (proposal_id, multisig, now, discussion_end));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "vetoed"),),
+            (proposal_id, multisig, now, discussion_end)
+        );
         Ok(())
     }
 
@@ -851,7 +936,11 @@ impl Governance {
     }
 
     /// LP balance at proposal snapshot ledger for `holder`.
-    pub fn get_snapshot_balance(env: Env, proposal_id: u32, holder: Address) -> Result<i128, GovernanceError> {
+    pub fn get_snapshot_balance(
+        env: Env,
+        proposal_id: u32,
+        holder: Address,
+    ) -> Result<i128, GovernanceError> {
         let proposal: Proposal = env
             .storage()
             .persistent()
@@ -979,7 +1068,15 @@ impl Governance {
                 .instance()
                 .get(&DataKey::Delegator(holder.clone(), i))
                 .unwrap();
-            Self::collect_voting_power(env, lp_client, &delegator, proposal, total, locks, depth + 1)?;
+            Self::collect_voting_power(
+                env,
+                lp_client,
+                &delegator,
+                proposal,
+                total,
+                locks,
+                depth + 1,
+            )?;
         }
         Ok(())
     }
@@ -1007,9 +1104,10 @@ impl Governance {
         env.storage()
             .instance()
             .set(&DataKey::Delegator(delegatee.clone(), count), delegator);
-        env.storage()
-            .instance()
-            .set(&DataKey::DelegatorSlot(delegator.clone()), &(delegatee.clone(), count));
+        env.storage().instance().set(
+            &DataKey::DelegatorSlot(delegator.clone()),
+            &(delegatee.clone(), count),
+        );
         env.storage()
             .instance()
             .set(&DataKey::DelegatorCount(delegatee.clone()), &(count + 1));
@@ -1039,9 +1137,10 @@ impl Governance {
                 .instance()
                 .get(&DataKey::Delegator(delegatee.clone(), last_index))
                 .unwrap();
-            env.storage()
-                .instance()
-                .set(&DataKey::Delegator(delegatee.clone(), index), &last_delegator);
+            env.storage().instance().set(
+                &DataKey::Delegator(delegatee.clone(), index),
+                &last_delegator,
+            );
             env.storage().instance().set(
                 &DataKey::DelegatorSlot(last_delegator.clone()),
                 &(delegatee.clone(), index),
@@ -1073,10 +1172,10 @@ impl Governance {
     /// - 3 → 100 bps (1.0%)
     fn fee_tier_to_bps(fee_tier: i128) -> Result<i128, GovernanceError> {
         match fee_tier {
-            0 => Ok(1),      // VeryLow: 0.01%
-            1 => Ok(5),      // Low: 0.05%
-            2 => Ok(30),     // Medium: 0.3%
-            3 => Ok(100),    // High: 1.0%
+            0 => Ok(1),   // VeryLow: 0.01%
+            1 => Ok(5),   // Low: 0.05%
+            2 => Ok(30),  // Medium: 0.3%
+            3 => Ok(100), // High: 1.0%
             _ => Err(GovernanceError::InvalidFeeBps),
         }
     }
@@ -1088,6 +1187,7 @@ impl Governance {
 mod tests {
     use super::*;
     use amm::AmmPool;
+    use soroban_sdk::token::{Client as StellarTokenClient, StellarAssetClient};
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
         Env,
@@ -1418,7 +1518,8 @@ mod tests {
                 e.0 == gov.address && e.1 == (Symbol::new(&s.env, "proposed"),).into_val(&s.env)
             })
             .expect("proposed event not found");
-        let __ver_7: (u32, (u32, Address, ProposalKind, u64, u32)) = proposed_evt.2.into_val(&s.env);
+        let __ver_7: (u32, (u32, Address, ProposalKind, u64, u32)) =
+            proposed_evt.2.into_val(&s.env);
         assert_eq!(__ver_7.0, soroban_amm_sdk::EVENT_SCHEMA_VERSION);
         let proposed_data: (u32, Address, ProposalKind, u64, u32) = __ver_7.1;
         assert_eq!(
@@ -1521,7 +1622,10 @@ mod tests {
 
         // --- 5. Test EmergencyWithdraw proposal ---
         let emergency_rec = Address::generate(&s.env);
-        let pid5 = gov.propose(&lp1, &ProposalKind::EmergencyWithdraw(emergency_rec.clone()));
+        let pid5 = gov.propose(
+            &lp1,
+            &ProposalKind::EmergencyWithdraw(emergency_rec.clone()),
+        );
         gov.vote(&lp1, &pid5, &Vote::For);
         let prop5 = gov.get_proposal(&pid5);
         s.env.ledger().set_timestamp(prop5.execute_after + 1);
@@ -1734,9 +1838,7 @@ mod tests {
             .iter()
             .find(|e| {
                 e.0 == s.gov_addr
-                    && e.1
-                        == (Symbol::new(&s.env, "vote_unlocked"), lp1.clone())
-                            .into_val(&s.env)
+                    && e.1 == (Symbol::new(&s.env, "vote_unlocked"), lp1.clone()).into_val(&s.env)
             })
             .expect("vote_unlocked event not emitted");
 
@@ -1758,10 +1860,12 @@ mod tests {
         mint_lp(&s, &lp1, 600);
         mint_lp(&s, &lp2, 400);
 
+        s.env.ledger().with_mut(|l| l.sequence_number = 10);
         let pid = gov.propose(&lp1, &ProposalKind::UpdateFee(50));
         let proposal = gov.get_proposal(&pid);
 
         // Acquire LP after snapshot — should not increase voting power.
+        s.env.ledger().with_mut(|l| l.sequence_number = 11);
         mint_lp(&s, &buyer, 500);
         assert_eq!(gov.get_snapshot_balance(&pid, &buyer), 0);
         assert!(gov.try_vote(&buyer, &pid, &Vote::For).is_err());
@@ -1915,7 +2019,7 @@ mod prop_tests {
     use proptest::collection;
     use proptest::prelude::*;
     use proptest::test_runner::{Config, TestRunner};
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::{Address, Env};
     use token::LpToken;
 
@@ -1968,13 +2072,17 @@ mod prop_tests {
         );
 
         token::LpTokenClient::new(&env, &lp_addr).set_locker(&gov_addr);
-        PropEnv { env, gov_addr, lp_addr }
+        PropEnv {
+            env,
+            gov_addr,
+            lp_addr,
+        }
     }
 
     // ── Pure math properties ────────────────────────────────────────────────────
 
     proptest! {
-        #![proptest_config = ProptestConfig::with_cases(512)]
+        #![proptest_config(ProptestConfig::with_cases(512))]
 
         /// Quorum threshold never overflows or goes out of bounds.
         #[test]
@@ -2063,7 +2171,10 @@ mod prop_tests {
 
     #[test]
     fn prop_voting_power_conservation() {
-        let mut runner = TestRunner::new(Config { cases: 256, ..Config::default() });
+        let mut runner = TestRunner::new(Config {
+            cases: 256,
+            ..Config::default()
+        });
 
         let strategy = collection::vec((1i128..10_000, 0..4i8), 2..=8);
 
@@ -2107,7 +2218,7 @@ mod prop_tests {
                     }
                     let locked = lp.locked_balance(&holders[i]);
                     prop_assert_eq!(locked, *amt,
-                        "locked balance should equal voting power: voter={i}, locked={locked}, power={amt}");
+                        "locked balance should equal voting power: voter={}, locked={}, power={}", i, locked, amt);
                 }
             }
 
@@ -2138,355 +2249,401 @@ mod prop_tests {
 
     #[test]
     fn prop_delegated_power_conservation() {
-        let mut runner = TestRunner::new(Config { cases: 256, ..Config::default() });
+        let mut runner = TestRunner::new(Config {
+            cases: 256,
+            ..Config::default()
+        });
 
         let strategy = (
             collection::vec(1i128..10_000, 2..=5),
             0..5u32, // delegatee index within voters
         );
 
-        runner.run(&strategy, |(amounts, delegatee_idx)| {
-            let pe = setup_prop_env();
-            let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
-            let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
+        runner
+            .run(&strategy, |(amounts, delegatee_idx)| {
+                let pe = setup_prop_env();
+                let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
+                let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
 
-            let n = amounts.len();
-            let holders: std::vec::Vec<Address> =
-                (0..n).map(|_| Address::generate(&pe.env)).collect();
+                let n = amounts.len();
+                let holders: std::vec::Vec<Address> =
+                    (0..n).map(|_| Address::generate(&pe.env)).collect();
 
-            for (i, amt) in amounts.iter().enumerate() {
-                lp.mint(&holders[i], amt);
-            }
-
-            let delegatee = if (delegatee_idx as usize) < n {
-                (delegatee_idx as usize)
-            } else {
-                0
-            };
-
-            // All non-delegatee holders delegate to delegatee.
-            for (i, _) in amounts.iter().enumerate() {
-                if i != delegatee {
-                    gov.delegate(&holders[i], &holders[delegatee]);
-                }
-            }
-
-            let proposer = &holders[delegatee];
-            let pid = gov.propose(proposer, &ProposalKind::UpdateFee(50));
-
-            // Delegatee votes with aggregated power.
-            if gov
-                .try_vote(&holders[delegatee], &pid, &Vote::For)
-                .is_ok()
-            {
-                let expected_power: i128 = amounts.iter().sum();
-                let proposal = gov.get_proposal(&pid);
-                prop_assert_eq!(proposal.votes_for, expected_power,
-                    "delegated power={} != expected={}", proposal.votes_for, expected_power);
-
-                // Delegatee's locked balance equals their own LP (not the whole delegation).
-                let delegatee_locked = lp.locked_balance(&holders[delegatee]);
-                prop_assert_eq!(delegatee_locked, amounts[delegatee],
-                    "delegatee locked should equal own balance");
-
-                // Delegators' LPs should also be locked.
                 for (i, amt) in amounts.iter().enumerate() {
+                    lp.mint(&holders[i], amt);
+                }
+
+                let delegatee = if (delegatee_idx as usize) < n {
+                    (delegatee_idx as usize)
+                } else {
+                    0
+                };
+
+                // All non-delegatee holders delegate to delegatee.
+                for (i, _) in amounts.iter().enumerate() {
                     if i != delegatee {
-                        let locked = lp.locked_balance(&holders[i]);
-                        prop_assert_eq!(locked, *amt,
-                            "delegator {i}: locked={locked} != balance={amt}");
+                        gov.delegate(&holders[i], &holders[delegatee]);
                     }
                 }
 
-                // Total supply conservation.
-                let total_supply: i128 = amounts.iter().sum();
-                let total_votes = proposal.votes_for + proposal.votes_against + proposal.votes_abstain;
-                prop_assert!(total_votes <= total_supply,
-                    "total_votes={total_votes} > total_supply={total_supply}");
-            }
+                let proposer = &holders[delegatee];
+                let pid = gov.propose(proposer, &ProposalKind::UpdateFee(50));
 
-            Ok(())
-        })
-        .unwrap();
+                // Delegatee votes with aggregated power.
+                if gov.try_vote(&holders[delegatee], &pid, &Vote::For).is_ok() {
+                    let expected_power: i128 = amounts.iter().sum();
+                    let proposal = gov.get_proposal(&pid);
+                    prop_assert_eq!(
+                        proposal.votes_for,
+                        expected_power,
+                        "delegated power={} != expected={}",
+                        proposal.votes_for,
+                        expected_power
+                    );
+
+                    // Delegatee's locked balance equals their own LP (not the whole delegation).
+                    let delegatee_locked = lp.locked_balance(&holders[delegatee]);
+                    prop_assert_eq!(
+                        delegatee_locked,
+                        amounts[delegatee],
+                        "delegatee locked should equal own balance"
+                    );
+
+                    // Delegators' LPs should also be locked.
+                    for (i, amt) in amounts.iter().enumerate() {
+                        if i != delegatee {
+                            let locked = lp.locked_balance(&holders[i]);
+                            prop_assert_eq!(
+                                locked,
+                                *amt,
+                                "delegator {}: locked={} != balance={}",
+                                i,
+                                locked,
+                                amt
+                            );
+                        }
+                    }
+
+                    // Total supply conservation.
+                    let total_supply: i128 = amounts.iter().sum();
+                    let total_votes =
+                        proposal.votes_for + proposal.votes_against + proposal.votes_abstain;
+                    prop_assert!(
+                        total_votes <= total_supply,
+                        "total_votes={total_votes} > total_supply={total_supply}"
+                    );
+                }
+
+                Ok(())
+            })
+            .unwrap();
     }
 
     // ── Property 3: Vote locking / unlocking consistency ────────────────────────
 
     #[test]
     fn prop_lock_unlock_consistency() {
-        let mut runner = TestRunner::new(Config { cases: 256, ..Config::default() });
+        let mut runner = TestRunner::new(Config {
+            cases: 256,
+            ..Config::default()
+        });
 
         let strategy = collection::vec((1i128..10_000, 1..4i8), 2..=5);
 
-        runner.run(&strategy, |voters| {
-            let pe = setup_prop_env();
-            let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
-            let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
+        runner
+            .run(&strategy, |voters| {
+                let pe = setup_prop_env();
+                let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
+                let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
 
-            let n = voters.len();
-            let holders: std::vec::Vec<Address> =
-                (0..n).map(|_| Address::generate(&pe.env)).collect();
+                let n = voters.len();
+                let holders: std::vec::Vec<Address> =
+                    (0..n).map(|_| Address::generate(&pe.env)).collect();
 
-            for (i, (amt, _)) in voters.iter().enumerate() {
-                lp.mint(&holders[i], amt);
-            }
-
-            let proposer_idx = voters.iter().position(|(a, _)| *a >= 1).unwrap();
-            let pid = gov.propose(&holders[proposer_idx], &ProposalKind::UpdateFee(50));
-
-            // Vote (each voter chooses For/Against/Abstain per their vote_choice)
-            for (i, (amt, vote_choice)) in voters.iter().enumerate() {
-                let choice = match *vote_choice {
-                    1 => Vote::For,
-                    2 => Vote::Against,
-                    _ => Vote::Abstain,
-                };
-                if gov.try_vote(&holders[i], &pid, &choice).is_ok() {
-                    // Immediately after vote: locked == voting power
-                    prop_assert_eq!(lp.locked_balance(&holders[i]), *amt,
-                        "after vote: locked={} != power={}", lp.locked_balance(&holders[i]), *amt);
+                for (i, (amt, _)) in voters.iter().enumerate() {
+                    lp.mint(&holders[i], amt);
                 }
-            }
 
-            // Verify unlocks fail while proposal is active.
-            for (i, _) in voters.iter().enumerate() {
-                if lp.locked_balance(&holders[i]) > 0 {
-                    prop_assert!(
-                        gov.try_unlock_vote(&holders[i], &pid).is_err(),
-                        "unlock should fail while proposal is active"
-                    );
-                }
-            }
+                let proposer_idx = voters.iter().position(|(a, _)| *a >= 1).unwrap();
+                let pid = gov.propose(&holders[proposer_idx], &ProposalKind::UpdateFee(50));
 
-            // Advance past voting + timelock.
-            let proposal = gov.get_proposal(&pid);
-            pe.env
-                .ledger()
-                .set_timestamp(proposal.execute_after + 1);
-
-            // Execute (may succeed or fail depending on quorum/majority).
-            let _ = gov.try_execute(&pid);
-            let status = gov.proposal_status(&pid);
-
-            // Only concluded statuses allow unlock.
-            let can_unlock = matches!(
-                status,
-                ProposalStatus::Executed
-                    | ProposalStatus::Defeated
-                    | ProposalStatus::Expired
-                    | ProposalStatus::Cancelled
-            );
-
-            if can_unlock {
-                for (i, amt) in voters.iter().enumerate() {
-                    let locked_before = lp.locked_balance(&holders[i]);
-                    if locked_before > 0 {
-                        if gov.try_unlock_vote(&holders[i], &pid).is_ok() {
-                            let locked_after = lp.locked_balance(&holders[i]);
-                            prop_assert_eq!(locked_after, 0,
-                                "after unlock: locked should be 0, got {locked_after}");
-                        }
-                    } else {
-                        // Unlock with no locked vote should fail.
-                        prop_assert!(
-                            gov.try_unlock_vote(&holders[i], &pid).is_err(),
-                            "unlock with no locked vote should fail"
+                // Vote (each voter chooses For/Against/Abstain per their vote_choice)
+                for (i, (amt, vote_choice)) in voters.iter().enumerate() {
+                    let choice = match *vote_choice {
+                        1 => Vote::For,
+                        2 => Vote::Against,
+                        _ => Vote::Abstain,
+                    };
+                    if gov.try_vote(&holders[i], &pid, &choice).is_ok() {
+                        // Immediately after vote: locked == voting power
+                        prop_assert_eq!(
+                            lp.locked_balance(&holders[i]),
+                            *amt,
+                            "after vote: locked={} != power={}",
+                            lp.locked_balance(&holders[i]),
+                            *amt
                         );
                     }
                 }
-            } else {
-                let status_name = std::format!("{:?}", status);
-                // Unlock should still fail for non-concluded proposals.
+
+                // Verify unlocks fail while proposal is active.
                 for (i, _) in voters.iter().enumerate() {
                     if lp.locked_balance(&holders[i]) > 0 {
-                        let result = gov.try_unlock_vote(&holders[i], &pid);
-                        prop_assert!(result.is_err(),
-                            "unlock should fail for status={status_name}");
+                        prop_assert!(
+                            gov.try_unlock_vote(&holders[i], &pid).is_err(),
+                            "unlock should fail while proposal is active"
+                        );
                     }
                 }
-            }
 
-            Ok(())
-        })
-        .unwrap();
+                // Advance past voting + timelock.
+                let proposal = gov.get_proposal(&pid);
+                pe.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+                // Execute (may succeed or fail depending on quorum/majority).
+                let _ = gov.try_execute(&pid);
+                let status = gov.proposal_status(&pid);
+
+                // Only concluded statuses allow unlock.
+                let can_unlock = matches!(
+                    status,
+                    ProposalStatus::Executed
+                        | ProposalStatus::Defeated
+                        | ProposalStatus::Expired
+                        | ProposalStatus::Cancelled
+                );
+
+                if can_unlock {
+                    for (i, amt) in voters.iter().enumerate() {
+                        let locked_before = lp.locked_balance(&holders[i]);
+                        if locked_before > 0 {
+                            if gov.try_unlock_vote(&holders[i], &pid).is_ok() {
+                                let locked_after = lp.locked_balance(&holders[i]);
+                                prop_assert_eq!(
+                                    locked_after,
+                                    0,
+                                    "after unlock: locked should be 0, got {}",
+                                    locked_after
+                                );
+                            }
+                        } else {
+                            // Unlock with no locked vote should fail.
+                            prop_assert!(
+                                gov.try_unlock_vote(&holders[i], &pid).is_err(),
+                                "unlock with no locked vote should fail"
+                            );
+                        }
+                    }
+                } else {
+                    let status_name = std::format!("{:?}", status);
+                    // Unlock should still fail for non-concluded proposals.
+                    for (i, _) in voters.iter().enumerate() {
+                        if lp.locked_balance(&holders[i]) > 0 {
+                            let result = gov.try_unlock_vote(&holders[i], &pid);
+                            prop_assert!(
+                                result.is_err(),
+                                "unlock should fail for status={status_name}"
+                            );
+                        }
+                    }
+                }
+
+                Ok(())
+            })
+            .unwrap();
     }
 
     // ── Property 4: Malicious / invalid voting scenarios ────────────────────────
 
     #[test]
     fn prop_malicious_voting_scenarios() {
-        let mut runner = TestRunner::new(Config { cases: 256, ..Config::default() });
+        let mut runner = TestRunner::new(Config {
+            cases: 256,
+            ..Config::default()
+        });
 
         let strategy = collection::vec(1i128..10_000, 3..=6);
 
-        runner.run(&strategy, |amounts| {
-            let pe = setup_prop_env();
-            let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
-            let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
+        runner
+            .run(&strategy, |amounts| {
+                let pe = setup_prop_env();
+                let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
+                let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
 
-            // We need n main holders, plus a zero-balance address, plus 2 delegation
-            // addresses — all minted before the proposal snapshot.
-            let n = amounts.len();
-            let holders: std::vec::Vec<Address> =
-                (0..n + 3).map(|_| Address::generate(&pe.env)).collect();
+                // We need n main holders, plus a zero-balance address, plus 2 delegation
+                // addresses — all minted before the proposal snapshot.
+                let n = amounts.len();
+                let holders: std::vec::Vec<Address> =
+                    (0..n + 3).map(|_| Address::generate(&pe.env)).collect();
 
-            for (i, amt) in amounts.iter().enumerate() {
-                lp.mint(&holders[i], amt);
-            }
-            // Mint LP for delegation addresses so they have snapshot voting power.
-            lp.mint(&holders[n + 1], &1000);
-            lp.mint(&holders[n + 2], &1000);
-
-            let pid = gov.propose(&holders[0], &ProposalKind::UpdateFee(50));
-
-            // ── A: Double vote ──
-            if gov.try_vote(&holders[0], &pid, &Vote::For).is_ok() {
-                let double = gov.try_vote(&holders[0], &pid, &Vote::For);
-                prop_assert!(double.is_err(), "double vote should fail");
-            }
-
-            // ── B: Vote after deadline ──
-            {
-                let proposal = gov.get_proposal(&pid);
-                pe.env.ledger().set_timestamp(proposal.vote_end + 1);
-                let late_vote = gov.try_vote(&holders[1], &pid, &Vote::For);
-                prop_assert!(late_vote.is_err(), "vote after deadline should fail");
-                pe.env.ledger().set_timestamp(1_000_000);
-            }
-
-            // ── C: Vote on non-existent proposal ──
-            {
-                let bad_vote = gov.try_vote(&holders[1], &u32::MAX, &Vote::For);
-                prop_assert!(bad_vote.is_err(), "vote on bad proposal should fail");
-            }
-
-            // ── D: Vote with 0 snapshot balance (holder never minted) ──
-            {
-                let zero_vote = gov.try_vote(&holders[n], &pid, &Vote::For);
-                prop_assert!(zero_vote.is_err(), "vote with 0 balance should fail");
-            }
-
-            // ── E: Self-delegation ──
-            {
-                let self_delegate = gov.try_delegate(&holders[1], &holders[1]);
-                prop_assert!(self_delegate.is_err(), "self-delegation should fail");
-            }
-
-            // ── F: Delegation cycle (a->b, b->a) ──
-            {
-                let a = &holders[n + 1];
-                let b = &holders[n + 2];
-                if gov.try_delegate(a, b).is_ok() {
-                    let cycle = gov.try_delegate(b, a);
-                    prop_assert!(cycle.is_err(), "delegation cycle should fail");
+                for (i, amt) in amounts.iter().enumerate() {
+                    lp.mint(&holders[i], amt);
                 }
-            }
+                // Mint LP for delegation addresses so they have snapshot voting power.
+                lp.mint(&holders[n + 1], &1000);
+                lp.mint(&holders[n + 2], &1000);
 
-            // ── G: Vote while delegated ──
-            {
-                let deleter = &holders[n + 1];
-                let del_target = &holders[n + 2];
-                if gov.try_delegate(deleter, del_target).is_ok() {
-                    let delegated_vote = gov.try_vote(deleter, &pid, &Vote::For);
-                    prop_assert!(delegated_vote.is_err(),
-                        "delegated address should not be able to vote directly");
+                let pid = gov.propose(&holders[0], &ProposalKind::UpdateFee(50));
+
+                // ── A: Double vote ──
+                if gov.try_vote(&holders[0], &pid, &Vote::For).is_ok() {
+                    let double = gov.try_vote(&holders[0], &pid, &Vote::For);
+                    prop_assert!(double.is_err(), "double vote should fail");
                 }
-            }
 
-            // ── H: Unlock without ever voting ──
-            {
-                let unlock_no_vote = gov.try_unlock_vote(&holders[2], &pid);
-                prop_assert!(unlock_no_vote.is_err(),
-                    "unlock without voting should fail");
-            }
+                // ── B: Vote after deadline ──
+                {
+                    let proposal = gov.get_proposal(&pid);
+                    pe.env.ledger().set_timestamp(proposal.vote_end + 1);
+                    let late_vote = gov.try_vote(&holders[1], &pid, &Vote::For);
+                    prop_assert!(late_vote.is_err(), "vote after deadline should fail");
+                    pe.env.ledger().set_timestamp(1_000_000);
+                }
 
-            Ok(())
-        })
-        .unwrap();
+                // ── C: Vote on non-existent proposal ──
+                {
+                    let bad_vote = gov.try_vote(&holders[1], &u32::MAX, &Vote::For);
+                    prop_assert!(bad_vote.is_err(), "vote on bad proposal should fail");
+                }
+
+                // ── D: Vote with 0 snapshot balance (holder never minted) ──
+                {
+                    let zero_vote = gov.try_vote(&holders[n], &pid, &Vote::For);
+                    prop_assert!(zero_vote.is_err(), "vote with 0 balance should fail");
+                }
+
+                // ── E: Self-delegation ──
+                {
+                    let self_delegate = gov.try_delegate(&holders[1], &holders[1]);
+                    prop_assert!(self_delegate.is_err(), "self-delegation should fail");
+                }
+
+                // ── F: Delegation cycle (a->b, b->a) ──
+                {
+                    let a = &holders[n + 1];
+                    let b = &holders[n + 2];
+                    if gov.try_delegate(a, b).is_ok() {
+                        let cycle = gov.try_delegate(b, a);
+                        prop_assert!(cycle.is_err(), "delegation cycle should fail");
+                    }
+                }
+
+                // ── G: Vote while delegated ──
+                {
+                    let deleter = &holders[n + 1];
+                    let del_target = &holders[n + 2];
+                    if gov.try_delegate(deleter, del_target).is_ok() {
+                        let delegated_vote = gov.try_vote(deleter, &pid, &Vote::For);
+                        prop_assert!(
+                            delegated_vote.is_err(),
+                            "delegated address should not be able to vote directly"
+                        );
+                    }
+                }
+
+                // ── H: Unlock without ever voting ──
+                {
+                    let unlock_no_vote = gov.try_unlock_vote(&holders[2], &pid);
+                    prop_assert!(unlock_no_vote.is_err(), "unlock without voting should fail");
+                }
+
+                Ok(())
+            })
+            .unwrap();
     }
 
     // ── Property 5: Post-execution unlock guarantees ────────────────────────────
 
     #[test]
     fn prop_post_execution_unlock_recovers_all_locked_tokens() {
-        let mut runner = TestRunner::new(Config { cases: 256, ..Config::default() });
+        let mut runner = TestRunner::new(Config {
+            cases: 256,
+            ..Config::default()
+        });
 
         let strategy = collection::vec((1i128..5_000, 1..4i8), 2..=5);
 
-        runner.run(&strategy, |voters| {
-            let pe = setup_prop_env();
-            let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
-            let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
+        runner
+            .run(&strategy, |voters| {
+                let pe = setup_prop_env();
+                let gov = GovernanceClient::new(&pe.env, &pe.gov_addr);
+                let lp = token::LpTokenClient::new(&pe.env, &pe.lp_addr);
 
-            let n = voters.len();
-            let holders: std::vec::Vec<Address> =
-                (0..n).map(|_| Address::generate(&pe.env)).collect();
-
-            for (i, (amt, _)) in voters.iter().enumerate() {
-                lp.mint(&holders[i], amt);
-            }
-
-            let proposer_idx = voters.iter().position(|(a, _)| *a >= 1).unwrap();
-            let pid = gov.propose(&holders[proposer_idx], &ProposalKind::UpdateFee(50));
-
-            for (i, (_, vote_choice)) in voters.iter().enumerate() {
-                let choice = match *vote_choice {
-                    1 => Vote::For,
-                    2 => Vote::Against,
-                    _ => Vote::Abstain,
-                };
-                let _ = gov.try_vote(&holders[i], &pid, &choice);
-            }
-
-            // Advance time and try to execute.
-            let proposal = gov.get_proposal(&pid);
-            pe.env.ledger().set_timestamp(proposal.execute_after + 1);
-            let _ = gov.try_execute(&pid);
-            let status = gov.proposal_status(&pid);
-
-            let can_unlock = matches!(
-                status,
-                ProposalStatus::Executed
-                    | ProposalStatus::Defeated
-                    | ProposalStatus::Expired
-                    | ProposalStatus::Cancelled
-            );
-
-            if can_unlock {
-                let mut total_locked_before: i128 = 0;
-                let mut total_locked_after: i128 = 0;
+                let n = voters.len();
+                let holders: std::vec::Vec<Address> =
+                    (0..n).map(|_| Address::generate(&pe.env)).collect();
 
                 for (i, (amt, _)) in voters.iter().enumerate() {
-                    let locked_before = lp.locked_balance(&holders[i]);
-                    total_locked_before += locked_before;
-                    if locked_before > 0 {
-                        // Balance before unlock = balance - locked (locked unavailable for transfer).
-                        let bal_before = lp.balance(&holders[i]);
-
-                        let _ = gov.try_unlock_vote(&holders[i], &pid);
-
-                        let locked_after = lp.locked_balance(&holders[i]);
-                        total_locked_after += locked_after;
-
-                        // After unlock: user should be able to transfer their full balance.
-                        if locked_before > 0 && locked_after == 0 {
-                            // Attempt to transfer the originally locked amount to a fresh address.
-                            let recipient = Address::generate(&pe.env);
-                            let transfer_result =
-                                lp.try_transfer(&holders[i], &recipient, &locked_before);
-                            prop_assert!(transfer_result.is_ok(),
-                                "should be able to transfer unlocked tokens");
-                        }
-                    }
+                    lp.mint(&holders[i], amt);
                 }
 
-                // After all unlocks, total locked should be 0 for concluded proposals.
-                prop_assert_eq!(total_locked_after, 0,
-                    "total locked after all unlocks should be 0, got {total_locked_after}");
-            }
+                let proposer_idx = voters.iter().position(|(a, _)| *a >= 1).unwrap();
+                let pid = gov.propose(&holders[proposer_idx], &ProposalKind::UpdateFee(50));
 
-            Ok(())
-        })
-        .unwrap();
+                for (i, (_, vote_choice)) in voters.iter().enumerate() {
+                    let choice = match *vote_choice {
+                        1 => Vote::For,
+                        2 => Vote::Against,
+                        _ => Vote::Abstain,
+                    };
+                    let _ = gov.try_vote(&holders[i], &pid, &choice);
+                }
+
+                // Advance time and try to execute.
+                let proposal = gov.get_proposal(&pid);
+                pe.env.ledger().set_timestamp(proposal.execute_after + 1);
+                let _ = gov.try_execute(&pid);
+                let status = gov.proposal_status(&pid);
+
+                let can_unlock = matches!(
+                    status,
+                    ProposalStatus::Executed
+                        | ProposalStatus::Defeated
+                        | ProposalStatus::Expired
+                        | ProposalStatus::Cancelled
+                );
+
+                if can_unlock {
+                    let mut total_locked_before: i128 = 0;
+                    let mut total_locked_after: i128 = 0;
+
+                    for (i, (amt, _)) in voters.iter().enumerate() {
+                        let locked_before = lp.locked_balance(&holders[i]);
+                        total_locked_before += locked_before;
+                        if locked_before > 0 {
+                            // Balance before unlock = balance - locked (locked unavailable for transfer).
+                            let bal_before = lp.balance(&holders[i]);
+
+                            let _ = gov.try_unlock_vote(&holders[i], &pid);
+
+                            let locked_after = lp.locked_balance(&holders[i]);
+                            total_locked_after += locked_after;
+
+                            // After unlock: user should be able to transfer their full balance.
+                            if locked_before > 0 && locked_after == 0 {
+                                // Attempt to transfer the originally locked amount to a fresh address.
+                                let recipient = Address::generate(&pe.env);
+                                let transfer_result =
+                                    lp.try_transfer(&holders[i], &recipient, &locked_before);
+                                prop_assert!(
+                                    transfer_result.is_ok(),
+                                    "should be able to transfer unlocked tokens"
+                                );
+                            }
+                        }
+                    }
+
+                    // After all unlocks, total locked should be 0 for concluded proposals.
+                    prop_assert_eq!(
+                        total_locked_after,
+                        0,
+                        "total locked after all unlocks should be 0, got {}",
+                        total_locked_after
+                    );
+                }
+
+                Ok(())
+            })
+            .unwrap();
     }
 }

--- a/contracts/router/src/lib.rs
+++ b/contracts/router/src/lib.rs
@@ -71,7 +71,6 @@ impl Router {
                 &current_amount,
                 &hop_min_out,
                 &deadline,
-                &None,
             );
         }
 

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -5,9 +5,11 @@
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec};
 
 // Export compiled WASM for tests/dev usage when the `testutils` feature is enabled.
-// When tests run, the WASM file may not exist; use empty slice to avoid error.
 #[cfg(feature = "testutils")]
-pub const WASM: &[u8] = &[];
+pub const WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/wasm32v1-none/release/token.wasm"
+));
 
 #[contracttype]
 pub enum DataKey {

--- a/contracts/v2_to_v3_migration/src/lib.rs
+++ b/contracts/v2_to_v3_migration/src/lib.rs
@@ -200,9 +200,8 @@ impl MigrationContract {
         let token_b = pool_info.token_b.clone();
 
         // Remove liquidity from V2; tokens land in provider's wallet.
-        let (received_a, received_b) = v2_client
-            .remove_liquidity(&provider, &v2_shares, &min_a, &min_b, &deadline)
-            .map_err(|_| MigrationError::MigrationFailed)?;
+        let (received_a, received_b) =
+            v2_client.remove_liquidity(&provider, &v2_shares, &min_a, &min_b, &deadline);
 
         // ── Step 2: compute optimal V3 tick range ────────────────────────────
         let v3_client = V3PoolClient::new(&env, &v3_pool);
@@ -222,18 +221,16 @@ impl MigrationContract {
         ta_client.approve(&contract_addr, &v3_pool, &received_a, &200u32);
         tb_client.approve(&contract_addr, &v3_pool, &received_b, &200u32);
 
-        let position_id = v3_client
-            .add_liquidity_range(
-                &contract_addr,
-                &received_a,
-                &received_b,
-                &final_tick_lower,
-                &final_tick_upper,
-                &min_v3_shares,
-                &deadline,
-                &true, // fee_discount: migration incentive
-            )
-            .map_err(|_| MigrationError::MigrationFailed)?;
+        let position_id = v3_client.add_liquidity_range(
+            &contract_addr,
+            &received_a,
+            &received_b,
+            &final_tick_lower,
+            &final_tick_upper,
+            &min_v3_shares,
+            &deadline,
+            &true, // fee_discount: migration incentive
+        );
 
         // ── Step 4: refund leftover dust to provider ──────────────────────────
         let refund_a = ta_client.balance(&contract_addr);


### PR DESCRIPTION
closes #322 
Summary:
Adds factory-level treasury protocol fee management and permissionless fee sweeping.

Changes include:
- Store treasury address and global protocol fee bps in the factory.
- Add global fee propagation across factory-administered pools.
- Add paginated global fee sync for large pool registries.
- Add permissionless token-specific fee sweeping to the configured treasury.
- Update governance execution to call the paginated factory global-fee sync path.
- Add coverage for zero-fee sweep no-op, multi-pool aggregation, treasury sync, and governance proposal flow.
- 
Reasons:
Protocol fees were previously fragmented across pools and required per-pool management. This change centralizes treasury routing and lets anyone trigger fee collection while preserving trustless forwarding to the configured treasury.