### PR TITLE
fix(oracle_aggregator): bound source agreement by a deviation band

### DIFF
--- a/contracts/oracle_aggregator/src/lib.rs
+++ b/contracts/oracle_aggregator/src/lib.rs
@@ -1,4 +1,17 @@
 #![no_std]
+//! Oracle aggregator: reports the median price over **fresh, agreeing**
+//! sources.
+//!
+//! A quote contributes to the result only when it is both fresh (reported
+//! within `max_staleness_seconds`) and *agreeing* — within a configurable
+//! deviation band (in basis points) of the median of the fresh quotes.
+//! Sources outside the band are dropped and reported via a `deviant` event,
+//! and only agreeing sources are counted toward `confidence`. This ensures a
+//! high confidence score actually implies the sources agree: a single wildly
+//! deviating feed can no longer inflate confidence or drag the reported price
+//! toward an attacker's value. The band defaults to
+//! [`DEFAULT_MAX_DEVIATION_BPS`] and is tunable by the admin via
+//! [`OracleAggregator::set_max_deviation_bps`].
 
 use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype,
@@ -42,6 +55,7 @@ pub enum OracleError {
     SourceNotFound = 5,
     InsufficientSources = 6,
     InvalidStaleness = 7,
+    InvalidDeviation = 8,
 }
 
 // ── Storage ────────────────────────────────────────────────────────────────
@@ -51,9 +65,19 @@ pub enum DataKey {
     Admin,
     MaxStaleness,
     Sources,
+    MaxDeviationBps,
 }
 
 pub const MIN_VALID_SOURCES: u32 = 2;
+
+/// Basis-points denominator (100% = 10_000 bps).
+pub const BPS_DENOMINATOR: i128 = 10_000;
+
+/// Default deviation band: a fresh quote must be within 5% of the median of
+/// the fresh quotes to count as agreeing. Chosen tight enough to flag the
+/// "pull the price halfway to the attacker" manipulation described in the
+/// aggregator's threat model, while tolerating normal cross-venue spread.
+pub const DEFAULT_MAX_DEVIATION_BPS: u32 = 500;
 
 // ── Adapter client (UPDATED) ───────────────────────────────────────────────
 
@@ -83,6 +107,9 @@ impl OracleAggregator {
         env.storage()
             .instance()
             .set(&DataKey::MaxStaleness, &max_staleness_seconds);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxDeviationBps, &DEFAULT_MAX_DEVIATION_BPS);
 
         let empty: Vec<OracleSource> = Vec::new(&env);
         env.storage().instance().set(&DataKey::Sources, &empty);
