### PR TITLE
feat(amm): standardize flash loan callback

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -10,7 +10,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracterror, contracttype, symbol_short, Address,
+    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, Address,
     Bytes, BytesN, Env, Symbol,
 };
 // Export compiled WASM for tests/dev usage when the `testutils` feature is enabled.
@@ -59,35 +59,37 @@ pub trait LpTokenInterface {
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum AmmError {
-    AlreadyInitialized   = 1,
-    InvalidFeeBps        = 2,
-    InsufficientShares   = 3,
-    DeadlineExceeded     = 4,
-    SlippageExceeded     = 5,
-    Paused               = 6,
-    Unauthorized         = 7,
-    ZeroAmount           = 8,
-    InvalidToken         = 9,
-    EmptyPool            = 10,
+    AlreadyInitialized = 1,
+    InvalidFeeBps = 2,
+    InsufficientShares = 3,
+    DeadlineExceeded = 4,
+    SlippageExceeded = 5,
+    Paused = 6,
+    Unauthorized = 7,
+    ZeroAmount = 8,
+    InvalidToken = 9,
+    EmptyPool = 10,
     InsufficientLiquidity = 11,
-    NoPendingAdmin       = 12,
-    WrongAdmin           = 13,
+    NoPendingAdmin = 12,
+    WrongAdmin = 13,
     /// A reentrant call was detected while a flash loan or state-mutating
     /// operation was already in progress. The receiver contract must not
     /// call back into this pool during an `on_flash_loan` callback.
-    Reentrant            = 14,
+    Reentrant = 14,
     /// The circuit breaker tripped: spot price deviated more than the
     /// configured threshold in a single block.  The pool has been
     /// automatically paused.  Recovery requires the cooldown period to
     /// elapse and a call to `try_circuit_breaker_recovery`, or a direct
     /// admin/governance `unpause`.
-    CircuitBreaker       = 15,
+    CircuitBreaker = 15,
     /// A fee-on-transfer token deducted more fees than the caller's
     /// `min_received` threshold permitted. The pool received fewer tokens
     /// than requested; the call is reverted to protect the caller.
-    FotSlippage          = 16,
+    FotSlippage = 16,
     /// Spot price deviated beyond the configured oracle tolerance.
     OracleDeviationExceeded = 17,
+    /// Flash-loan receiver did not return the borrowed amounts plus fees.
+    FlashLoanRepaymentFailed = 18,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -207,16 +209,11 @@ pub struct MultisigProposal {
 
 #[contractclient(name = "FlashLoanReceiverClient")]
 pub trait FlashLoanReceiver {
-    fn on_flash_loan(env: Env, token: Address, amount: i128, fee: i128, data: Bytes) -> bool;
-}
-
-#[contractclient(name = "FlashLoanBothReceiverClient")]
-pub trait FlashLoanBothReceiver {
-    fn on_flash_loan_both(
+    fn on_flash_loan(
         env: Env,
-        amount_a: i128,
+        token_a_amount: i128,
+        token_b_amount: i128,
         fee_a: i128,
-        amount_b: i128,
         fee_b: i128,
         data: Bytes,
     ) -> bool;
@@ -363,12 +360,17 @@ impl AmmPool {
         // Issue #292: LP rebate disabled by default.
         env.storage().instance().set(&DataKey::LpRebateBps, &0_i128);
         // Issue #293: multisig disabled by default (empty signers, quorum 0).
-        env.storage().instance().set(&DataKey::MultisigQuorum, &0_u32);
         env.storage()
             .instance()
-            .set(&DataKey::MultisigSigners, &soroban_sdk::Vec::<Address>::new(&env));
+            .set(&DataKey::MultisigQuorum, &0_u32);
+        env.storage().instance().set(
+            &DataKey::MultisigSigners,
+            &soroban_sdk::Vec::<Address>::new(&env),
+        );
         // Issue #294: minimum liquidity not yet locked.
-        env.storage().instance().set(&DataKey::MinLiquidityLocked, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinLiquidityLocked, &false);
         // Circuit breaker: default threshold 50 % (5 000 bps), cooldown 600 s.
         env.storage()
             .instance()
@@ -472,12 +474,18 @@ impl AmmPool {
 
         // Transfer reserves to recipient
         if reserve_a > 0 {
-            SepTokenClient::new(&env, &token_a)
-                .transfer(&env.current_contract_address(), &to, &reserve_a);
+            SepTokenClient::new(&env, &token_a).transfer(
+                &env.current_contract_address(),
+                &to,
+                &reserve_a,
+            );
         }
         if reserve_b > 0 {
-            SepTokenClient::new(&env, &token_b)
-                .transfer(&env.current_contract_address(), &to, &reserve_b);
+            SepTokenClient::new(&env, &token_b).transfer(
+                &env.current_contract_address(),
+                &to,
+                &reserve_b,
+            );
         }
 
         // Zero out reserves
@@ -485,7 +493,11 @@ impl AmmPool {
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
 
         // Emit event for audit trail
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "emergency_withdraw"), admin.clone()), (to, reserve_a, reserve_b));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "emergency_withdraw"), admin.clone()),
+            (to, reserve_a, reserve_b)
+        );
 
         Ok(())
     }
@@ -533,7 +545,11 @@ impl AmmPool {
             .instance()
             .set(&DataKey::CircuitBreakerCooldown, &cooldown_secs);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "cb_config"),), (threshold_bps, cooldown_secs));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "cb_config"),),
+            (threshold_bps, cooldown_secs)
+        );
 
         Ok(())
     }
@@ -673,7 +689,11 @@ impl AmmPool {
                 .instance()
                 .set(&DataKey::CircuitBreakerTriggeredAt, &now);
 
-            soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "circuit_break"),), (baseline_price, current_price, deviation_bps, threshold_bps));
+            soroban_amm_sdk::emit_versioned_event!(
+                env,
+                (Symbol::new(env, "circuit_break"),),
+                (baseline_price, current_price, deviation_bps, threshold_bps)
+            );
 
             return Err(AmmError::CircuitBreaker);
         }
