### PR TITLE
fix: governance two-step admin rotation and TWAL tracked-pools persistent storage

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -68,6 +68,7 @@ pub enum GovernanceError {
     NotVetoMultisig = 30,
     InsufficientSnapshotBal = 31,
     VetoMultisigNotSet = 32,
+    NoPendingAdmin = 33,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -82,6 +83,8 @@ pub enum DataKey {
     ProposalCount,
     /// Governance admin.
     Admin,
+    /// Pending admin nomination for two-step handover.
+    PendingAdmin,
     /// Minimum proposer stake in basis points of total LP supply.
     MinProposerStakeBps,
     /// Voting period in seconds (configurable at initialize).
@@ -424,6 +427,59 @@ impl Governance {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DataKey::Timelock, &new_delay);
+        Ok(())
+    }
+
+    /// Admin-only: nominate a new governance admin.
+    ///
+    /// The nominee must call `accept_admin` to complete the two-step handover,
+    /// preventing a single compromised transaction from taking over the contract.
+    pub fn propose_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), GovernanceError> {
+        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if current_admin != stored {
+            return Err(GovernanceError::Unauthorized);
+        }
+        current_admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &Some(new_admin.clone()));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "admin_nominated"),),
+            (current_admin, new_admin)
+        );
+        Ok(())
+    }
+
+    /// Accept a pending governance admin nomination.
+    ///
+    /// Only the nominated address can call this, and it must authorize the
+    /// transaction. On success the stored admin is updated and the pending
+    /// nomination is cleared.
+    pub fn accept_admin(env: Env, new_admin: Address) -> Result<(), GovernanceError> {
+        let pending: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .unwrap_or(None);
+        let nominee = pending.ok_or(GovernanceError::NoPendingAdmin)?;
+        if new_admin != nominee {
+            return Err(GovernanceError::Unauthorized);
+        }
+        new_admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &Option::<Address>::None);
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "admin_changed"),),
+            (new_admin,)
+        );
         Ok(())
     }
 
@@ -1310,6 +1366,7 @@ mod tests {
         gov_addr: Address,
         lp_addr: Address,
         amm_addr: Address,
+        admin: Address,
     }
 
     fn setup_suite(initial_fee_bps: i128) -> Suite {
@@ -1366,6 +1423,7 @@ mod tests {
             gov_addr,
             lp_addr,
             amm_addr,
+            admin,
         }
     }
 
@@ -2820,5 +2878,46 @@ mod prop_tests {
                 Ok(())
             })
             .unwrap();
+    }
+
+    // ── Admin rotation (#379) ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_propose_admin_requires_current_admin() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+        let rando = Address::generate(&s.env);
+        let nominee = Address::generate(&s.env);
+        assert!(gov.try_propose_admin(&rando, &nominee).is_err());
+    }
+
+    #[test]
+    fn test_accept_admin_requires_pending_nomination() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+        let nominee = Address::generate(&s.env);
+        assert!(gov.try_accept_admin(&nominee).is_err());
+    }
+
+    #[test]
+    fn test_admin_rotation_two_step_handover() {
+        let s = setup_suite(30);
+        let gov = GovernanceClient::new(&s.env, &s.gov_addr);
+        let new_admin = Address::generate(&s.env);
+
+        // Current admin nominates the new admin.
+        gov.propose_admin(&s.admin, &new_admin);
+
+        // A non-nominee cannot accept.
+        let rando = Address::generate(&s.env);
+        assert!(gov.try_accept_admin(&rando).is_err());
+
+        // The nominee accepts and becomes admin.
+        gov.accept_admin(&new_admin);
+
+        // Old admin can no longer nominate; new admin can.
+        let another = Address::generate(&s.env);
+        assert!(gov.try_propose_admin(&s.admin, &another).is_err());
+        gov.propose_admin(&new_admin, &another);
     }
 }

--- a/contracts/twal_consumer/src/lib.rs
+++ b/contracts/twal_consumer/src/lib.rs
@@ -24,7 +24,8 @@ pub enum DataKey {
     /// Address authorized to write snapshots (a keeper bot or governance).
     Keeper,
     LiquiditySnapshot(Address, u64),
-    TrackedPools,
+    /// Persistent registry of tracked pools to avoid instance storage limits.
+    TrackedPoolsPersistent,
 }
 
 #[contracttype]
@@ -85,24 +86,34 @@ impl TwalConsumer {
             Self::SNAPSHOT_TTL_LEDGERS,
         );
 
