### PR TITLE
chore: add hot path benchmark suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run all tests
         run: cargo test -p factory
 
+      - name: Run hot-path benchmarks
+        run: cargo run -p benches -- --check
+
       - name: Clippy
         run: cargo clippy -p factory --no-deps -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "benches"
+version = "0.1.0"
+dependencies = [
+ "amm",
+ "batch_auction",
+ "concentrated_liquidity",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "contracts/cl_position_nft",
   "contracts/v2_to_v3_migration",
   "contracts/pol_vesting",
+  "benches",
 ]
 
 [workspace.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt lint check deploy e2e clean optimize
+.PHONY: build test fmt lint check bench deploy e2e clean optimize
 
 # Default target
 all: build
@@ -23,6 +23,9 @@ lint:
 	cargo clippy --all -- -D warnings
 
 check: fmt lint test
+
+bench:
+	cargo run -p benches -- --check
 
 deploy:
 	bash scripts/deploy.sh

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "benches"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+amm = { path = "../contracts/amm", features = ["testutils"] }
+batch_auction = { path = "../contracts/batch_auction", features = ["testutils"] }
+concentrated_liquidity = { path = "../contracts/concentrated_liquidity", features = ["testutils"] }
+token = { path = "../contracts/token", features = ["testutils"] }

--- a/benches/baseline.json
+++ b/benches/baseline.json
@@ -1,0 +1,11 @@
+{
+  "metrics": [
+    { "name": "amm.swap", "cpu_instructions": 729495, "mem_bytes": 95481 },
+    { "name": "amm.add_liquidity", "cpu_instructions": 850593, "mem_bytes": 119609 },
+    { "name": "amm.remove_liquidity", "cpu_instructions": 887155, "mem_bytes": 123544 },
+    { "name": "amm.flash_loan", "cpu_instructions": 868047, "mem_bytes": 110407 },
+    { "name": "cl.mint_position", "cpu_instructions": 685173, "mem_bytes": 81048 },
+    { "name": "cl.swap", "cpu_instructions": 703943, "mem_bytes": 93535 },
+    { "name": "batch.settle_batch", "cpu_instructions": 61120, "mem_bytes": 6081 }
+  ]
+}

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,0 +1,297 @@
+use std::{env as std_env, fs, process};
+
+use amm::{AmmPool, AmmPoolClient};
+use batch_auction::{BatchAuction, BatchAuctionClient};
+use concentrated_liquidity::{ConcentratedLiquidity, ConcentratedLiquidityClient};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient as StellarTokenClient},
+    Address, Bytes, Env, String as SorobanString,
+};
+use token::{LpToken, LpTokenClient};
+
+const REGRESSION_BPS: u128 = 500;
+const BASELINE_PATH: &str = "benches/baseline.json";
+
+#[derive(Clone)]
+struct Metric {
+    name: &'static str,
+    cpu_instructions: u64,
+    mem_bytes: u64,
+}
+
+#[contracttype]
+enum ReceiverDataKey {
+    Amm,
+    ShouldRepay,
+}
+
+#[contract]
+struct BenchFlashLoanReceiver;
+
+#[contractimpl]
+impl BenchFlashLoanReceiver {
+    pub fn initialize(env: Env, amm: Address, should_repay: bool) {
+        env.storage().instance().set(&ReceiverDataKey::Amm, &amm);
+        env.storage()
+            .instance()
+            .set(&ReceiverDataKey::ShouldRepay, &should_repay);
+    }
+
+    pub fn on_flash_loan(env: Env, token: Address, amount: i128, fee: i128, _data: Bytes) -> bool {
+        let should_repay = env
+            .storage()
+            .instance()
+            .get(&ReceiverDataKey::ShouldRepay)
+            .unwrap_or(false);
+        if should_repay {
+            let amm: Address = env.storage().instance().get(&ReceiverDataKey::Amm).unwrap();
+            StellarTokenClient::new(&env, &token).transfer(
+                &env.current_contract_address(),
+                &amm,
+                &(amount + fee),
+            );
+        }
+        true
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std_env::args().collect();
+    let metrics = run_all();
+    let json = render_json(&metrics);
+
+    if args.iter().any(|arg| arg == "--write-baseline") {
+        fs::write(BASELINE_PATH, json).expect("write baseline");
+        return;
+    }
+
+    println!("{json}");
+
+    if args.iter().any(|arg| arg == "--check") {
+        let baseline = fs::read_to_string(BASELINE_PATH).expect("read benches/baseline.json");
+        if let Err(message) = check_regressions(&metrics, &baseline) {
+            eprintln!("{message}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run_all() -> Vec<Metric> {
+    vec![
+        measure("amm.swap", bench_amm_swap),
+        measure("amm.add_liquidity", bench_amm_add_liquidity),
+        measure("amm.remove_liquidity", bench_amm_remove_liquidity),
+        measure("amm.flash_loan", bench_amm_flash_loan),
+        measure("cl.mint_position", bench_cl_mint_position),
+        measure("cl.swap", bench_cl_swap),
+        measure("batch.settle_batch", bench_batch_settle),
+    ]
+}
+
+fn measure(name: &'static str, f: fn(&Env)) -> Metric {
+    eprintln!("running {name}");
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    f(&env);
+    let (cpu_instructions, mem_bytes) = parse_budget(&format!("{}", env.budget()));
+    Metric {
+        name,
+        cpu_instructions,
+        mem_bytes,
+    }
+}
+
+fn setup_amm(env: &Env, flash_fee_bps: i128) -> (AmmPoolClient<'_>, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let token_a = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_b = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let lp = env.register_contract(None, LpToken);
+    let amm = env.register_contract(None, AmmPool);
+    LpTokenClient::new(env, &lp).initialize(
+        &amm,
+        &SorobanString::from_str(env, "LP"),
+        &SorobanString::from_str(env, "LP"),
+        &7,
+    );
+    let client = AmmPoolClient::new(env, &amm);
+    client.initialize_with_flash_loan_fee(
+        &admin,
+        &token_a,
+        &token_b,
+        &lp,
+        &30,
+        &admin,
+        &0,
+        &flash_fee_bps,
+    );
+
+    let provider = Address::generate(env);
+    StellarAssetClient::new(env, &token_a).mint(&provider, &2_000_000);
+    StellarAssetClient::new(env, &token_b).mint(&provider, &2_000_000);
+    client.add_liquidity(&provider, &1_000_000, &1_000_000, &0, &u64::MAX);
+    (client, amm, token_a, token_b)
+}
+
+fn bench_amm_swap(env: &Env) {
+    let (client, _, token_a, _) = setup_amm(env, 0);
+    let trader = Address::generate(env);
+    StellarAssetClient::new(env, &token_a).mint(&trader, &100_000);
+    env.budget().reset_unlimited();
+    client.swap(&trader, &token_a, &100_000, &0, &u64::MAX);
+}
+
+fn bench_amm_add_liquidity(env: &Env) {
+    let (client, _, token_a, token_b) = setup_amm(env, 0);
+    let provider = Address::generate(env);
+    StellarAssetClient::new(env, &token_a).mint(&provider, &500_000);
+    StellarAssetClient::new(env, &token_b).mint(&provider, &500_000);
+    env.budget().reset_default();
+    client.add_liquidity(&provider, &500_000, &500_000, &0, &u64::MAX);
+}
+
+fn bench_amm_remove_liquidity(env: &Env) {
+    let (client, _, _, _) = setup_amm(env, 0);
+    let provider = Address::generate(env);
+    let info = client.get_info();
+    StellarAssetClient::new(env, &info.token_a).mint(&provider, &500_000);
+    StellarAssetClient::new(env, &info.token_b).mint(&provider, &500_000);
+    let shares = client.add_liquidity(&provider, &500_000, &500_000, &0, &u64::MAX);
+    env.budget().reset_default();
+    client.remove_liquidity(&provider, &(shares / 2), &0, &0, &u64::MAX);
+}
+
+fn bench_amm_flash_loan(env: &Env) {
+    let (client, amm, token_a, _) = setup_amm(env, 50);
+    let receiver_addr = env.register_contract(None, BenchFlashLoanReceiver);
+    let receiver = BenchFlashLoanReceiverClient::new(env, &receiver_addr);
+    receiver.initialize(&amm, &true);
+    StellarAssetClient::new(env, &token_a).mint(&receiver_addr, &1_000);
+    env.budget().reset_default();
+    client.flash_loan(&receiver_addr, &token_a, &100_000, &Bytes::new(env));
+}
+
+fn setup_cl(env: &Env) -> (ConcentratedLiquidityClient<'_>, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let provider = Address::generate(env);
+    let token_a = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_b = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let cl = env.register_contract(None, ConcentratedLiquidity);
+    let client = ConcentratedLiquidityClient::new(env, &cl);
+    client.initialize(&admin, &token_a, &token_b, &30, &0, &1);
+    StellarAssetClient::new(env, &token_a).mint(&provider, &10_000_000);
+    StellarAssetClient::new(env, &token_b).mint(&provider, &10_000_000);
+    (client, provider, token_a, token_b)
+}
+
+fn bench_cl_mint_position(env: &Env) {
+    let (client, provider, _, _) = setup_cl(env);
+    env.budget().reset_default();
+    client.mint_position(&provider, &-100, &100, &100_000, &100_000, &0, &0);
+}
+
+fn bench_cl_swap(env: &Env) {
+    let (client, provider, token_a, _) = setup_cl(env);
+    client.mint_position(&provider, &-100, &100, &100_000, &100_000, &0, &0);
+    StellarAssetClient::new(env, &token_a).mint(&provider, &100);
+    env.budget().reset_default();
+    client.swap(&provider, &true, &100, &0, &0, &u64::MAX);
+}
+
+fn bench_batch_settle(env: &Env) {
+    env.ledger().set_timestamp(1_000);
+    let auction_addr = env.register_contract(None, BatchAuction);
+    let admin = Address::generate(env);
+    let auction = BatchAuctionClient::new(env, &auction_addr);
+    auction.initialize(&admin, &30);
+    env.ledger().set_timestamp(1_031);
+    env.budget().reset_default();
+    let _ = auction.try_settle_batch();
+}
+
+fn parse_budget(text: &str) -> (u64, u64) {
+    let mut cpu = 0;
+    let mut mem = 0;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("Cpu limit:") {
+            let mut used = rest.split("used:");
+            let _ = used.next();
+            cpu = used
+                .next()
+                .and_then(|s| s.split(';').next())
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .unwrap_or(0);
+        } else if let Some(rest) = line.strip_prefix("Mem limit:") {
+            let mut used = rest.split("used:");
+            let _ = used.next();
+            mem = used
+                .next()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .unwrap_or(0);
+        }
+    }
+    (cpu, mem)
+}
+
+fn render_json(metrics: &[Metric]) -> String {
+    let mut out = String::from("{\n  \"metrics\": [\n");
+    for (idx, metric) in metrics.iter().enumerate() {
+        let comma = if idx + 1 == metrics.len() { "" } else { "," };
+        out.push_str(&format!(
+            "    {{ \"name\": \"{}\", \"cpu_instructions\": {}, \"mem_bytes\": {} }}{}\n",
+            metric.name, metric.cpu_instructions, metric.mem_bytes, comma
+        ));
+    }
+    out.push_str("  ]\n}\n");
+    out
+}
+
+fn check_regressions(metrics: &[Metric], baseline: &str) -> Result<(), String> {
+    for metric in metrics {
+        let cpu = read_baseline_value(baseline, metric.name, "cpu_instructions")
+            .ok_or_else(|| format!("missing baseline CPU metric for {}", metric.name))?;
+        let mem = read_baseline_value(baseline, metric.name, "mem_bytes")
+            .ok_or_else(|| format!("missing baseline memory metric for {}", metric.name))?;
+        assert_within(
+            metric.name,
+            "cpu_instructions",
+            metric.cpu_instructions,
+            cpu,
+        )?;
+        assert_within(metric.name, "mem_bytes", metric.mem_bytes, mem)?;
+    }
+    Ok(())
+}
+
+fn assert_within(name: &str, key: &str, current: u64, baseline: u64) -> Result<(), String> {
+    let allowed = (baseline as u128) * (10_000 + REGRESSION_BPS) / 10_000;
+    if (current as u128) > allowed {
+        return Err(format!(
+            "{name} {key} regressed: current {current}, baseline {baseline}, allowed {allowed}"
+        ));
+    }
+    Ok(())
+}
+
+fn read_baseline_value(text: &str, name: &str, key: &str) -> Option<u64> {
+    let name_pos = text.find(&format!("\"name\": \"{name}\""))?;
+    let after_name = &text[name_pos..];
+    let key_pos = after_name.find(&format!("\"{key}\":"))?;
+    let after_key = &after_name[key_pos + key.len() + 3..];
+    let digits: String = after_key
+        .chars()
+        .skip_while(|c| c.is_whitespace())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}


### PR DESCRIPTION
## What changed
- Adds a workspace benchmark binary crate under benches/.
- Records Soroban budget CPU instructions and memory bytes for AMM swap/add/remove/flash-loan, CL mint/swap, and the batch settle entrypoint.
- Commits benches/baseline.json and fails --check when a metric regresses by more than 5%.
- Adds make bench and wires the benchmark check into CI.

Closes #300

## How to test
- cargo run -p benches -- --check
- make bench
- cargo fmt -p benches

Note: the batch metric exercises the settle_batch entrypoint no-orders path because the batch_auction crate's own settlement tests are currently out of sync with the AMM client API on upstream main.