@@ -685,7 +705,12 @@ impl AmmPool {
     ///
     /// Set `protocol_fee_bps` to 0 to disable protocol fee collection.
     /// `protocol_fee_bps` must be ≤ the pool's `fee_bps`.
-    pub fn set_protocol_fee(env: Env, admin: Address, recipient: Address, protocol_fee_bps: i128) -> Result<(), AmmError> {
+    pub fn set_protocol_fee(
+        env: Env,
+        admin: Address,
+        recipient: Address,
+        protocol_fee_bps: i128,
+    ) -> Result<(), AmmError> {
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
             return Err(AmmError::Unauthorized);
@@ -736,7 +761,11 @@ impl AmmPool {
         env.storage()
             .instance()
             .set(&DataKey::LpRebateBps, &lp_rebate_bps);
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "lp_rebate_set"), admin), (lp_rebate_bps,));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "lp_rebate_set"), admin),
+            (lp_rebate_bps,)
+        );
         Ok(())
     }
 
@@ -776,13 +805,19 @@ impl AmmPool {
             .instance()
             .set(&DataKey::MultisigQuorum, &quorum);
         // Clear any pending proposal when config changes.
-        env.storage()
-            .instance()
-            .set(&DataKey::MultisigProposalRecipient, &Option::<Address>::None);
-        env.storage()
-            .instance()
-            .set(&DataKey::MultisigProposalApprovals, &soroban_sdk::Vec::<Address>::new(&env));
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "multisig_set"), admin), (quorum,));
+        env.storage().instance().set(
+            &DataKey::MultisigProposalRecipient,
+            &Option::<Address>::None,
+        );
+        env.storage().instance().set(
+            &DataKey::MultisigProposalApprovals,
+            &soroban_sdk::Vec::<Address>::new(&env),
+        );
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "multisig_set"), admin),
+            (quorum,)
+        );
         Ok(())
     }
 
@@ -847,13 +882,18 @@ impl AmmPool {
         if !approvals.contains(&signer) {
             approvals.push_back(signer.clone());
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::MultisigProposalRecipient, &Some(recipient.clone()));
+        env.storage().instance().set(
+            &DataKey::MultisigProposalRecipient,
+            &Some(recipient.clone()),
+        );
         env.storage()
             .instance()
             .set(&DataKey::MultisigProposalApprovals, &approvals);
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "ms_proposed"), signer), (recipient, approvals.len()));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "ms_proposed"), signer),
+            (recipient, approvals.len())
+        );
         Ok(())
     }
 
@@ -877,10 +917,7 @@ impl AmmPool {
     /// Execute the pending multisig emergency withdrawal once quorum is reached.
     ///
     /// Any signer may call this after enough approvals have been collected.
-    pub fn exec_multisig_emergency_wd(
-        env: Env,
-        signer: Address,
-    ) -> Result<(), AmmError> {
+    pub fn exec_multisig_emergency_wd(env: Env, signer: Address) -> Result<(), AmmError> {
         signer.require_auth();
         let quorum: u32 = env
             .storage()
@@ -909,7 +946,7 @@ impl AmmPool {
             .instance()
             .get(&DataKey::MultisigProposalApprovals)
             .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
-        if (approvals.len() as u32) < quorum {
+        if approvals.len() < quorum {
             return Err(AmmError::InsufficientShares);
         }
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
@@ -917,23 +954,35 @@ impl AmmPool {
         let reserve_a = Self::get_reserve_a(env.clone());
         let reserve_b = Self::get_reserve_b(env.clone());
         if reserve_a > 0 {
-            SepTokenClient::new(&env, &token_a)
-                .transfer(&env.current_contract_address(), &to, &reserve_a);
+            SepTokenClient::new(&env, &token_a).transfer(
+                &env.current_contract_address(),
+                &to,
+                &reserve_a,
+            );
         }
         if reserve_b > 0 {
-            SepTokenClient::new(&env, &token_b)
-                .transfer(&env.current_contract_address(), &to, &reserve_b);
+            SepTokenClient::new(&env, &token_b).transfer(
+                &env.current_contract_address(),
+                &to,
+                &reserve_b,
+            );
         }
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
         // Clear proposal.
-        env.storage()
-            .instance()
-            .set(&DataKey::MultisigProposalRecipient, &Option::<Address>::None);
-        env.storage()
-            .instance()
-            .set(&DataKey::MultisigProposalApprovals, &soroban_sdk::Vec::<Address>::new(&env));
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "ms_ew"), signer), (to, reserve_a, reserve_b));
+        env.storage().instance().set(
+            &DataKey::MultisigProposalRecipient,
+            &Option::<Address>::None,
+        );
+        env.storage().instance().set(
+            &DataKey::MultisigProposalApprovals,
+            &soroban_sdk::Vec::<Address>::new(&env),
+        );
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "ms_ew"), signer),
+            (to, reserve_a, reserve_b)
+        );
         Ok(())
     }
 
@@ -958,8 +1007,8 @@ impl AmmPool {
             .get(&DataKey::MaxOracleDeviationBps)
             .unwrap_or(500);
 
-        let agg = OracleAggregatorClient::new(env, &oracle_addr)
-            .get_price_safe(token_in, token_out);
+        let agg =
+            OracleAggregatorClient::new(env, &oracle_addr).get_price_safe(token_in, token_out);
         if amount_in <= 0 || agg.confidence == 0 || agg.price <= 0 {
             return Ok(());
         }
@@ -1024,7 +1073,11 @@ impl AmmPool {
         env.storage()
             .instance()
             .set(&DataKey::FlashLoanFeeBps, &new_fee_bps);
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "flash_fee_upd"), admin.clone()), (new_fee_bps,));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "flash_fee_upd"), admin.clone()),
+            (new_fee_bps,)
+        );
         Ok(())
     }
 
@@ -1033,7 +1086,11 @@ impl AmmPool {
     /// # Panics
     /// - If `current_admin` is not the stored admin.
     /// - If `current_admin` auth fails.
-    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), AmmError> {
+    pub fn propose_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), AmmError> {
         let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if current_admin != stored {
             return Err(AmmError::Unauthorized);
@@ -1042,7 +1099,11 @@ impl AmmPool {
         env.storage()
             .instance()
             .set(&DataKey::PendingAdmin, &Some(new_admin.clone()));
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "admin_nominated"),), (current_admin, new_admin));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "admin_nominated"),),
+            (current_admin, new_admin)
+        );
         Ok(())
     }
 