+        Self::register_tracked_pool(&env, &pool);
+    }
+
+    /// Register a pool in the persistent tracked-pools list, deduplicating entries.
+    fn register_tracked_pool(env: &Env, pool: &Address) {
         let mut tracked: Vec<Address> = env
             .storage()
-            .instance()
-            .get(&DataKey::TrackedPools)
-            .unwrap_or_else(|| Vec::new(&env));
+            .persistent()
+            .get(&DataKey::TrackedPoolsPersistent)
+            .unwrap_or_else(|| Vec::new(env));
         let mut already = false;
         for i in 0..tracked.len() {
-            if tracked.get(i).unwrap() == pool {
+            if tracked.get(i).unwrap() == *pool {
                 already = true;
                 break;
             }
         }
         if !already {
-            tracked.push_back(pool);
-            env.storage()
-                .instance()
-                .set(&DataKey::TrackedPools, &tracked);
+            tracked.push_back(pool.clone());
         }
+        env.storage()
+            .persistent()
+            .set(&DataKey::TrackedPoolsPersistent, &tracked);
+        env.storage().persistent().extend_ttl(
+            &DataKey::TrackedPoolsPersistent,
+            Self::SNAPSHOT_TTL_LEDGERS / 2,
+            Self::SNAPSHOT_TTL_LEDGERS,
+        );
     }
 
     /// Average pool liquidity (sqrt(reserve_a * reserve_b)) over `window_seconds`.
@@ -144,8 +155,8 @@ impl TwalConsumer {
 
     pub fn get_tracked_pools(env: Env) -> Vec<Address> {
         env.storage()
-            .instance()
-            .get(&DataKey::TrackedPools)
+            .persistent()
+            .get(&DataKey::TrackedPoolsPersistent)
             .unwrap_or_else(|| Vec::new(&env))
     }
 
@@ -167,24 +178,7 @@ impl TwalConsumer {
             Self::SNAPSHOT_TTL_LEDGERS,
         );
 
-        let mut tracked: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::TrackedPools)
-            .unwrap_or_else(|| Vec::new(&env));
-        let mut already = false;
-        for i in 0..tracked.len() {
-            if tracked.get(i).unwrap() == pool {
-                already = true;
-                break;
-            }
-        }
-        if !already {
-            tracked.push_back(pool);
-            env.storage()
-                .instance()
-                .set(&DataKey::TrackedPools, &tracked);
-        }
+        Self::register_tracked_pool(&env, &pool);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #379 and #377.

This PR addresses two independent storage/auth issues:

1. **Governance admin rotation (#379)** — the governance contract stored a single immutable admin with no safe handover path.
2. **TWAL consumer tracked-pools overflow (#377)** — the tracked-pools registry was stored in instance storage, which is capped at ~64 KB and becomes unwritable at scale.

---

## Fixes

### Governance: two-step admin handover (#379)

- Added `propose_admin(env, current_admin, new_admin)` that stores a pending admin nominee under the new `DataKey::PendingAdmin`.
- Added `accept_admin(env, new_admin)` that completes the transfer after the nominee authorizes the call.
- Added `GovernanceError::NoPendingAdmin` for the case where `accept_admin` is called without an active nomination.
- Emits `admin_nominated` and `admin_changed` events, matching the event pattern used by the AMM contract.
- Added unit tests covering:
  - only the current admin can nominate,
  - a non-nominee cannot accept,
  - full two-step handover changes the stored admin.

This mirrors the existing `propose_admin` / `accept_admin` implementation in `contracts/amm/src/lib.rs`.

### TWAL consumer: persistent tracked-pools registry (#377)

- Moved `TrackedPools` from instance storage to persistent storage and renamed the key to `TrackedPoolsPersistent` (consistent with `twap_consumer`).
- Added a private `register_tracked_pool` helper used by both `save_snapshot` and `save_cl_snapshot` that:
  - deduplicates pool addresses,
  - writes the registry to persistent storage,
  - calls `extend_ttl` on every write, matching the per-snapshot TTL pattern already used for `LiquiditySnapshot` keys.
- Updated `get_tracked_pools` to read from persistent storage.

This prevents the instance storage limit from making the contract state unwritable as the number of tracked pools grows.

---

## Verification

- `cargo wasm -p twal-consumer -p governance` builds successfully.
- Native `cargo test` could not be executed in this Windows environment because the build toolchain is missing `dlltool.exe`; the contract WASM compiles cleanly, and the test code was added following the existing test patterns in the repository.

Closes #379 
Closes #377
