### PR TITLE
fix(twap-consumer): emit event on delete_snapshot and require keeper …

### DIFF
--- a/contracts/twap_consumer/src/lib.rs
+++ b/contracts/twap_consumer/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, Vec};
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, symbol_short, Address, Env, Vec};
 
 #[contractclient(name = "AmmPoolOracleClient")]
 pub trait AmmPoolOracle {
@@ -122,8 +122,12 @@ impl TwapConsumer {
     /// Deletes a price snapshot from persistent storage.
     pub fn delete_snapshot(env: Env, pool: Address, ledger_ts: u64) {
         Self::require_keeper(&env);
-        let key = DataKey::Snapshot(pool, ledger_ts);
+        let key = DataKey::Snapshot(pool.clone(), ledger_ts);
         env.storage().persistent().remove(&key);
+        env.events().publish(
+            (symbol_short!("snap_del"), pool),
+            ledger_ts,
+        );
     }
 
     /// Computes TWAP for token A in terms of token B over `window_seconds`.
@@ -911,5 +915,31 @@ mod tests {
         assert_eq!(consumer.get_keeper(), keeper);
         // A second initialize must be rejected.
         assert!(consumer.try_initialize(&Address::generate(&env)).is_err());
+    }
+
+    #[test]
+    fn test_delete_snapshot_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let keeper = Address::generate(&env);
+        let pool = Address::generate(&env);
+        let ledger_ts = 100u64;
+        let consumer_addr = env.register_contract(None, TwapConsumer);
+        let consumer = TwapConsumerClient::new(&env, &consumer_addr);
+        consumer.initialize(&keeper);
+
+        consumer.delete_snapshot(&pool, &ledger_ts);
+
+        let events = env.events().all();
+        let event = events.last().unwrap();
+        let (contract_id, topics, data) = event;
+
+        assert_eq!(contract_id, consumer_addr);
+        // topics are (symbol_short!("snap_del"), pool)
+        assert_eq!(topics.len(), 2);
+        assert_eq!(topics.get(0).unwrap(), symbol_short!("snap_del").to_val());
+        assert_eq!(topics.get(1).unwrap(), pool.to_val());
+        // data is ledger_ts
+        assert_eq!(data, ledger_ts.into_val(&env));
     }
 }


### PR DESCRIPTION
Summary of Changes

  This PR updates twap_consumer::delete_snapshot to emit a "snap_del" event upon successful execution. This improves
  observability for indexers and forensic auditing, ensuring that snapshot deletions can be tracked. Keeper
  authentication was already enforced for this function, so no changes to authorization logic were required.

  Related Issue(s)

   - Closes #381 

  Type of Change

   - [x] Bug fix
   - [ ] New feature
   - [ ] Refactor (no behaviour change)
   - [ ] Tests only
   - [ ] Documentation only
   - [ ] Chore (build, tooling, dependencies)

  Checklist

   - [x] cargo fmt has been run
   - [x] cargo clippy -- -D warnings passes with no new warnings
   - [x] cargo test passes
   - [x] New behaviour is covered by tests
   - [ ] If I changed a hot-path contract (amm, concentrated_liquidity, batch_auction), I ran cargo run -p benches --
     --write-baseline and committed the updated benches/baseline.json
   - [ ] Public interface changes are reflected in the README
   - [ ] CHANGELOG.md has been updated with any notable changes
   - [x] Commit messages follow the [Conventional Commits (https://www.conventionalcommits.org/) format