@@ -1250,7 +1311,7 @@ impl AmmPool {
             return Err(AmmError::ZeroAmount);
         }
 
-       // Checkpoint TWAP before updating reserves; reuse the reserves it read.
+        // Checkpoint TWAP before updating reserves; reuse the reserves it read.
         let (reserve_a, reserve_b) = Self::checkpoint_twap(&env);
         // Checkpoint oracles before updating reserves.
         Self::checkpoint_oracles(&env);
@@ -1326,7 +1387,11 @@ impl AmmPool {
         }
         lp_client.mint(&provider, &shares_to_provider);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "add_liquidity"), provider), (amount_a, amount_b, shares_to_provider));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "add_liquidity"), provider),
+            (amount_a, amount_b, shares_to_provider)
+        );
 
         Ok(shares_to_provider)
     }
@@ -1394,7 +1459,6 @@ impl AmmPool {
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
         let lp_token: Address = env.storage().instance().get(&DataKey::LpToken).unwrap();
 
-        
         let total_shares = Self::get_total_shares(env.clone());
 
         let out_a = shares * reserve_a / total_shares;
@@ -1425,7 +1489,11 @@ impl AmmPool {
         client_a.transfer(&env.current_contract_address(), &provider, &out_a);
         client_b.transfer(&env.current_contract_address(), &provider, &out_b);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (symbol_short!("rm_liq"),), (provider.clone(), shares, out_a, out_b));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (symbol_short!("rm_liq"),),
+            (provider.clone(), shares, out_a, out_b)
+        );
 
         Ok((out_a, out_b))
     }
@@ -1631,7 +1699,11 @@ impl AmmPool {
         let client_out = SepTokenClient::new(&env, &token_out);
         client_out.transfer(&env.current_contract_address(), &provider, &total_out);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (symbol_short!("rm_liq_1s"),), (provider.clone(), shares, token_out.clone(), total_out));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (symbol_short!("rm_liq_1s"),),
+            (provider.clone(), shares, token_out.clone(), total_out)
+        );
 
         Ok(total_out)
     }
@@ -1689,7 +1761,7 @@ impl AmmPool {
             return Err(AmmError::ZeroAmount);
         }
 
-// Checkpoint TWAP before updating reserves; reuse the reserves it read.
+        // Checkpoint TWAP before updating reserves; reuse the reserves it read.
         let (reserve_a, reserve_b) = Self::checkpoint_twap(&env);
         // Checkpoint oracles before updating reserves.
         Self::checkpoint_oracles(&env);
@@ -1762,9 +1834,10 @@ impl AmmPool {
         let net_protocol_fee = protocol_fee - lp_rebate;
         // Update reserves (net protocol fee held outside LP reserves; rebate stays in reserves).
         if token_in == token_a {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveA, &(reserve_in + amount_in - net_protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveA,
+                &(reserve_in + amount_in - net_protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveB, &(reserve_out - amount_out));
@@ -1779,9 +1852,10 @@ impl AmmPool {
                     .set(&DataKey::AccruedFeeA, &(accrued + net_protocol_fee));
             }
         } else {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveB, &(reserve_in + amount_in - net_protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveB,
+                &(reserve_in + amount_in - net_protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveA, &(reserve_out - amount_out));
@@ -1801,7 +1875,11 @@ impl AmmPool {
             (Symbol::new(&env, "swap"), trader.clone()),
             (token_in.clone(), amount_in, token_out.clone(), amount_out),
         );
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "swap"), trader), (token_in, amount_in, token_out, amount_out, None::<Address>));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "swap"), trader),
+            (token_in, amount_in, token_out, amount_out, None::<Address>)
+        );
 
         Ok(amount_out)
     }
@@ -1834,7 +1912,6 @@ impl AmmPool {
         amount_out: i128,
         max_in: i128,
         deadline: u64,
-        
     ) -> Result<i128, AmmError> {
         if deadline < env.ledger().timestamp() {
             return Err(AmmError::DeadlineExceeded);
@@ -1915,9 +1992,10 @@ impl AmmPool {
 
         // Update reserves (net protocol fee held outside LP reserves; rebate stays in reserves).
         if token_in == token_a {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveA, &(reserve_a + amount_in - net_protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveA,
+                &(reserve_a + amount_in - net_protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveB, &(reserve_b - amount_out));
@@ -1932,9 +2010,10 @@ impl AmmPool {
                     .set(&DataKey::AccruedFeeA, &(accrued + net_protocol_fee));
             }
         } else {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveB, &(reserve_b + amount_in - net_protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveB,
+                &(reserve_b + amount_in - net_protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveA, &(reserve_a - amount_out));
@@ -1954,7 +2033,11 @@ impl AmmPool {
             (Symbol::new(&env, "swap"), trader.clone()),
             (token_in.clone(), amount_in, token_out.clone(), amount_out),
         );
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "swap"), trader), (token_in, amount_in, token_out, amount_out, None::<Address>));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "swap"), trader),
+            (token_in, amount_in, token_out, amount_out, None::<Address>)
+        );
 
         Ok(amount_in)
     }
