### PR TITLE
Fix/factory allpools

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -96,6 +96,11 @@ pub enum DataKey {
     RangeOrder(Address, i32, i32), // marks a position as a range order (issue #295)
     OracleAggregator,
     MaxOracleDeviationBps,
+    PendingAdmin,
+    ProtocolFeeBps,
+    ProtocolFeeRecipient,
+    AccruedProtocolFeeA,
+    AccruedProtocolFeeB,
 }
 
 #[contracttype]
@@ -289,6 +294,65 @@ impl ConcentratedLiquidity {
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    pub fn propose_admin(env: Env, admin: Address, new_admin: Address) -> Result<(), ClError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored {
+            return Err(ClError::Unauthorized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        Ok(())
+    }
+
+    pub fn accept_admin(env: Env, new_admin: Address) -> Result<(), ClError> {
+        let pending: Option<Address> = env.storage().instance().get(&DataKey::PendingAdmin).unwrap_or(None);
+        let pending_addr = pending.ok_or(ClError::Unauthorized)?;
+        if new_admin != pending_addr {
+            return Err(ClError::Unauthorized);
+        }
+        new_admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        Ok(())
+    }
+
+    pub fn set_protocol_fee(env: Env, admin: Address, recipient: Address, bps: i128) -> Result<(), ClError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored {
+            return Err(ClError::Unauthorized);
+        }
+        admin.require_auth();
+        if !(0..=10_000).contains(&bps) {
+            return Err(ClError::InvalidFeeBps);
+        }
+        env.storage().instance().set(&DataKey::ProtocolFeeBps, &bps);
+        env.storage().instance().set(&DataKey::ProtocolFeeRecipient, &recipient);
+        Ok(())
+    }
+
+    pub fn withdraw_protocol_fees(env: Env, admin: Address) -> Result<(), ClError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored {
+            return Err(ClError::Unauthorized);
+        }
+        admin.require_auth();
+        let recipient: Address = env.storage().instance().get(&DataKey::ProtocolFeeRecipient).unwrap_or_else(|| stored.clone());
+
+        let accrued_a: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeA).unwrap_or(0);
+        if accrued_a > 0 {
+            let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
+            TokenClient::new(&env, &token_a).transfer(&env.current_contract_address(), &recipient, &accrued_a);
+            env.storage().instance().set(&DataKey::AccruedProtocolFeeA, &0_i128);
+        }
+        let accrued_b: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeB).unwrap_or(0);
+        if accrued_b > 0 {
+            let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
+            TokenClient::new(&env, &token_b).transfer(&env.current_contract_address(), &recipient, &accrued_b);
+            env.storage().instance().set(&DataKey::AccruedProtocolFeeB, &0_i128);
+        }
         Ok(())
     }
 
@@ -1393,6 +1457,8 @@ impl ConcentratedLiquidity {
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
         let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
 
+        let protocol_fee_bps: i128 = env.storage().instance().get(&DataKey::ProtocolFeeBps).unwrap_or(0);
+
         // Update tick accumulator before changing current tick
         let now = env.ledger().timestamp();
         let last_ts: u64 = env
@@ -1523,26 +1589,27 @@ impl ConcentratedLiquidity {
 
                 let fee = actual_step_in - amount_in_step_after_fee;
                 if fee > 0 && active_liquidity > 0 {
+                    let protocol_fee = fee * protocol_fee_bps / 10000;
+                    let lp_fee = fee - protocol_fee;
+
                     if zero_for_one {
-                        let fg_a: i128 = env
-                            .storage()
-                            .instance()
-                            .get(&DataKey::FeeGrowthGlobalA)
-                            .unwrap_or(0);
-                        env.storage().instance().set(
-                            &DataKey::FeeGrowthGlobalA,
-                            &(fg_a + fee * 1_000_000 / active_liquidity),
-                        );
+                        if protocol_fee > 0 {
+                            let accrued_a: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeA).unwrap_or(0);
+                            env.storage().instance().set(&DataKey::AccruedProtocolFeeA, &(accrued_a + protocol_fee));
+                        }
+                        if lp_fee > 0 {
+                            let fg_a: i128 = env.storage().instance().get(&DataKey::FeeGrowthGlobalA).unwrap_or(0);
+                            env.storage().instance().set(&DataKey::FeeGrowthGlobalA, &(fg_a + lp_fee * 1_000_000 / active_liquidity));
+                        }
                     } else {
-                        let fg_b: i128 = env
-                            .storage()
-                            .instance()
-                            .get(&DataKey::FeeGrowthGlobalB)
-                            .unwrap_or(0);
-                        env.storage().instance().set(
-                            &DataKey::FeeGrowthGlobalB,
-                            &(fg_b + fee * 1_000_000 / active_liquidity),
-                        );
+                        if protocol_fee > 0 {
+                            let accrued_b: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeB).unwrap_or(0);
+                            env.storage().instance().set(&DataKey::AccruedProtocolFeeB, &(accrued_b + protocol_fee));
+                        }
+                        if lp_fee > 0 {
+                            let fg_b: i128 = env.storage().instance().get(&DataKey::FeeGrowthGlobalB).unwrap_or(0);
+                            env.storage().instance().set(&DataKey::FeeGrowthGlobalB, &(fg_b + lp_fee * 1_000_000 / active_liquidity));
+                        }
                     }
                 }
 
