### PR TITLE
feat(concentrated_liquidity): add deadline parameter to modify_position

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ A V3-style tick-based AMM where liquidity providers specify a price range `[lowe
 |---|---|
 | `initialize(token_a, token_b, fee_bps, initial_tick)` | One-time pool setup |
 | `mint_position(provider, lower_tick, upper_tick, amount_a_desired, amount_b_desired, min_a, min_b) → (a, b)` | Open or add to a tick-range position |
-| `modify_position(provider, lower_tick, upper_tick, liquidity_delta, min_a, min_b) → (a, b)` | Increase liquidity on an existing position in place |
+| `modify_position(provider, lower_tick, upper_tick, liquidity_delta, min_a, min_b, deadline) → (a, b)` | Increase liquidity on an existing position in place |
 | `burn_position(provider, lower_tick, upper_tick, liquidity) → (a, b)` | Reduce or close a position and withdraw tokens |
 | `collect_fees(provider, lower_tick, upper_tick) → (a, b)` | Collect accrued fees for a position |
 | `get_position(provider, lower_tick, upper_tick) → Position` | Read a position's current state |

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -537,6 +537,11 @@ impl ConcentratedLiquidity {
     /// upper_tick)` storage key, settles accrued fees into `tokens_owed`, and
     /// computes the required token amounts from the current price before
     /// increasing the stored liquidity.
+    ///
+    /// `deadline` is a Unix timestamp (seconds); the call reverts with
+    /// [`ClError::DeadlineExpired`] once the ledger time has passed it. The
+    /// `min_a` / `min_b` slippage guards alone cannot protect a transaction
+    /// that sits in the mempool and later executes at a stale price.
     pub fn modify_position(
         env: Env,
         provider: Address,
@@ -545,7 +550,11 @@ impl ConcentratedLiquidity {
         liquidity_delta: i128,
         min_a: i128,
         min_b: i128,
+        deadline: u64,
     ) -> Result<(i128, i128), ClError> {
+        if env.ledger().timestamp() > deadline {
+            return Err(ClError::DeadlineExpired);
+        }
         if Self::is_paused(env.clone()) {
             return Err(ClError::Paused);
         }
@@ -2769,6 +2778,19 @@ mod tests {
     }
 
     #[test]
+    fn test_modify_position_deadline_expired() {
+        let env = Env::default();
+        let te = setup_test_env(&env, 0, 0);
+        env.ledger().set_timestamp(101);
+        // The deadline check runs before any position lookup, so an expired
+        // deadline must short-circuit regardless of position state.
+        let result = te
+            .client
+            .try_modify_position(&te.provider, &-100, &100, &1000, &0, &0, &100);
+        assert_eq!(result, Err(Ok(ClError::DeadlineExpired)));
+    }
+
+    #[test]
     fn test_non_overlapping_fee_collection() {
         let env = Env::default();
         let te = setup_test_env(&env, 1000, 100); // 10% fee, start at tick 100
@@ -3498,6 +3520,7 @@ mod test_new_features {
             &5_000_i128,
             &0_i128,
             &0_i128,
+            &u64::MAX,
         );
 
         assert_eq!(added_a, quote.0, "modify_position must use the current-price quote for token A");

--- a/packages/sdk/src/cl.ts
+++ b/packages/sdk/src/cl.ts
@@ -297,7 +297,7 @@ export class ConcentratedLiquidityClient {
 
   /**
    * Parameters for `modify_position(provider, lower_tick, upper_tick,
-   * liquidity_delta, min_a, min_b)`.
+   * liquidity_delta, min_a, min_b, deadline)`.
    * Returns `(amount_a, amount_b)`.
    */
   modifyPositionParams(
@@ -306,9 +306,10 @@ export class ConcentratedLiquidityClient {
     upperTick: number,
     liquidityDelta: bigint,
     minA: bigint,
-    minB: bigint
+    minB: bigint,
+    deadline: bigint
   ): xdr.ScVal[] {
-    return [addr(provider), i32(lowerTick), i32(upperTick), i128(liquidityDelta), i128(minA), i128(minB)];
+    return [addr(provider), i32(lowerTick), i32(upperTick), i128(liquidityDelta), i128(minA), i128(minB), u64(deadline)];
   }
 
   /**


### PR DESCRIPTION
## Summary

`concentrated_liquidity::modify_position` accepted slippage guards (`min_a`, `min_b`) but no `deadline`, unlike `swap` and `mint_position_single_token` which both check one. Without a deadline a `modify_position` transaction can sit in the mempool for an arbitrarily long time and execute at a stale price — the slippage guard alone does not protect against time-based manipulation.

## Fix

Add `deadline: u64` as the last parameter and revert with `ClError::DeadlineExpired` when `env.ledger().timestamp() > deadline`, matching the existing guard used in `swap` and `mint_position_single_token`. The check runs first, before auth and position lookup.

Kept in sync:
- `packages/sdk/src/cl.ts` — `modifyPositionParams` now takes and encodes `deadline`.
- `README.md` — updated `modify_position` signature.

## Testing

- Added `test_modify_position_deadline_expired` to the deadline test suite, asserting an expired deadline returns `ClError::DeadlineExpired`.
- Updated the existing `modify_position` test call to pass `u64::MAX`.
- `cargo test -p concentrated_liquidity` — 106 passed.

closes #362
