### PR TITLE
fix(batch_router): return token amounts from remove_liquidity ops

### DIFF
--- a/contracts/batch_router/src/lib.rs
+++ b/contracts/batch_router/src/lib.rs
@@ -45,6 +45,23 @@ pub enum BatchOp {
     RemoveLiquidity(RemoveLiquidityOp),
 }
 
+/// Result of a single [`BatchOp`], preserving the real output of each leg so
+/// callers chaining batch results can do downstream accounting.
+///
+/// `RemoveLiquidity` carries both token amounts: packing them into one `i128`
+/// would be lossy, and returning the shares burned (which the caller already
+/// knows) tells them nothing about the tokens actually received.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BatchOpResult {
+    /// Output amount received from the swap.
+    Swap(i128),
+    /// LP shares minted by adding liquidity.
+    AddLiquidity(i128),
+    /// Token amounts `(amount_a, amount_b)` returned by removing liquidity.
+    RemoveLiquidity(i128, i128),
+}
+
 #[contract]
 pub struct BatchRouter;
 
@@ -59,7 +76,7 @@ impl BatchRouter {
         caller: Address,
         ops: Vec<BatchOp>,
         deadline: u64,
-    ) -> Vec<i128> {
+    ) -> Vec<BatchOpResult> {
         caller.require_auth();
         assert!(!ops.is_empty(), "empty batch");
         assert!(env.ledger().timestamp() <= deadline, "deadline expired");
@@ -86,25 +103,27 @@ impl BatchRouter {
         (ops_len, 1)
     }
 
-    fn execute_op(env: &Env, caller: &Address, op: &BatchOp, deadline: u64) -> i128 {
+    fn execute_op(env: &Env, caller: &Address, op: &BatchOp, deadline: u64) -> BatchOpResult {
         match op {
             BatchOp::Swap(op) => {
-                AmmPoolClient::new(env, &op.pool).swap(
+                let amount_out = AmmPoolClient::new(env, &op.pool).swap(
                     caller,
                     &op.token_in,
                     &op.amount_in,
                     &op.min_out,
                     &deadline,
-                )
+                );
+                BatchOpResult::Swap(amount_out)
             }
             BatchOp::AddLiquidity(op) => {
-                AmmPoolClient::new(env, &op.pool).add_liquidity(
+                let shares = AmmPoolClient::new(env, &op.pool).add_liquidity(
                     caller,
                     &op.amount_a,
                     &op.amount_b,
                     &op.min_shares,
                     &deadline,
-                )
+                );
+                BatchOpResult::AddLiquidity(shares)
             }
             BatchOp::RemoveLiquidity(op) => {
                 let (a, b) = AmmPoolClient::new(env, &op.pool).remove_liquidity(
@@ -114,9 +133,7 @@ impl BatchRouter {
                     &op.min_b,
                     &deadline,
                 );
-                // Pack both legs into one i128 result is lossy; return shares burned as marker.
-                let _ = (a, b);
-                op.shares
+                BatchOpResult::RemoveLiquidity(a, b)
             }
         }
     }
@@ -214,7 +231,10 @@ mod tests {
             .execute_batch(&trader, &ops, &deadline);
 
         assert_eq!(results.len(), 3);
-        assert!(results.get(0).unwrap() > 0);
+        match results.get(0).unwrap() {
+            BatchOpResult::Swap(out) => assert!(out > 0),
+            other => panic!("expected swap result, got {other:?}"),
+        }
     }
 
     #[test]
@@ -258,9 +278,59 @@ mod tests {
             BatchRouterClient::new(&env, &batch_addr).execute_batch(&trader, &ops, &deadline);
 
         assert_eq!(results.len(), 2);
-        assert!(results.get(0).unwrap() > 0);
-        assert!(results.get(1).unwrap() > 0);
+        match results.get(0).unwrap() {
+            BatchOpResult::Swap(out) => assert!(out > 0),
+            other => panic!("expected swap result, got {other:?}"),
+        }
+        match results.get(1).unwrap() {
+            BatchOpResult::AddLiquidity(shares) => assert!(shares > 0),
+            other => panic!("expected add-liquidity result, got {other:?}"),
+        }
         let _ = swap_out;
+    }
+
+    #[test]
+    fn test_batch_remove_liquidity_returns_token_amounts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (ta, tb, pool, _) = setup_pool(&env);
+
+        // The LP adds liquidity directly so the batch can later remove it.
+        let lp = Address::generate(&env);
+        StellarAssetClient::new(&env, &ta).mint(&lp, &500_000_i128);
+        StellarAssetClient::new(&env, &tb).mint(&lp, &500_000_i128);
+        let shares = AmmPoolClient::new(&env, &pool).add_liquidity(
+            &lp,
+            &400_000_i128,
+            &400_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+
+        let ops = vec![
+            &env,
+            BatchOp::RemoveLiquidity(RemoveLiquidityOp {
+                pool: pool.clone(),
+                shares,
+                min_a: 0_i128,
+                min_b: 0_i128,
+            }),
+        ];
+
+        let batch_addr = env.register_contract(None, BatchRouter);
+        let deadline = env.ledger().timestamp() + 1000;
+        let results =
+            BatchRouterClient::new(&env, &batch_addr).execute_batch(&lp, &ops, &deadline);
+
+        assert_eq!(results.len(), 1);
+        // The actual token amounts received are reported, not the shares burned.
+        match results.get(0).unwrap() {
+            BatchOpResult::RemoveLiquidity(a, b) => {
+                assert!(a > 0, "expected token_a out, got {a}");
+                assert!(b > 0, "expected token_b out, got {b}");
+            }
+            other => panic!("expected remove-liquidity result, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In `contracts/batch_router/src/lib.rs`, `execute_batch` returned `Vec<i128>` and the `RemoveLiquidity` arm of `execute_op` threw away the `(amount_a, amount_b)` returned by `remove_liquidity`, reporting the number of shares burned instead:

```rust
let (a, b) = AmmPoolClient::new(env, &op.pool).remove_liquidity(...);
// Pack both legs into one i128 result is lossy; return shares burned as marker.
let _ = (a, b);
op.shares
```

The shares burned are an input the caller already supplied, so the result told them nothing about the tokens actually received. Callers chaining batch results had no way to do downstream accounting for a remove-liquidity leg.

## Fix

Introduce a typed `BatchOpResult` enum that preserves each leg's real output:

```rust
pub enum BatchOpResult {
    Swap(i128),                   // amount out
    AddLiquidity(i128),           // shares minted
    RemoveLiquidity(i128, i128),  // (amount_a, amount_b)
}
```

`execute_batch` now returns `Vec<BatchOpResult>`, and `execute_op` returns the matching variant for each operation. Both token amounts from `remove_liquidity` are carried through without the lossy `i128` packing.

This is an intentional change to the public return type (`Vec<i128>` to `Vec<BatchOpResult>`); no other contract in the workspace consumes `execute_batch`.

## Testing

- Existing swap / add-liquidity tests updated to match on the new variants.
- New `test_batch_remove_liquidity_returns_token_amounts` asserts both token amounts are reported (not the shares burned).
- `cargo test -p batch_router` — 5 passed, 0 failed.

closes #375