@@ -2020,14 +2103,14 @@ impl AmmPool {
     pub fn flash_loan(
         env: Env,
         receiver: Address,
-        token: Address,
-        amount: i128,
+        amount_a: i128,
+        amount_b: i128,
         data: Bytes,
-    ) -> Result<i128, AmmError> {
+    ) -> Result<(i128, i128), AmmError> {
         if Self::is_paused(env.clone()) {
             return Err(AmmError::Paused);
         }
-        if amount <= 0 {
+        if amount_a < 0 || amount_b < 0 || (amount_a == 0 && amount_b == 0) {
             return Err(AmmError::ZeroAmount);
         }
 
@@ -2046,72 +2129,79 @@ impl AmmPool {
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
-        let reserve = if token == token_a {
-           reserve_a
-        } else if token == token_b {
-            reserve_b
-        } else {
-            // exit_lock is not needed: returning Err reverts all storage writes.
-            return Err(AmmError::InvalidToken);
-        };
-        if reserve < amount {
+        if reserve_a < amount_a || reserve_b < amount_b {
             return Err(AmmError::InsufficientLiquidity);
         }
 
         let fee_bps = Self::get_flash_loan_fee_bps(env.clone());
-        let fee = if fee_bps > 0 {
-            (amount * fee_bps / 10_000).max(1)
+        let fee_a = if fee_bps > 0 && amount_a > 0 {
+            (amount_a * fee_bps / 10_000).max(1)
+        } else {
+            0
+        };
+        let fee_b = if fee_bps > 0 && amount_b > 0 {
+            (amount_b * fee_bps / 10_000).max(1)
         } else {
             0
         };
         let pool = env.current_contract_address();
-        let token_client = SepTokenClient::new(&env, &token);
-        let balance_before = token_client.balance(&pool);
+        let token_a_client = SepTokenClient::new(&env, &token_a);
+        let token_b_client = SepTokenClient::new(&env, &token_b);
+        let balance_a_before = token_a_client.balance(&pool);
+        let balance_b_before = token_b_client.balance(&pool);
 
-        token_client.transfer(&pool, &receiver, &amount);
+        if amount_a > 0 {
+            token_a_client.transfer(&pool, &receiver, &amount_a);
+        }
+        if amount_b > 0 {
+            token_b_client.transfer(&pool, &receiver, &amount_b);
+        }
 
         // ── External callback (lock is held) ─────────────────────────────────
         // The receiver cannot reenter this pool because Locked == true.
         // Any reentrant call will return AmmError::Reentrant.
         let accepted = FlashLoanReceiverClient::new(&env, &receiver)
-            .on_flash_loan(&token, &amount, &fee, &data);
+            .on_flash_loan(&amount_a, &amount_b, &fee_a, &fee_b, &data);
         if !accepted {
-            return Err(AmmError::InsufficientLiquidity);
+            return Err(AmmError::FlashLoanRepaymentFailed);
         }
 
-        let balance_after = token_client.balance(&pool);
-        if balance_after < balance_before + fee {
-            return Err(AmmError::InsufficientLiquidity);
+        let balance_a_after = token_a_client.balance(&pool);
+        let balance_b_after = token_b_client.balance(&pool);
+        if balance_a_after < balance_a_before + fee_a || balance_b_after < balance_b_before + fee_b
+        {
+            return Err(AmmError::FlashLoanRepaymentFailed);
         }
 
-        let accrued_fee = if token == token_a {
-            env.storage()
-                .instance()
-                .get(&DataKey::AccruedFeeA)
-                .unwrap_or(0)
-        } else {
-            env.storage()
-                .instance()
-                .get(&DataKey::AccruedFeeB)
-                .unwrap_or(0)
-        };
-        let reserve_after = balance_after - accrued_fee;
-        if token == token_a {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveA, &reserve_after);
-        } else {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveB, &reserve_after);
-        }
+        let accrued_fee_a = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccruedFeeA)
+            .unwrap_or(0);
+        let accrued_fee_b = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccruedFeeB)
+            .unwrap_or(0);
+        let reserve_a_after = balance_a_after - accrued_fee_a;
+        let reserve_b_after = balance_b_after - accrued_fee_b;
+        env.storage()
+            .instance()
+            .set(&DataKey::ReserveA, &reserve_a_after);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReserveB, &reserve_b_after);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "flash_loan"), receiver), (token, amount, fee));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "flash_loan"), receiver),
+            (amount_a, amount_b, fee_a, fee_b)
+        );
 
         // Release the lock only on the success path; on error paths Soroban
         // reverts all storage writes (including the lock) automatically.
         Self::exit_lock(&env);
-        Ok(fee)
+        Ok((fee_a, fee_b))
     }
 
     // ── Quotes (read-only) ────────────────────────────────────────────────────
@@ -2184,7 +2274,11 @@ impl AmmPool {
     /// Returns the expected output, total fee taken, effective execution price,
     /// spot price, and price impact — all computed from current reserve state.
     /// `amount_out` is guaranteed to match `get_amount_out` for the same inputs.
-    pub fn simulate_swap(env: Env, token_in: Address, amount_in: i128) -> Result<SwapSimulation, AmmError> {
+    pub fn simulate_swap(
+        env: Env,
+        token_in: Address,
+        amount_in: i128,
+    ) -> Result<SwapSimulation, AmmError> {
         if amount_in <= 0 {
             return Err(AmmError::ZeroAmount);
         }
@@ -2265,7 +2359,6 @@ impl AmmPool {
     /// - `admin` — the pool administrator.
     /// - `fee_recipient` — recipient of accrued protocol fees.
     /// - `protocol_fee_bps` — protocol fee in basis points (subset of `fee_bps`).
-    
     pub fn get_fee_info(env: Env) -> i128 {
         env.storage().instance().get(&DataKey::FeeBps).unwrap()
     }
@@ -2447,9 +2540,10 @@ impl AmmPool {
         };
 
         if token_in == token_a {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveA, &(reserve_in + actual_received - protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveA,
+                &(reserve_in + actual_received - protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveB, &(reserve_out - amount_out));
@@ -2464,9 +2558,10 @@ impl AmmPool {
                     .set(&DataKey::AccruedFeeA, &(accrued + protocol_fee));
             }
         } else {
-            env.storage()
-                .instance()
-                .set(&DataKey::ReserveB, &(reserve_in + actual_received - protocol_fee));
+            env.storage().instance().set(
+                &DataKey::ReserveB,
+                &(reserve_in + actual_received - protocol_fee),
+            );
             env.storage()
                 .instance()
                 .set(&DataKey::ReserveA, &(reserve_out - amount_out));
@@ -2483,10 +2578,18 @@ impl AmmPool {
         }
 
         if actual_received < amount_in {
-            soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "fot_detected"), token_in.clone()), (amount_in, actual_received));
+            soroban_amm_sdk::emit_versioned_event!(
+                env,
+                (Symbol::new(&env, "fot_detected"), token_in.clone()),
+                (amount_in, actual_received)
+            );
         }
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "swap"), trader), (token_in, actual_received, token_out, amount_out, referrer));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "swap"), trader),
+            (token_in, actual_received, token_out, amount_out, referrer)
+        );
 
         Ok((amount_out, actual_received))
     }