@@ -174,6 +201,9 @@ impl OracleAggregator {
             .unwrap_or(0);
 
         let mut prices: Vec<i128> = Vec::new(env);
+        // Source address paralleling each entry in `prices`, so a deviating
+        // quote can be reported by contract address.
+        let mut fresh_sources: Vec<Address> = Vec::new(env);
         let mut updated: Vec<OracleSource> = Vec::new(env);
         let mut stale_sources: Vec<Address> = Vec::new(env);
 
@@ -193,6 +223,7 @@ impl OracleAggregator {
             if price > 0 && is_fresh {
                 source.last_updated_at = source_timestamp;
                 prices.push_back(price);
+                fresh_sources.push_back(source.source_contract.clone());
                 contributed = true;
             }
 
@@ -216,11 +247,43 @@ impl OracleAggregator {
             env.storage().instance().set(&DataKey::Sources, &updated);
         }
 
-        let median = median_i128(env, &prices);
+        // Reference median over all fresh quotes. The median is robust to a
+        // minority of outliers, so it is a sound centre for the agreement test.
+        let reference_median = median_i128(env, &prices);
+        let max_deviation_bps = read_max_deviation_bps(env);
+
+        // Keep only quotes within the deviation band of the reference median;
+        // everything else is a disagreeing outlier that must not inflate
+        // confidence or move the reported price.
+        let mut agreeing: Vec<i128> = Vec::new(env);
+        let mut deviant_sources: Vec<Address> = Vec::new(env);
+        for i in 0..prices.len() {
+            let price = prices.get_unchecked(i);
+            if within_deviation_band(price, reference_median, max_deviation_bps) {
+                agreeing.push_back(price);
+            } else {
+                deviant_sources.push_back(fresh_sources.get_unchecked(i));
+            }
+        }
+
+        if !deviant_sources.is_empty() {
+            env.events()
+                .publish((symbol_short!("deviant"),), (deviant_sources,));
+        }
+
+        // Too few sources agree — a high-variance quote set. Report no
+        // confidence rather than a price that only looks corroborated.
+        if agreeing.len() < MIN_VALID_SOURCES {
+            return AggregatedPrice { price: 0, confidence: 0 };
+        }
+
+        // Report the median of the agreeing subset so a dropped outlier does
+        // not skew the result, and count only agreeing sources as confidence.
+        let median = median_i128(env, &agreeing);
 
         AggregatedPrice {
             price: median,
-            confidence: prices.len(),
+            confidence: agreeing.len(),
         }
     }
 
@@ -243,6 +306,26 @@ impl OracleAggregator {
         env.storage()
             .instance()
             .set(&DataKey::MaxStaleness, &max_staleness_seconds);
+    }
+
+    /// Returns the deviation band (in bps) a fresh quote must fall within of
+    /// the median to be counted as agreeing.
+    pub fn get_max_deviation_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxDeviationBps)
+            .unwrap_or(DEFAULT_MAX_DEVIATION_BPS)
+    }
+
+    /// Admin: set the agreement deviation band, in bps (must be `1..=10_000`).
+    pub fn set_max_deviation_bps(env: Env, admin: Address, max_deviation_bps: u32) {
+        require_admin(&env, &admin);
+        if max_deviation_bps == 0 || max_deviation_bps as i128 > BPS_DENOMINATOR {
+            panic_with_error!(&env, OracleError::InvalidDeviation);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxDeviationBps, &max_deviation_bps);
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -274,6 +357,26 @@ fn require_admin(env: &Env, claimed: &Address) {
     }
 
     claimed.require_auth();
+}
+
+fn read_max_deviation_bps(env: &Env) -> i128 {
+    let bps: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MaxDeviationBps)
+        .unwrap_or(DEFAULT_MAX_DEVIATION_BPS);
+    bps as i128
+}
+
+/// Returns `true` when `price` is within `max_deviation_bps` of `median`.
+///
+/// Uses the cross-multiplied form `|price - median| * 10_000 <= bps * median`
+/// to avoid a division (and its precision loss). `median` is always `> 0`
+/// here because it is derived from strictly-positive quotes.
+fn within_deviation_band(price: i128, median: i128, max_deviation_bps: i128) -> bool {
+    let diff = price - median;
+    let abs_diff = if diff < 0 { -diff } else { diff };
+    abs_diff.saturating_mul(BPS_DENOMINATOR) <= max_deviation_bps.saturating_mul(median)
 }
 
 fn median_i128(env: &Env, values: &Vec<i128>) -> i128 {

--- a/contracts/oracle_aggregator/src/test.rs
+++ b/contracts/oracle_aggregator/src/test.rs
@@ -168,6 +168,8 @@ fn get_price_returns_median_of_three_sources() {
         .register_source(&h.admin, &s2, &OracleSourceType::ClTwap);
     h.aggregator
         .register_source(&h.admin, &s3, &OracleSourceType::External);
+    // These prices span 50%; widen the band so this stays a pure median test.
+    h.aggregator.set_max_deviation_bps(&h.admin, &5_000);
     set_now(&env, 1_000);
 
     let result = h.aggregator.get_price(&h.token_a, &h.token_b);
@@ -185,6 +187,8 @@ fn get_price_returns_two_way_median_average() {
         .register_source(&h.admin, &s1, &OracleSourceType::AmmTwap);
     h.aggregator
         .register_source(&h.admin, &s2, &OracleSourceType::External);
+    // 100 vs 200 straddle the median by 33%; widen the band so both count.
+    h.aggregator.set_max_deviation_bps(&h.admin, &5_000);
     set_now(&env, 1_000);
     let result = h.aggregator.get_price(&h.token_a, &h.token_b);
     assert_eq!(result.price, 150);
@@ -205,6 +209,8 @@ fn stale_source_excluded_after_window() {
         .register_source(&h.admin, &s2, &OracleSourceType::ClTwap);
     h.aggregator
         .register_source(&h.admin, &s3, &OracleSourceType::External);
+    // Prices span 50%; widen the band so this stays a pure staleness test.
+    h.aggregator.set_max_deviation_bps(&h.admin, &5_000);
 
     set_now(&env, 1_000);
     h.aggregator.get_price(&h.token_a, &h.token_b);
@@ -310,4 +316,169 @@ fn stale_src_event_emitted_when_sources_skipped() {
     assert_eq!(stale_addrs.len(), 2);
     assert!(stale_addrs.contains(&s2));
     assert!(stale_addrs.contains(&s3));
+}
+
+// ── Deviation band (#466) ────────────────────────────────────────────────────
+
+#[test]
+fn get_max_deviation_bps_defaults_to_constant() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    assert_eq!(h.aggregator.get_max_deviation_bps(), DEFAULT_MAX_DEVIATION_BPS);
+}
+
+#[test]
+fn set_max_deviation_bps_updates_band() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    h.aggregator.set_max_deviation_bps(&h.admin, &250);
+    assert_eq!(h.aggregator.get_max_deviation_bps(), 250);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn set_max_deviation_bps_rejects_zero() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    h.aggregator.set_max_deviation_bps(&h.admin, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn set_max_deviation_bps_rejects_above_max() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    h.aggregator.set_max_deviation_bps(&h.admin, &10_001);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn set_max_deviation_bps_rejects_non_admin() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let attacker = Address::generate(&env);
+    h.aggregator.set_max_deviation_bps(&attacker, &250);
+}
+
+/// A source deviating far outside the band is dropped: it does not count
+/// toward confidence and does not move the reported median.
+#[test]
+fn deviating_source_excluded_from_confidence_and_price() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let s1 = deploy_source(&env, 100);
+    let s2 = deploy_source(&env, 102);
+    let s3 = deploy_source(&env, 300); // ~194% above the median → out of band
+    h.aggregator
+        .register_source(&h.admin, &s1, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &s2, &OracleSourceType::ClTwap);
+    h.aggregator
+        .register_source(&h.admin, &s3, &OracleSourceType::External);
+    set_now(&env, 1_000);
+
+    let result = h.aggregator.get_price(&h.token_a, &h.token_b);
+    // Only s1 and s2 agree: median(100, 102) = 101, confidence 2 (not 3).
+    assert_eq!(result.price, 101);
+    assert_eq!(result.confidence, 2);
+}
+
+/// The two-source manipulation from the issue: with exactly MIN_VALID_SOURCES
+/// sources that disagree, neither sits within the band of their (mean) median,
+/// so no confident price is produced.
+#[test]
+fn two_disagreeing_sources_report_no_confidence() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let honest = deploy_source(&env, 100);
+    let attacker = deploy_source(&env, 200);
+    h.aggregator
+        .register_source(&h.admin, &honest, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &attacker, &OracleSourceType::External);
+    set_now(&env, 1_000);
+
+    // Neither source is within 5% of the median (150) → zero confidence.
+    let safe = h.aggregator.get_price_safe(&h.token_a, &h.token_b);
+    assert_eq!(safe.confidence, 0);
+    assert_eq!(safe.price, 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn two_disagreeing_sources_panic_on_get_price() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let honest = deploy_source(&env, 100);
+    let attacker = deploy_source(&env, 200);
+    h.aggregator
+        .register_source(&h.admin, &honest, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &attacker, &OracleSourceType::External);
+    set_now(&env, 1_000);
+    h.aggregator.get_price(&h.token_a, &h.token_b);
+}
+
+/// Widening the band lets a previously-deviant source count again, confirming
+/// the band is genuinely configurable.
+#[test]
+fn widening_band_admits_previously_deviant_source() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let s1 = deploy_source(&env, 100);
+    let s2 = deploy_source(&env, 102);
+    let s3 = deploy_source(&env, 150); // ~47% above the median → out of the 5% band
+    h.aggregator
+        .register_source(&h.admin, &s1, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &s2, &OracleSourceType::ClTwap);
+    h.aggregator
+        .register_source(&h.admin, &s3, &OracleSourceType::External);
+
+    // Under the default band, s3 is dropped: median(100, 102) = 101, conf 2.
+    set_now(&env, 1_000);
+    let tight = h.aggregator.get_price(&h.token_a, &h.token_b);
+    assert_eq!(tight.price, 101);
+    assert_eq!(tight.confidence, 2);
+
+    // Widen the band to 50%; s3 now agrees: median(100, 102, 150) = 102, conf 3.
+    h.aggregator.set_max_deviation_bps(&h.admin, &5_000);
+    let wide = h.aggregator.get_price(&h.token_a, &h.token_b);
+    assert_eq!(wide.price, 102);
+    assert_eq!(wide.confidence, 3);
+}
+
+/// A `deviant` event names each out-of-band source that was dropped.
+#[test]
+fn deviant_event_lists_out_of_band_sources() {
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::IntoVal;
+
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    let s1 = deploy_source(&env, 100);
+    let s2 = deploy_source(&env, 102);
+    let s3 = deploy_source(&env, 300); // out of band
+    h.aggregator
+        .register_source(&h.admin, &s1, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &s2, &OracleSourceType::ClTwap);
+    h.aggregator
+        .register_source(&h.admin, &s3, &OracleSourceType::External);
+    set_now(&env, 1_000);
+
+    h.aggregator.get_price_safe(&h.token_a, &h.token_b);
+
+    let events = env.events().all();
+    let agg_id = h.aggregator.address.clone();
+    let expected_topics: soroban_sdk::Vec<soroban_sdk::Val> =
+        (symbol_short!("deviant"),).into_val(&env);
+    let deviant_event = events
+        .iter()
+        .find(|e| e.0 == agg_id && e.1 == expected_topics)
+        .expect("deviant event must be emitted when a source is out of band");
+
+    let (deviant_addrs,): (soroban_sdk::Vec<Address>,) = deviant_event.2.into_val(&env);
+    assert_eq!(deviant_addrs.len(), 1);
+    assert!(deviant_addrs.contains(&s3));
 }


### PR DESCRIPTION
## Summary

closes #466

The module contract is that the aggregator reports the median over fresh, **agreeing** sources, but `aggregate_price` only checked freshness and `price > 0`. Every positive quote was pushed into `prices` and counted in `confidence` no matter how far it sat from the others, so a high confidence did not actually imply agreement.

With exactly `MIN_VALID_SOURCES` (2) sources, one manipulated feed pulled the reported price halfway to the attacker's value while `confidence` still read `2` — no signal that the sources disagreed.

## Fix

After collecting the fresh, positive quotes:

1. Compute a **reference median** over them (the median is robust to a minority of outliers, so it is a sound centre for the agreement test).
2. Keep only quotes **within a configurable deviation band** (in bps) of that median. Out-of-band quotes are dropped, excluded from `confidence`, and reported via a new `deviant` event (mirroring the existing `stale_src` event).
3. Report the **median of the agreeing subset** as the price and the **agreeing count** as confidence.
4. If fewer than `MIN_VALID_SOURCES` agree, return zero confidence so `get_price` surfaces `InsufficientSources` rather than a falsely corroborated price.

For the two-source manipulation in the issue (`100` honest vs `200` attacker), neither quote is within the band of the median (`150`), so the aggregator now reports zero confidence instead of `150` with confidence `2`.

## Configuration

- New band, in basis points, stored under `DataKey::MaxDeviationBps`.
- Defaults to `DEFAULT_MAX_DEVIATION_BPS = 500` (5%) — tight enough to flag the "halfway to the attacker" move (~33% deviation), loose enough for normal cross-venue spread.
- Admin-tunable via `set_max_deviation_bps` (valid range `1..=10_000`) and readable via `get_max_deviation_bps`.
- `initialize` seeds the default; already-deployed instances fall back to it on read.

The `AggregatedPrice` struct, the `OracleSourceAdapter` interface, and `get_price` / `get_price_safe` signatures are unchanged, so existing callers (e.g. the CL pool's oracle deviation check) are unaffected.

## Testing

`cargo test -p oracle-aggregator` — 25 passed, 0 failed.

New tests:
- `deviating_source_excluded_from_confidence_and_price` — an out-of-band source is dropped; confidence reflects only the agreeing sources.
- `two_disagreeing_sources_report_no_confidence` / `two_disagreeing_sources_panic_on_get_price` — the issue's two-source manipulation now yields zero confidence.
- `deviant_event_lists_out_of_band_sources` — the `deviant` event names each dropped source.
- `widening_band_admits_previously_deviant_source` — the band is genuinely configurable.
- `get_max_deviation_bps_defaults_to_constant`, `set_max_deviation_bps_updates_band`, and rejection tests for zero / above-max / non-admin.

Three existing median/staleness tests use fixtures whose prices span up to 50%; they now widen the band explicitly so they keep testing median math and staleness rather than the new agreement gate. Their assertions are otherwise unchanged.