### PR TITLE
fix(batch_auction): validate pool token pair in submit_order

### DIFF
--- a/contracts/batch_auction/src/lib.rs
+++ b/contracts/batch_auction/src/lib.rs
@@ -38,6 +38,8 @@ pub enum AuctionError {
     DeadlineExceeded = 7,
     BatchFull = 8,
     InvalidMaxOrders = 9,
+    /// `token_in`/`token_out` do not match the pool's token pair (issue #361).
+    InvalidPoolTokenPair = 10,
 }
 
 // ── Storage types ─────────────────────────────────────────────────────────────
@@ -113,8 +115,8 @@ impl BatchAuction {
     /// Submit a swap order and escrow `amount_in` of `token_in`.
     ///
     /// Tokens are pulled from `trader` immediately so the batch holds a firm
-    /// commitment. `token_out` must be the other pool token (not validated
-    /// on-chain — mismatches are caught at settlement time).
+    /// commitment. `token_in`/`token_out` must be the pool's token pair; this
+    /// is validated here so a mismatched order can never reach `settle_batch`.
     ///
     /// Returns the new order ID.
     pub fn submit_order(
@@ -132,6 +134,18 @@ impl BatchAuction {
         }
         if amount_in <= 0 {
             return Err(AuctionError::ZeroAmount);
+        }
+
+        // Validate the order's tokens against the pool's actual pair up front.
+        // If a mismatched pair slipped through, settle_batch would call swap
+        // with the wrong tokens and panic; since settlement is atomic, that
+        // panic reverts the whole batch and locks every other trader's escrow
+        // until each order is cancelled individually (issue #361).
+        let info = AmmPoolClient::new(&env, &pool).get_info();
+        let valid_pair = (token_in == info.token_a && token_out == info.token_b)
+            || (token_in == info.token_b && token_out == info.token_a);
+        if !valid_pair {
+            return Err(AuctionError::InvalidPoolTokenPair);
         }
 
         let mut pending: Vec<u64> = env
@@ -486,6 +500,48 @@ mod tests {
         // Trader received token_b.
         let tb_balance = StellarTokenClient::new(&env, &tb).balance(&trader);
         assert!(tb_balance > 0);
+    }
+
+    #[test]
+    fn test_submit_order_rejects_mismatched_pool_tokens() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        env.ledger().set_timestamp(1000);
+
+        let (ta, _tb, pool, admin) = setup(&env);
+
+        // A token that is not part of the pool's pair.
+        let foreign_admin = Address::generate(&env);
+        let foreign = env
+            .register_stellar_asset_contract_v2(foreign_admin)
+            .address();
+
+        let auction_addr = env.register_contract(None, BatchAuction);
+        let client = BatchAuctionClient::new(&env, &auction_addr);
+        client.initialize(&admin, &30_u64);
+
+        let trader = Address::generate(&env);
+        StellarAssetClient::new(&env, &ta).mint(&trader, &100_000_i128);
+
+        // token_out is not the pool's other token → rejected up front.
+        let result = client.try_submit_order(
+            &trader,
+            &pool,
+            &ta,
+            &foreign,
+            &10_000_i128,
+            &0_i128,
+            &u64::MAX,
+        );
+        assert_eq!(result, Err(Ok(AuctionError::InvalidPoolTokenPair)));
+
+        // The order is rejected before any escrow, so the trader keeps its funds
+        // and no order is recorded in the batch.
+        assert_eq!(
+            StellarTokenClient::new(&env, &ta).balance(&trader),
+            100_000_i128
+        );
+        assert_eq!(client.get_pending_orders().len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`submit_order` in `contracts/batch_auction/src/lib.rs` escrowed `token_in` from the trader but did not validate that `token_in`/`token_out` actually belong to the target pool — the original comment even noted the pair was "not validated on-chain — mismatches are caught at settlement time".

That is the problem: a mismatched pool/token pair is only discovered in `settle_batch`, where `AmmPoolClient::swap` is called with the wrong tokens and panics. Because `settle_batch` is atomic, the panic reverts the entire batch, so every other trader's escrowed funds stay locked in that batch window until each order is cancelled individually. A single malformed order grief-locks the whole batch.

## Fix

Validate the pair at `submit_order` time, before any tokens are escrowed, by reading the pool's `get_info()` and asserting the order's tokens are exactly the pool's pair:

```rust
let info = AmmPoolClient::new(&env, &pool).get_info();
let valid_pair = (token_in == info.token_a && token_out == info.token_b)
    || (token_in == info.token_b && token_out == info.token_a);
if !valid_pair {
    return Err(AuctionError::InvalidPoolTokenPair);
}
```

A new typed error `AuctionError::InvalidPoolTokenPair` is returned instead of letting the order panic at settlement. Validating before escrow also means a rejected order pulls no funds.

## Testing

- New `test_submit_order_rejects_mismatched_pool_tokens` asserts a foreign `token_out` is rejected with `InvalidPoolTokenPair`, the trader's balance is untouched, and no order is recorded.
- `cargo test -p batch_auction` — 7 passed, 0 failed.

closes #361