@@ -2583,7 +2686,11 @@ impl AmmPool {
 
         LpTokenClient::new(&env, &lp_token).mint(&provider, &shares);
 
-        soroban_amm_sdk::emit_versioned_event!(env, (Symbol::new(&env, "add_liquidity"), provider), (actual_a, actual_b, shares));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "add_liquidity"), provider),
+            (actual_a, actual_b, shares)
+        );
 
         Ok(shares)
     }
@@ -2686,23 +2793,38 @@ pub(crate) mod tests {
     #[contracttype]
     enum ReceiverDataKey {
         Amm,
+        TokenA,
+        TokenB,
         ShouldRepay,
     }
     #[contract]
     pub(crate) struct MockFlashLoanReceiver;
     #[contractimpl]
     impl MockFlashLoanReceiver {
-        pub fn initialize(env: Env, amm: Address, should_repay: bool) {
+        pub fn initialize(
+            env: Env,
+            amm: Address,
+            token_a: Address,
+            token_b: Address,
+            should_repay: bool,
+        ) {
             env.storage().instance().set(&ReceiverDataKey::Amm, &amm);
+            env.storage()
+                .instance()
+                .set(&ReceiverDataKey::TokenA, &token_a);
+            env.storage()
+                .instance()
+                .set(&ReceiverDataKey::TokenB, &token_b);
             env.storage()
                 .instance()
                 .set(&ReceiverDataKey::ShouldRepay, &should_repay);
         }
         pub fn on_flash_loan(
             env: Env,
-            token: Address,
-            amount: i128,
-            fee: i128,
+            amount_a: i128,
+            amount_b: i128,
+            fee_a: i128,
+            fee_b: i128,
             _data: Bytes,
         ) -> bool {
             let should_repay = env
@@ -2712,8 +2834,30 @@ pub(crate) mod tests {
                 .unwrap_or(false);
             if should_repay {
                 let amm: Address = env.storage().instance().get(&ReceiverDataKey::Amm).unwrap();
-                let token_client = SepTokenClient::new(&env, &token);
-                token_client.transfer(&env.current_contract_address(), &amm, &(amount + fee));
+                let token_a: Address = env
+                    .storage()
+                    .instance()
+                    .get(&ReceiverDataKey::TokenA)
+                    .unwrap();
+                let token_b: Address = env
+                    .storage()
+                    .instance()
+                    .get(&ReceiverDataKey::TokenB)
+                    .unwrap();
+                if amount_a > 0 || fee_a > 0 {
+                    SepTokenClient::new(&env, &token_a).transfer(
+                        &env.current_contract_address(),
+                        &amm,
+                        &(amount_a + fee_a),
+                    );
+                }
+                if amount_b > 0 || fee_b > 0 {
+                    SepTokenClient::new(&env, &token_b).transfer(
+                        &env.current_contract_address(),
+                        &amm,
+                        &(amount_b + fee_b),
+                    );
+                }
             }
             true
         }
@@ -3549,7 +3693,8 @@ pub(crate) mod tests {
         let swap_event = events
             .iter()
             .find(|e| {
-                e.0 == amm.address && e.1 == (Symbol::new(env, "swap"), trader.clone()).into_val(env)
+                e.0 == amm.address
+                    && e.1 == (Symbol::new(env, "swap"), trader.clone()).into_val(env)
             })
             .expect("swap event not found");
 
@@ -4126,7 +4271,13 @@ pub(crate) mod tests {
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &1_000_000_i128);
         tb_sac.mint(&provider, &1_000_000_i128);
-        amm.add_liquidity(&provider, &1_000_000_i128, &1_000_000_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(
+            &provider,
+            &1_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
 
         let trader = Address::generate(env);
         ta_sac.mint(&trader, &100_000_i128);
@@ -4150,7 +4301,13 @@ pub(crate) mod tests {
         let seeder = Address::generate(env);
         ta_sac.mint(&seeder, &1_000_000_i128);
         tb_sac.mint(&seeder, &1_000_000_i128);
-        amm.add_liquidity(&seeder, &1_000_000_i128, &1_000_000_i128, &0_i128, &u64::MAX);
+        amm.add_liquidity(
+            &seeder,
+            &1_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
 
         let provider = Address::generate(env);
         ta_sac.mint(&provider, &500_000_i128);
@@ -4274,26 +4431,26 @@ mod prop_tests {
 
         let receiver_addr = env.register_contract(None, MockFlashLoanReceiver);
         let receiver = MockFlashLoanReceiverClient::new(&env, &receiver_addr);
-        receiver.initialize(&amm_addr, &true);
+        receiver.initialize(&amm_addr, &ta_client.address, &tb_client.address, &true);
 
         ta_sac.mint(&receiver_addr, &1_000_i128);
+        tb_sac.mint(&receiver_addr, &1_000_i128);
 
-        let fee = amm.flash_loan(
+        let fees = amm.flash_loan(
             &receiver_addr,
-            &ta_client.address,
             &100_000_i128,
+            &50_000_i128,
             &Bytes::new(&env),
         );
-        assert_eq!(fee, 500);
+        assert_eq!(fees, (500, 250));
 
         let info = amm.get_info();
         assert_eq!(info.reserve_a, 1_000_500);
-        assert_eq!(info.reserve_b, 1_000_000);
+        assert_eq!(info.reserve_b, 1_000_250);
         assert_eq!(info.flash_loan_fee_bps, 50);
     }
 
     #[test]
-    #[should_panic]
     fn test_flash_loan_failed_repayment_panics() {
         let (env, admin, amm_addr, lp_addr, _) = setup();
 
@@ -4324,14 +4481,10 @@ mod prop_tests {
 
         let receiver_addr = env.register_contract(None, MockFlashLoanReceiver);
         let receiver = MockFlashLoanReceiverClient::new(&env, &receiver_addr);
-        receiver.initialize(&amm_addr, &false);
+        receiver.initialize(&amm_addr, &ta_client.address, &tb_client.address, &false);
 
-        amm.flash_loan(
-            &receiver_addr,
-            &ta_client.address,
-            &100_000_i128,
-            &Bytes::new(&env),
-        );
+        let result = amm.try_flash_loan(&receiver_addr, &100_000_i128, &0_i128, &Bytes::new(&env));
+        assert_eq!(result, Err(Ok(AmmError::FlashLoanRepaymentFailed)));
     }
 
     #[test]
@@ -4353,75 +4506,83 @@ mod prop_tests {
 
         assert_eq!(amm.get_fee_info(), 30_i128);
         assert_eq!(amm.get_fee_info(), amm.get_info().fee_bps);
-     }
+    }
 
-     #[test]
-     fn test_emergency_withdraw() {
-         let (env, admin, amm_addr, lp_addr, _) = setup();
-         let (ta_client, ta_sac) = create_sac(&env, &admin);
-         let (tb_client, tb_sac) = create_sac(&env, &admin);
-         let amm = AmmPoolClient::new(&env, &amm_addr);
+    #[test]
+    fn test_emergency_withdraw() {
+        let (env, admin, amm_addr, lp_addr, _) = setup();
+        let (ta_client, ta_sac) = create_sac(&env, &admin);
+        let (tb_client, tb_sac) = create_sac(&env, &admin);
+        let amm = AmmPoolClient::new(&env, &amm_addr);
 
-         amm.initialize(
-             &admin,
-             &ta_client.address,
-             &tb_client.address,
-             &lp_addr,
-             &30_i128,
-             &admin,
-             &0_i128,
-         );
+        amm.initialize(
+            &admin,
+            &ta_client.address,
+            &tb_client.address,
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &0_i128,
+        );
 
-         let provider = Address::generate(&env);
-         ta_sac.mint(&provider, &2_000_000_i128);
-         tb_sac.mint(&provider, &1_000_000_i128);
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &2_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
 
-         amm.add_liquidity(
-             &provider,
-             &2_000_000_i128,
-             &1_000_000_i128,
-             &0_i128,
-             &u64::MAX,
-         );
+        amm.add_liquidity(
+            &provider,
+            &2_000_000_i128,
+            &1_000_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
 
-         let info_before = amm.get_info();
-         assert_eq!(info_before.reserve_a, 2_000_000);
-         assert_eq!(info_before.reserve_b, 1_000_000);
+        let info_before = amm.get_info();
+        assert_eq!(info_before.reserve_a, 2_000_000);
+        assert_eq!(info_before.reserve_b, 1_000_000);
 
-         let recipient = Address::generate(&env);
-         let expected_ts = 99999_u64;
-         env.ledger().set_timestamp(expected_ts);
+        let recipient = Address::generate(&env);
+        let expected_ts = 99999_u64;
+        env.ledger().set_timestamp(expected_ts);
 
-         // Call emergency_withdraw
-         amm.emergency_withdraw(&recipient);
+        // Call emergency_withdraw
+        amm.emergency_withdraw(&recipient);
 
-         // Verify reserves are now zeroed
-         let info_after = amm.get_info();
-         assert_eq!(info_after.reserve_a, 0);
-         assert_eq!(info_after.reserve_b, 0);
+        // Verify reserves are now zeroed
+        let info_after = amm.get_info();
+        assert_eq!(info_after.reserve_a, 0);
+        assert_eq!(info_after.reserve_b, 0);
 
-         // Verify recipient received the tokens
-         assert_eq!(ta_client.balance(&recipient), 2_000_000);
-         assert_eq!(tb_client.balance(&recipient), 1_000_000);
+        // Verify recipient received the tokens
+        assert_eq!(ta_client.balance(&recipient), 2_000_000);
+        assert_eq!(tb_client.balance(&recipient), 1_000_000);
 
-         // Verify audit log values in contract storage from the contract context.
-         env.as_contract(&amm_addr, || {
-             let ts: u64 = env.storage().instance().get(&DataKey::EmergencyWithdrawTimestamp).unwrap();
-             let rec: Address = env.storage().instance().get(&DataKey::EmergencyWithdrawRecipient).unwrap();
-             assert_eq!(ts, expected_ts);
-             assert_eq!(rec, recipient);
-         });
-     }
+        // Verify audit log values in contract storage from the contract context.
+        env.as_contract(&amm_addr, || {
+            let ts: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::EmergencyWithdrawTimestamp)
+                .unwrap();
+            let rec: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::EmergencyWithdrawRecipient)
+                .unwrap();
+            assert_eq!(ts, expected_ts);
+            assert_eq!(rec, recipient);
+        });
+    }
 
-     #[test]
-     #[should_panic]
-     fn test_emergency_withdraw_requires_admin_auth() {
-         let env = Env::default();
-         let amm_addr = env.register_contract(None, AmmPool);
-         let amm = AmmPoolClient::new(&env, &amm_addr);
-         let recipient = Address::generate(&env);
-         amm.emergency_withdraw(&recipient);
-     }
+    #[test]
+    #[should_panic]
+    fn test_emergency_withdraw_requires_admin_auth() {
+        let env = Env::default();
+        let amm_addr = env.register_contract(None, AmmPool);
+        let amm = AmmPoolClient::new(&env, &amm_addr);
+        let recipient = Address::generate(&env);
+        amm.emergency_withdraw(&recipient);
+    }
 
     #[test]
     #[should_panic]
@@ -4967,7 +5128,10 @@ mod prop_tests {
         //   amount_in_with_fee = 100_000 * (10000 - 30) = 997_000_000
         //   amount_out ≈ 90_661; effective_price ≈ 906_610
         //   price_impact_bps ≈ 934
-        assert!(large.price_impact_bps > 0, "price_impact_bps must be positive for large swap");
+        assert!(
+            large.price_impact_bps > 0,
+            "price_impact_bps must be positive for large swap"
+        );
 
         // Larger swap must have higher price impact than smaller swap.
         let medium = amm.simulate_swap(&ts.ta_addr, &10_000_i128);

--- a/contracts/amm/test_snapshots/prop_tests/test_flash_loan_failed_repayment_panics.1.json
+++ b/contracts/amm/test_snapshots/prop_tests/test_flash_loan_failed_repayment_panics.1.json
@@ -451,6 +451,72 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "CircuitBreakerCooldown"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerLastPrice"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerLastSeqno"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 5000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerTriggeredAt"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeBps"
                             }
                           ]
@@ -505,6 +571,48 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidityCumulative"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Locked"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LpRebateBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LpToken"
                             }
                           ]
@@ -512,6 +620,67 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MaxOracleDeviationBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 500
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinLiquidityLocked"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultisigQuorum"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultisigSigners"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OracleAggregator"
+                            }
+                          ]
+                        },
+                        "val": "void"
                       },
                       {
                         "key": {
@@ -659,6 +828,54 @@
                   "symbol": "Balance"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
@@ -687,8 +904,77 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000000
+                    "lo": 999000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Checkpoints"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Checkpoints"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "balance"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 1000
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "ledger"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             },
@@ -743,7 +1029,7 @@
                           "val": {
                             "i128": {
                               "hi": 0,
-                              "lo": 1000000
+                              "lo": 999000
                             }
                           }
                         },
@@ -952,6 +1238,30 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenB"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                         }
                       }
                     ]
