### PR TITLE
fix(amm): emergency_withdraw bypasses configured k-of-n multisig

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -457,6 +457,18 @@ impl AmmPool {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
+        // If a k-of-n multisig guard is configured, the single-admin path must
+        // not be allowed to drain reserves. Callers must use the multisig flow
+        // (propose_emergency_withdraw / exec_multisig_emergency_wd) instead.
+        let quorum: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigQuorum)
+            .unwrap_or(0);
+        if quorum > 0 {
+            return Err(AmmError::Unauthorized);
+        }
+
         // Record audit information
         let ts: u64 = env.ledger().timestamp();
         env.storage()


### PR DESCRIPTION
@
Closes #373

`amm::emergency_withdraw` only called `admin.require_auth()` and never consulted the multisig guard configured via `set_multisig`. This let a single admin key drain all pool reserves even when a k-of-n quorum had been configured, defeating the purpose of the multisig flow (`propose_emergency_withdraw` / `exec_multisig_emergency_wd`) and contradicting the `set_multisig` docstring ("Once set, emergency_withdraw requires quorum approvals from signers").

This change reads `DataKey::MultisigQuorum` at the top of `emergency_withdraw` and returns `Err(AmmError::Unauthorized)` when `quorum > 0`, directing callers to the multisig path. When no multisig is configured (`quorum == 0`) the function behaves exactly as before, so existing single-admin deployments are unaffected.
@