### PR TITLE
test+fix: AMM multisig emergency withdrawal integration tests

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -19,6 +19,7 @@ pub const WASM: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../target/wasm32v1-none/release/amm.wasm"
 ));
+
 // Standard SEP-41 interface for pool tokens (token_a, token_b)
 use soroban_sdk::token::Client as SepTokenClient;
 
@@ -53,6 +54,9 @@ pub trait LpTokenInterface {
     fn burn(env: Env, from: Address, amount: i128);
     fn balance(env: Env, id: Address) -> i128;
 }
+
+/// Lifetime of a multisig emergency-withdraw proposal before it expires.
+const MULTISIG_PROPOSAL_TTL_SECS: u64 = 7 * 24 * 60 * 60; // 7 days
 
 // ── Typed errors ─────────────────────────────────────────────────────────────
 
@@ -90,6 +94,10 @@ pub enum AmmError {
     OracleDeviationExceeded = 17,
     /// Flash-loan receiver did not return the borrowed amounts plus fees.
     FlashLoanRepaymentFailed = 18,
+    /// Multisig emergency withdrawal was already executed.
+    AlreadyExecuted = 19,
+    /// Multisig emergency withdrawal proposal has expired.
+    ProposalExpired = 20,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -134,6 +142,10 @@ pub enum DataKey {
     /// Pending emergency-withdraw proposal: (recipient, Vec<Address> approvals).
     MultisigProposalRecipient,
     MultisigProposalApprovals,
+    /// Expiration timestamp for the pending multisig proposal.
+    MultisigProposalExpiresAt,
+    /// Whether the pending multisig proposal has already been executed.
+    MultisigProposalExecuted,
 
     // Issue #294: minimum liquidity lock — LP tokens permanently locked on first deposit.
     /// Whether the minimum liquidity has already been locked (set on first deposit).
@@ -836,6 +848,12 @@ impl AmmPool {
             &DataKey::MultisigProposalApprovals,
             &soroban_sdk::Vec::<Address>::new(&env),
         );
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigProposalExpiresAt, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigProposalExecuted, &false);
         soroban_amm_sdk::emit_versioned_event!(
             env,
             (Symbol::new(&env, "multisig_set"), admin),
@@ -913,6 +931,13 @@ impl AmmPool {
         env.storage()
             .instance()
             .set(&DataKey::MultisigProposalApprovals, &approvals);
+        env.storage().instance().set(
+            &DataKey::MultisigProposalExpiresAt,
+            &(env.ledger().timestamp() + MULTISIG_PROPOSAL_TTL_SECS),
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigProposalExecuted, &false);
         soroban_amm_sdk::emit_versioned_event!(
             env,
             (Symbol::new(&env, "ms_proposed"), signer),
@@ -960,12 +985,28 @@ impl AmmPool {
         if !signers.contains(&signer) {
             return Err(AmmError::Unauthorized);
         }
+        let executed: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigProposalExecuted)
+            .unwrap_or(false);
+        if executed {
+            return Err(AmmError::AlreadyExecuted);
+        }
         let recipient: Option<Address> = env
             .storage()
             .instance()
             .get(&DataKey::MultisigProposalRecipient)
             .unwrap_or(None);
         let to = recipient.ok_or(AmmError::NoPendingAdmin)?;
+        let expires_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigProposalExpiresAt)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expires_at {
+            return Err(AmmError::ProposalExpired);
+        }
         let approvals: soroban_sdk::Vec<Address> = env
             .storage()
             .instance()
@@ -994,7 +1035,11 @@ impl AmmPool {
         }
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
-        // Clear proposal.
+        // Mark executed so re-execution returns AlreadyExecuted.
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigProposalExecuted, &true);
+        // Clear proposal details.
         env.storage().instance().set(
             &DataKey::MultisigProposalRecipient,
             &Option::<Address>::None,
@@ -1003,6 +1048,9 @@ impl AmmPool {
             &DataKey::MultisigProposalApprovals,
             &soroban_sdk::Vec::<Address>::new(&env),
         );
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigProposalExpiresAt, &0u64);
         soroban_amm_sdk::emit_versioned_event!(
             env,
             (Symbol::new(&env, "ms_ew"), signer),
@@ -1060,9 +1108,7 @@ impl AmmPool {
     }
 
     fn extend_ttl(env: &Env) {
-        env.storage()
-            .instance()
-            .extend_ttl(172_800, 518_400);
+        env.storage().instance().extend_ttl(172_800, 518_400);
     }
 
     /// Update the swap fee post-deployment. Admin-only.

--- a/contracts/integration-tests/src/lib.rs
+++ b/contracts/integration-tests/src/lib.rs
@@ -9,6 +9,9 @@
 #[cfg(test)]
 mod upgrade_integration_test;
 
+#[cfg(test)]
+mod multisig_emergency_withdraw_test;
+
 #[cfg(all(test, feature = "legacy-integration-matrix"))]
 mod tests {
     use soroban_sdk::{

--- a/contracts/integration-tests/src/multisig_emergency_withdraw_test.rs
+++ b/contracts/integration-tests/src/multisig_emergency_withdraw_test.rs
@@ -1,0 +1,250 @@
+//! Integration tests for the AMM k-of-n multisig emergency withdrawal flow.
+//!
+//! Issue #391: covers set_multisig, propose_emergency_withdraw,
+//! exec_multisig_emergency_wd, and the unilateral emergency_withdraw guard.
+
+use amm::{AmmError, AmmPool, AmmPoolClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+use token::LpToken;
+
+const DEADLINE: u64 = u64::MAX;
+
+fn set_ledger_ts(env: &Env, ts: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: ts,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 4096,
+        max_entry_ttl: 6_312_000,
+    });
+}
+
+struct Suite {
+    env: Env,
+    amm_addr: Address,
+    token_a: Address,
+    token_b: Address,
+    admin: Address,
+}
+
+fn setup_suite() -> Suite {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    env.mock_all_auths();
+    set_ledger_ts(&env, 1_000);
+
+    let admin = Address::generate(&env);
+    let token_a = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_b = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let lp_addr = env.register_contract(None, LpToken);
+    token::LpTokenClient::new(&env, &lp_addr).initialize(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "AMM LP"),
+        &soroban_sdk::String::from_str(&env, "ALP"),
+        &7u32,
+    );
+
+    let amm_addr = env.register_contract(None, AmmPool);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    amm.initialize(
+        &admin, &token_a, &token_b, &lp_addr, &30_i128, &admin, &0_i128,
+    );
+
+    // Seed the pool with reserves.
+    let provider = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_a).mint(&provider, &1_000_000_i128);
+    StellarAssetClient::new(&env, &token_b).mint(&provider, &1_000_000_i128);
+    amm.add_liquidity(&provider, &500_000_i128, &500_000_i128, &1_i128, &DEADLINE);
+
+    Suite {
+        env,
+        amm_addr,
+        token_a,
+        token_b,
+        admin,
+    }
+}
+
+fn signer_vec(env: &Env, signers: &[Address]) -> Vec<Address> {
+    let mut v = Vec::new(env);
+    for s in signers {
+        v.push_back(s.clone());
+    }
+    v
+}
+
+#[test]
+fn scenario_multisig_non_signer_proposal_fails() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let c = Address::generate(&s.env);
+    let non_signer = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone(), c.clone()]),
+        &2u32,
+    );
+
+    let result = amm.try_propose_emergency_withdraw(&non_signer, &recipient);
+    assert!(result.is_err(), "non-signer proposal should fail");
+}
+
+#[test]
+fn scenario_multisig_single_approval_does_not_execute() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let c = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone(), c.clone()]),
+        &2u32,
+    );
+
+    amm.propose_emergency_withdraw(&a, &recipient);
+
+    // Only one approval collected; execution must fail before quorum is reached.
+    let result = amm.try_exec_multisig_emergency_wd(&a);
+    assert!(result.is_err(), "execution with 1/2 approvals should fail");
+}
+
+#[test]
+fn scenario_multisig_quorum_triggers_emergency_withdrawal() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let c = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone(), c.clone()]),
+        &2u32,
+    );
+
+    let pool_a_before = TokenClient::new(&s.env, &s.token_a).balance(&s.amm_addr);
+    let pool_b_before = TokenClient::new(&s.env, &s.token_b).balance(&s.amm_addr);
+    let recipient_a_before = TokenClient::new(&s.env, &s.token_a).balance(&recipient);
+    let recipient_b_before = TokenClient::new(&s.env, &s.token_b).balance(&recipient);
+
+    amm.propose_emergency_withdraw(&a, &recipient);
+    amm.exec_multisig_emergency_wd(&b);
+
+    // Pool reserves should have been drained to the recipient.
+    assert_eq!(
+        TokenClient::new(&s.env, &s.token_a).balance(&s.amm_addr),
+        0,
+        "reserve_a should be drained"
+    );
+    assert_eq!(
+        TokenClient::new(&s.env, &s.token_b).balance(&s.amm_addr),
+        0,
+        "reserve_b should be drained"
+    );
+    assert_eq!(
+        TokenClient::new(&s.env, &s.token_a).balance(&recipient),
+        recipient_a_before + pool_a_before,
+        "recipient should receive token_a reserves"
+    );
+    assert_eq!(
+        TokenClient::new(&s.env, &s.token_b).balance(&recipient),
+        recipient_b_before + pool_b_before,
+        "recipient should receive token_b reserves"
+    );
+}
+
+#[test]
+fn scenario_multisig_re_execution_returns_already_executed() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone()]),
+        &2u32,
+    );
+
+    amm.propose_emergency_withdraw(&a, &recipient);
+    amm.exec_multisig_emergency_wd(&b);
+
+    // Re-executing the same proposal must fail with AlreadyExecuted.
+    let result = amm.try_exec_multisig_emergency_wd(&a);
+    assert_eq!(
+        result,
+        Err(Ok(AmmError::AlreadyExecuted)),
+        "second execution should return AlreadyExecuted"
+    );
+}
+
+#[test]
+fn scenario_multisig_expired_proposal_cannot_execute() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone()]),
+        &2u32,
+    );
+
+    amm.propose_emergency_withdraw(&a, &recipient);
+
+    // Advance past the 7-day proposal TTL.
+    set_ledger_ts(&s.env, 1_000 + (7 * 24 * 60 * 60) + 1);
+
+    let result = amm.try_exec_multisig_emergency_wd(&b);
+    assert_eq!(
+        result,
+        Err(Ok(AmmError::ProposalExpired)),
+        "expired proposal should return ProposalExpired"
+    );
+}
+
+#[test]
+fn scenario_plain_emergency_withdraw_blocked_with_multisig() {
+    let s = setup_suite();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+
+    let amm = AmmPoolClient::new(&s.env, &s.amm_addr);
+    amm.set_multisig(
+        &s.admin,
+        &signer_vec(&s.env, &[a.clone(), b.clone()]),
+        &2u32,
+    );
+
+    // Even the admin must use the multisig flow when a quorum is configured.
+    let result = amm.try_emergency_withdraw(&recipient);
+    assert_eq!(
+        result,
+        Err(Ok(AmmError::Unauthorized)),
+        "plain emergency_withdraw should be blocked while multisig guard is active"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #391.

This PR adds the missing integration tests for the AMM k-of-n multisig emergency-withdraw flow and implements the two state-machine checks required by the test scenarios (`AlreadyExecuted` and `ProposalExpired`).

---

## Changes

### AMM contract changes

- Added `AmmError::AlreadyExecuted` and `AmmError::ProposalExpired` error variants.
- Added a 7-day TTL constant for multisig emergency proposals (`MULTISIG_PROPOSAL_TTL_SECS`).
- Added two new storage keys:
  - `MultisigProposalExpiresAt` — set when a proposal is created.
  - `MultisigProposalExecuted` — set to `true` after a successful execution.
- `set_multisig` now clears the new proposal TTL and executed flag when the multisig config changes.
- `propose_emergency_withdraw` records the expiration timestamp and resets the executed flag.
- `exec_multisig_emergency_wd` now:
  1. Re-execution of an already-executed proposal returns `AlreadyExecuted`.
  2. Execution after the TTL returns `ProposalExpired`.
  3. Marks the proposal executed before clearing recipient/approvals.

### Integration tests

Added `contracts/integration-tests/src/multisig_emergency_withdraw_test.rs`, wired into `lib.rs`, covering all six required scenarios:

1. `scenario_multisig_non_signer_proposal_fails` — `propose_emergency_withdraw` from a non-signer is rejected.
2. `scenario_multisig_single_approval_does_not_execute` — 1/2 approvals cannot execute.
3. `scenario_multisig_quorum_triggers_emergency_withdrawal` — signer A proposes, signer B co-signs (2/2), reserves are transferred to the recipient, and pool balances are drained.
4. `scenario_multisig_re_execution_returns_already_executed` — second `exec_multisig_emergency_wd` returns `AlreadyExecuted`.
5. `scenario_multisig_expired_proposal_cannot_execute` — execution after the 7-day TTL returns `ProposalExpired`.
6. `scenario_plain_emergency_withdraw_blocked_with_multisig` — the single-admin `emergency_withdraw` is rejected with `Unauthorized` while a quorum > 0 is configured (covers #373).

---

## Verification

- `cargo wasm -p amm` builds successfully.
- `cargo check -p integration-tests --tests --target x86_64-pc-windows-msvc` compiles cleanly (native test execution is blocked in this Windows environment by a broken `link.exe`/`dlltool.exe` toolchain).