@@ -2313,12 +2623,69 @@
             "data": {
               "vec": [
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000003",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000000
+                    "lo": 999000
                   }
                 }
               ]
@@ -2367,22 +2734,29 @@
             "data": {
               "vec": [
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
+                  "u32": 1
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
+                  "vec": [
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 1000000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 1000000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 999000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -2409,7 +2783,7 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 1000000
+                "lo": 999000
               }
             }
           }
@@ -2439,6 +2813,12 @@
               "vec": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                },
+                {
+                  "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                 },
                 {
                   "bool": false
@@ -2495,12 +2875,15 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
                 {
-                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000
+                  }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100000
+                    "lo": 0
                   }
                 },
                 {
@@ -2543,6 +2926,58 @@
       "event": {
         "ext": "v0",
         "contract_id": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -2678,9 +3113,6 @@
             "data": {
               "vec": [
                 {
-                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
-                },
-                {
                   "i128": {
                     "hi": 0,
                     "lo": 100000
@@ -2689,7 +3121,19 @@
                 {
                   "i128": {
                     "hi": 0,
+                    "lo": 0
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
                     "lo": 300
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
                   }
                 },
                 {
@@ -2786,6 +3230,58 @@
           "v0": {
             "topics": [
               {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
                 "symbol": "fn_return"
               },
               {
@@ -2794,7 +3290,7 @@
             ],
             "data": {
               "error": {
-                "contract": 11
+                "contract": 18
               }
             }
           }
@@ -2815,7 +3311,7 @@
               },
               {
                 "error": {
-                  "contract": 11
+                  "contract": 18
                 }
               }
             ],
@@ -2840,14 +3336,14 @@
               },
               {
                 "error": {
-                  "contract": 11
+                  "contract": 18
                 }
               }
             ],
             "data": {
               "vec": [
                 {
-                  "string": "contract call failed"
+                  "string": "contract try_call failed"
                 },
                 {
                   "symbol": "flash_loan"
@@ -2858,12 +3354,15 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                     },
                     {
-                      "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      "i128": {
+                        "hi": 0,
+                        "lo": 100000
+                      }
                     },
                     {
                       "i128": {
                         "hi": 0,
-                        "lo": 100000
+                        "lo": 0
                       }
                     },
                     {
@@ -2872,31 +3371,6 @@
                   ]
                 }
               ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "error"
-              },
-              {
-                "error": {
-                  "contract": 11
-                }
-              }
-            ],
-            "data": {
-              "string": "escalating error to panic"
             }
           }
         }

