### PR TITLE
fix: guard update_rewards against reward pool overdraft

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -696,6 +696,7 @@ impl Staking {
             .instance()
             .get(&DataKey::RewardPoolBalance)
             .unwrap_or(0);
+        assert!(new_rewards <= pool_balance, "insufficient reward pool balance");
         env.storage()
             .instance()
             .set(&DataKey::RewardPoolBalance, &(pool_balance - new_rewards));


### PR DESCRIPTION
Add assert!(new_rewards <= pool_balance) to prevent admin from scheduling more rewards than the pool holds. Without this check, RewardPoolBalance goes negative and acc_per_share is inflated, leading to claim/unstake reverts on reward-token transfer.

## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

Closes #421