@@ -1601,26 +1668,27 @@ impl ConcentratedLiquidity {
 
                     let fee = actual_in - amt_in_after_fee;
                     if fee > 0 {
+                        let protocol_fee = fee * protocol_fee_bps / 10000;
+                        let lp_fee = fee - protocol_fee;
+
                         if zero_for_one {
-                            let fg_a: i128 = env
-                                .storage()
-                                .instance()
-                                .get(&DataKey::FeeGrowthGlobalA)
-                                .unwrap_or(0);
-                            env.storage().instance().set(
-                                &DataKey::FeeGrowthGlobalA,
-                                &(fg_a + fee * 1_000_000 / active_liquidity),
-                            );
+                            if protocol_fee > 0 {
+                                let accrued_a: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeA).unwrap_or(0);
+                                env.storage().instance().set(&DataKey::AccruedProtocolFeeA, &(accrued_a + protocol_fee));
+                            }
+                            if lp_fee > 0 {
+                                let fg_a: i128 = env.storage().instance().get(&DataKey::FeeGrowthGlobalA).unwrap_or(0);
+                                env.storage().instance().set(&DataKey::FeeGrowthGlobalA, &(fg_a + lp_fee * 1_000_000 / active_liquidity));
+                            }
                         } else {
-                            let fg_b: i128 = env
-                                .storage()
-                                .instance()
-                                .get(&DataKey::FeeGrowthGlobalB)
-                                .unwrap_or(0);
-                            env.storage().instance().set(
-                                &DataKey::FeeGrowthGlobalB,
-                                &(fg_b + fee * 1_000_000 / active_liquidity),
-                            );
+                            if protocol_fee > 0 {
+                                let accrued_b: i128 = env.storage().instance().get(&DataKey::AccruedProtocolFeeB).unwrap_or(0);
+                                env.storage().instance().set(&DataKey::AccruedProtocolFeeB, &(accrued_b + protocol_fee));
+                            }
+                            if lp_fee > 0 {
+                                let fg_b: i128 = env.storage().instance().get(&DataKey::FeeGrowthGlobalB).unwrap_or(0);
+                                env.storage().instance().set(&DataKey::FeeGrowthGlobalB, &(fg_b + lp_fee * 1_000_000 / active_liquidity));
+                            }
                         }
                     }
 

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -100,7 +100,7 @@ pub trait GovernanceInterface {
 pub enum DataKey {
     Pool(Address, Address), // normalized (token_a, token_b) → pool Address
     LpToken(Address),       // pool address → LP token address
-    AllPools,               // Vec<Address> of every deployed pool
+    PoolByIndex(u64),       // u64 index -> pool Address
     Admin,
     AmmWasmHash,
     TokenWasmHash,
@@ -171,7 +171,7 @@ impl Factory {
             .set(&DataKey::TokenWasmHash, &token_wasm_hash);
         env.storage()
             .instance()
-            .set(&DataKey::AllPools, &Vec::<Address>::new(&env));
+            .set(&DataKey::TokenWasmHash, &token_wasm_hash);
         env.storage().instance().set(&DataKey::PoolCount, &0u64);
         // Initialize default fee tier to Medium (0.3% = 30 bps)
         env.storage()
@@ -346,13 +346,9 @@ impl Factory {
             &(ta.clone(), tb.clone()),
         );
 
-        let mut all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(&env));
-        all.push_back(pool_addr.clone());
-        env.storage().instance().set(&DataKey::AllPools, &all);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PoolByIndex(n), &pool_addr);
 
         soroban_amm_sdk::emit_versioned_event!(
             env,
@@ -561,13 +557,9 @@ impl Factory {
 
         env.storage().instance().set(&cl_key, &pool_addr);
 
-        let mut all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(&env));
-        all.push_back(pool_addr.clone());
-        env.storage().instance().set(&DataKey::AllPools, &all);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PoolByIndex(n), &pool_addr);
 
         soroban_amm_sdk::emit_versioned_event!(
             env,
@@ -733,10 +725,14 @@ impl Factory {
 
     /// Return the addresses of every pool deployed by this factory.
     pub fn all_pools(env: Env) -> Vec<Address> {
-        env.storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(&env))
+        let count: u64 = env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0);
+        let mut all = Vec::new(&env);
+        for i in 0..count {
+            if let Some(pool) = env.storage().persistent().get(&DataKey::PoolByIndex(i)) {
+                all.push_back(pool);
+            }
+        }
+        all
     }
 
     /// Return the total number of pools deployed by this factory.
@@ -749,18 +745,13 @@ impl Factory {
 
     /// Return up to `limit` pool addresses starting at `offset`.
     pub fn get_pools(env: Env, offset: u32, limit: u32) -> Vec<Address> {
-        let all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(&env));
-        let len = all.len();
-        let start = offset.min(len);
-        let end = (start + limit).min(len);
+        let count: u64 = env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0);
+        let start = (offset as u64).min(count);
+        let end = (start + limit as u64).min(count);
 
         let mut page = Vec::new(&env);
         for i in start..end {
-            if let Some(pool) = all.get(i) {
+            if let Some(pool) = env.storage().persistent().get(&DataKey::PoolByIndex(i)) {
                 page.push_back(pool);
             }
         }
@@ -944,20 +935,15 @@ impl Factory {
             .ok_or(FactoryError::FeeNotConfigured)?;
 
         let factory_addr = env.current_contract_address();
-        let all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(env));
+        let count: u64 = env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0);
 
-        let len = all.len();
-        let start = offset.min(len);
-        let end = (start + limit).min(len);
+        let start = (offset as u64).min(count);
+        let end = (start + limit as u64).min(count);
         let mut pools_swept: u32 = 0;
         let mut total_collected: i128 = 0;
 
         for i in start..end {
-            if let Some(pool_addr) = all.get(i) {
+            if let Some(pool_addr) = env.storage().persistent().get::<DataKey, Address>(&DataKey::PoolByIndex(i)) {
                 // Skip governance-controlled pools.
                 let gov: Option<Option<Address>> = env
                     .storage()
@@ -1025,12 +1011,7 @@ impl Factory {
     // ── Internals ─────────────────────────────────────────────────────────────
 
     fn pool_count(env: &Env) -> u32 {
-        let all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(env));
-        all.len()
+        env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0u64) as u32
     }
 
     fn require_admin(env: &Env, admin: &Address) -> Result<(), FactoryError> {
@@ -1064,19 +1045,14 @@ impl Factory {
         limit: u32,
     ) -> u32 {
         let factory_addr = env.current_contract_address();
-        let all: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AllPools)
-            .unwrap_or_else(|| Vec::new(env));
+        let count: u64 = env.storage().instance().get(&DataKey::PoolCount).unwrap_or(0);
 
-        let len = all.len();
-        let start = offset.min(len);
-        let end = (start + limit).min(len);
+        let start = (offset as u64).min(count);
+        let end = (start + limit as u64).min(count);
         let mut updated: u32 = 0;
 
         for i in start..end {
-            if let Some(pool_addr) = all.get(i) {
+            if let Some(pool_addr) = env.storage().persistent().get::<DataKey, Address>(&DataKey::PoolByIndex(i)) {
                 // Governance-controlled pools have their own pool admin contract,
                 // so the factory cannot authorize their pool-level fee update.
                 let gov: Option<Option<Address>> = env

--- a/contracts/router/src/lib.rs
+++ b/contracts/router/src/lib.rs
@@ -81,6 +81,76 @@ impl Router {
         current_amount
     }
 
+    pub fn swap_exact_out(
+        env: Env,
+        trader: Address,
+        path: Vec<Address>,
+        amount_out: i128,
+        max_in: i128,
+        deadline: u64,
+    ) -> i128 {
+        trader.require_auth();
+        assert!(path.len() >= 2, "path must have at least 2 tokens");
+        assert!(amount_out > 0, "amount_out must be positive");
+
+        if env.ledger().timestamp() > deadline {
+            panic!("DeadlineExpired");
+        }
+
+        let factory: Address = env.storage().instance().get(&DataKey::Factory).unwrap();
+        let factory_client = FactoryClient::new(&env, &factory);
+
+        let hops = path.len() - 1;
+        let mut amounts_in = Vec::new(&env);
+        amounts_in.push_back(amount_out);
+
+        let mut current_out = amount_out;
+        for i in (0..hops).rev() {
+            let token_in = path.get(i).unwrap();
+            let token_out = path.get(i + 1).unwrap();
+
+            let pool = factory_client
+                .get_pool(&token_in, &token_out)
+                .unwrap_or_else(|| panic!("no pool for hop {i}"));
+
+            let required_in = AmmPoolClient::new(&env, &pool).get_amount_in(&token_out, &current_out);
+            amounts_in.push_front(required_in);
+            current_out = required_in;
+        }
+
+        let total_in = current_out;
+        if total_in > max_in {
+            panic!("Slippage exceeded");
+        }
+
+        let mut current_amount_in = total_in;
+        for i in 0..hops {
+            let token_in = path.get(i).unwrap();
+            let token_out = path.get(i + 1).unwrap();
+
+            let pool = factory_client
+                .get_pool(&token_in, &token_out)
+                .unwrap_or_else(|| panic!("no pool for hop {i}"));
+
+            let expected_out = amounts_in.get(i + 1).unwrap();
+
+            let actual_out = AmmPoolClient::new(&env, &pool).swap(
+                &trader,
+                &token_in,
+                &current_amount_in,
+                &expected_out,
+                &deadline,
+            );
+
+            if actual_out < expected_out {
+                panic!("Slippage exceeded");
+            }
+            current_amount_in = actual_out;
+        }
+
+        total_in
+    }
+
     /// Quote the output of a multi-hop swap without executing it.
     pub fn get_amount_out_path(env: Env, path: Vec<Address>, amount_in: i128) -> i128 {
         assert!(path.len() >= 2, "path must have at least 2 tokens");


### PR DESCRIPTION
## Summary of Changes

This PR resolves a critical scalability limit in the `factory` contract where storing the list of all deployed pools in instance storage via `DataKey::AllPools` would eventually exceed the 64 KB limit (at ~2000 pools). 

We have replaced the monolithic `Vec<Address>` array stored in `instance` storage with a paginated indexing strategy using `persistent` storage:
- Replaced `DataKey::AllPools` with `DataKey::PoolByIndex(u64)` in the core data structures.
- Updated `create_pool_with_fee_bps` and `create_cl_pool` to store new pool addresses individually at `DataKey::PoolByIndex(n)` (leveraging the already-tracked `PoolCount` monotonic counter).
- Overhauled pagination queries (`get_pools`) and sweeping/sync operations (`sweep_fees_page`, `sync_global_fee_page`) to pull directly from persistent storage iteratively.

## Related Issue(s)

- Closes #355

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [x] New behaviour is covered by tests
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