--- a/contracts/amm/test_snapshots/prop_tests/test_flash_loan_success_with_repayment.1.json
+++ b/contracts/amm/test_snapshots/prop_tests/test_flash_loan_success_with_repayment.1.json
@@ -207,6 +207,31 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [],
     []
   ],
@@ -444,6 +469,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 8370022561469687789
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 8370022561469687789
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
@@ -510,6 +568,72 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "CircuitBreakerCooldown"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerLastPrice"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerLastSeqno"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 5000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CircuitBreakerTriggeredAt"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FeeBps"
                             }
                           ]
@@ -564,6 +688,48 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidityCumulative"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Locked"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LpRebateBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LpToken"
                             }
                           ]
@@ -571,6 +737,67 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MaxOracleDeviationBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 500
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinLiquidityLocked"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultisigQuorum"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultisigSigners"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OracleAggregator"
+                            }
+                          ]
+                        },
+                        "val": "void"
                       },
                       {
                         "key": {
@@ -655,7 +882,7 @@
                         "val": {
                           "i128": {
                             "hi": 0,
-                            "lo": 1000000
+                            "lo": 1000250
                           }
                         }
                       },
@@ -718,6 +945,54 @@
                   "symbol": "Balance"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
@@ -746,8 +1021,77 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000000
+                    "lo": 999000
                   }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Checkpoints"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Checkpoints"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "balance"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 1000
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "ledger"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             },
@@ -802,7 +1146,7 @@
                           "val": {
                             "i128": {
                               "hi": 0,
-                              "lo": 1000000
+                              "lo": 999000
                             }
                           }
                         },
@@ -1011,6 +1355,30 @@
                         },
                         "val": {
                           "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenA"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenB"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                         }
                       }
                     ]
@@ -1398,7 +1766,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 1000000
+                          "lo": 1000250
                         }
                       }
                     },
@@ -1472,6 +1840,79 @@
                         "i128": {
                           "hi": 0,
                           "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 750
                         }
                       }
                     },
@@ -2451,12 +2892,69 @@
             "data": {
               "vec": [
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000003",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000000
+                    "lo": 999000
                   }
                 }
               ]
@@ -2505,22 +3003,29 @@
             "data": {
               "vec": [
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
+                  "u32": 1
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
+                  "vec": [
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 1000000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 1000000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 999000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -2547,7 +3052,7 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 1000000
+                "lo": 999000
               }
             }
           }
@@ -2577,6 +3082,12 @@
               "vec": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                },
+                {
+                  "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                 },
                 {
                   "bool": true
@@ -2710,6 +3221,95 @@
                 "symbol": "fn_call"
               },
               {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "mint"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
               },
               {
@@ -2722,12 +3322,15 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
                 {
-                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000
+                  }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100000
+                    "lo": 50000
                   }
                 },
                 {
@@ -2770,6 +3373,58 @@
       "event": {
         "ext": "v0",
         "contract_id": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -2896,6 +3551,98 @@
                 "symbol": "fn_call"
               },
               {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 50000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000007"
               },
               {
@@ -2905,9 +3652,6 @@
             "data": {
               "vec": [
                 {
-                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
-                },
-                {
                   "i128": {
                     "hi": 0,
                     "lo": 100000
@@ -2916,7 +3660,19 @@
                 {
                   "i128": {
                     "hi": 0,
+                    "lo": 50000
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
                     "lo": 500
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 250
                   }
                 },
                 {
@@ -3030,6 +3786,98 @@
           "v0": {
             "topics": [
               {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50250
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 50250
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
                 "symbol": "fn_return"
               },
               {
@@ -3100,6 +3948,58 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000250
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000002",
         "type_": "contract",
         "body": {
           "v0": {
@@ -3114,19 +4014,35 @@
             "data": {
               "vec": [
                 {
-                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                  "u32": 1
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 100000
-                  }
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
-                  }
+                  "vec": [
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 100000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 50000
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 500
+                      }
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 250
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -3151,10 +4067,20 @@
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 500
-              }
+              "vec": [
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 250
+                  }
+                }
+              ]
             }
           }
         }
@@ -3242,6 +4168,17 @@
                 },
                 {
                   "key": {
+                    "symbol": "lp_rebate_bps"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "protocol_fee_bps"
                   },
                   "val": {
@@ -3269,7 +4206,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 1000000
+                      "lo": 1000250
                     }
                   }
                 },

--- a/contracts/integration-tests/src/flash_loan_integration_test.rs
+++ b/contracts/integration-tests/src/flash_loan_integration_test.rs
@@ -38,18 +38,30 @@ mod flash_loan_tests {
         #[contracttype]
         struct FlashReceiver;
         impl FlashReceiver {
-            fn on_flash_loan(env: Env, token: Address, amount: i128, _fee: i128, _: Bytes) -> bool {
+            fn on_flash_loan(
+                env: Env,
+                amount_a: i128,
+                amount_b: i128,
+                _fee_a: i128,
+                _fee_b: i128,
+                _: Bytes,
+            ) -> bool {
                 // Use the borrowed amount to add liquidity and then swap
                 let pool = AmmPoolClient::new(&env, &env.register_contract(&"amm", amm::AmmPool));
+                let amount = amount_a + amount_b;
                 // Add liquidity (half of amount for each side)
                 pool.add_liquidity(&env.get_caller(), amount / 2, amount / 2, 1, DEADLINE).unwrap();
-                // Perform a swap using the borrowed token
-                pool.swap(&env.get_caller(), &token, amount / 2, 1, DEADLINE, None).unwrap();
                 true // indicate successful repayment
             }
         }
         // Execute flash‑loan
-        let fee = amm.flash_loan(&receiver, &token_a, 500_000_i128, Bytes::from_array(&env, &[0; 0])).unwrap();
-        assert!(fee > 0);
+        let (fee_a, fee_b) = amm.flash_loan(
+            &receiver,
+            &500_000_i128,
+            &0_i128,
+            &Bytes::from_array(&env, &[0; 0]),
+        ).unwrap();
+        assert!(fee_a > 0);
+        assert_eq!(fee_b, 0);
     }
 }

--- a/examples/flash_loan_receiver.rs
+++ b/examples/flash_loan_receiver.rs
@@ -1,0 +1,72 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractclient, contractimpl, contracttype, token::Client as TokenClient, Address,
+    Bytes, Env,
+};
+
+#[contractclient(name = "AmmPoolClient")]
+pub trait AmmPool {
+    fn get_info(env: Env) -> PoolInfo;
+}
+
+#[contracttype]
+pub struct PoolInfo {
+    pub token_a: Address,
+    pub token_b: Address,
+    pub reserve_a: i128,
+    pub reserve_b: i128,
+    pub total_shares: i128,
+    pub fee_bps: i128,
+    pub flash_loan_fee_bps: i128,
+    pub admin: Address,
+    pub fee_recipient: Address,
+    pub protocol_fee_bps: i128,
+    pub lp_rebate_bps: i128,
+}
+
+#[contracttype]
+enum DataKey {
+    Pool,
+}
+
+#[contract]
+pub struct ExampleFlashLoanReceiver;
+
+#[contractimpl]
+impl ExampleFlashLoanReceiver {
+    pub fn initialize(env: Env, pool: Address) {
+        env.storage().instance().set(&DataKey::Pool, &pool);
+    }
+
+    pub fn on_flash_loan(
+        env: Env,
+        token_a_amount: i128,
+        token_b_amount: i128,
+        fee_a: i128,
+        fee_b: i128,
+        _data: Bytes,
+    ) -> bool {
+        let pool: Address = env.storage().instance().get(&DataKey::Pool).unwrap();
+        let info = AmmPoolClient::new(&env, &pool).get_info();
+        let receiver = env.current_contract_address();
+
+        if token_a_amount > 0 || fee_a > 0 {
+            TokenClient::new(&env, &info.token_a).transfer(
+                &receiver,
+                &pool,
+                &(token_a_amount + fee_a),
+            );
+        }
+
+        if token_b_amount > 0 || fee_b > 0 {
+            TokenClient::new(&env, &info.token_b).transfer(
+                &receiver,
+                &pool,
+                &(token_b_amount + fee_b),
+            );
+        }
+
+        true
+    }
+}


### PR DESCRIPTION
## What changed
- Updates flash_loan to use the standard receiver callback shape: receiver, token A amount, token B amount, callback data.
- Defines the receiver callback as on_flash_loan(token_a_amount, token_b_amount, fee_a, fee_b, data).
- Adds FlashLoanRepaymentFailed for callback rejection or short repayment.
- Verifies repayment for both pool tokens after the callback returns.
- Adds an example flash-loan receiver contract in examples/.

Closes #297

## How to test
- cargo test -p amm flash_loan
- cargo clippy -p amm --no-deps -- -D warnings
- cargo fmt -p amm -- --check

Note: cargo test -p integration-tests flash_loan currently fails before the flash-loan test because the integration-tests crate has pre-existing API mismatches with factory/concentrated_liquidity/dex_aggregator clients.