### PR TITLE
fix: persist range order side so check_range_order_filled reports correctly

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -1164,10 +1164,11 @@ impl ConcentratedLiquidity {
             deadline,
         )?;
 
-        // Tag the position as a range order.
+        // Tag the position as a range order and record which side it was
+        // placed on, so `check_range_order_filled` knows the fill direction.
         env.storage().instance().set(
             &DataKey::RangeOrder(provider.clone(), lower_tick, upper_tick),
-            &true,
+            &is_above,
         );
 
         soroban_amm_sdk::emit_versioned_event!(
@@ -1203,14 +1204,14 @@ impl ConcentratedLiquidity {
             .get(&DataKey::Position(provider.clone(), lower_tick, upper_tick))
             .ok_or(ClError::PositionNotFound)?;
 
-        let is_range_order: bool = env
-            .storage()
-            .instance()
-            .get(&DataKey::RangeOrder(provider, lower_tick, upper_tick))
-            .unwrap_or(false);
-        if !is_range_order {
+        let range_order_key = DataKey::RangeOrder(provider, lower_tick, upper_tick);
+        if !env.storage().instance().has(&range_order_key) {
             return Err(ClError::PositionNotFound);
         }
+        // The original side the order was placed on: `true` for an
+        // above-range order (fills as price rises), `false` for a
+        // below-range order (fills as price falls).
+        let is_above: bool = env.storage().instance().get(&range_order_key).unwrap();
 
         let current_tick: i32 = env
             .storage()
@@ -1218,20 +1219,17 @@ impl ConcentratedLiquidity {
             .get(&DataKey::CurrentTick)
             .unwrap_or(0);
 
-        // Determine fill direction from the range relative to the current tick
-        // at the time of the query.
-        let status = if current_tick >= upper_tick {
-            // Price has risen above the range → above-range order is filled.
-            RangeOrderStatus::Filled
+        // Only report Filled once the price has crossed through the range in
+        // this order's original fill direction; otherwise it is still Pending.
+        let status = if is_above {
+            if current_tick >= upper_tick {
+                RangeOrderStatus::Filled
+            } else {
+                RangeOrderStatus::Pending
+            }
         } else if current_tick < lower_tick {
-            // Price is still below the range → above-range order is pending,
-            // OR price has fallen below the range → below-range order is filled.
-            // We distinguish by checking which side the range was on originally.
-            // Since we only allow fully out-of-range creation, if current_tick
-            // is now below lower_tick the below-range order is filled.
             RangeOrderStatus::Filled
         } else {
-            // Price is inside the range — order is partially filled (pending).
             RangeOrderStatus::Pending
         };
 
@@ -5907,6 +5905,199 @@ mod test_single_token_deposit {
         assert_eq!(
             f.client.position_token_id(&f.alice, &f.lower, &f.upper),
             None
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_range_order_fill_status {
+    // Regression tests for issue #472: a range order must record which side
+    // it was placed on, and only report `Filled` once the price has crossed
+    // through the range in that order's original fill direction.
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::token::StellarAssetClient;
+    use soroban_sdk::Env;
+
+    fn setup_pool(
+        env: &Env,
+        initial_tick: i32,
+    ) -> (Address, Address, Address, ConcentratedLiquidityClient) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        env.budget().reset_unlimited();
+        let token_a = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let token_b = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let cl_addr = env.register_contract(None, ConcentratedLiquidity);
+        let client = ConcentratedLiquidityClient::new(env, &cl_addr);
+        client.initialize(&admin, &token_a, &token_b, &0_i128, &initial_tick, &1_i32);
+
+        let provider = Address::generate(env);
+        StellarAssetClient::new(env, &token_a).mint(&provider, &100_000_000_i128);
+        StellarAssetClient::new(env, &token_b).mint(&provider, &100_000_000_i128);
+        StellarAssetClient::new(env, &token_a).mint(&cl_addr, &100_000_000_i128);
+        StellarAssetClient::new(env, &token_b).mint(&cl_addr, &100_000_000_i128);
+
+        (provider, token_a, token_b, client)
+    }
+
+    /// Moves the pool's current tick directly via storage, standing in for a
+    /// swap that has crossed price through (or into) the range.
+    fn set_current_tick(env: &Env, cl_addr: &Address, tick: i32) {
+        env.as_contract(cl_addr, || {
+            env.storage().instance().set(&DataKey::CurrentTick, &tick);
+        });
+    }
+
+    // ── Above-range order (deposit token A, fills as price rises) ────────────
+
+    #[test]
+    fn above_range_order_is_pending_at_placement() {
+        let env = Env::default();
+        // current_tick = 0, range = [100, 200] → an above-range order.
+        let (provider, _token_a, _token_b, client) = setup_pool(&env, 0);
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &_token_a,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Pending,
+            "an above-range order must not be reported as Filled before the price has moved"
+        );
+    }
+
+    #[test]
+    fn above_range_order_is_pending_while_price_is_still_below_range() {
+        let env = Env::default();
+        let (provider, token_a, _token_b, client) = setup_pool(&env, 0);
+        let cl_addr = client.address.clone();
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &token_a,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        // Price has moved but has not yet reached the range.
+        set_current_tick(&env, &cl_addr, 50);
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Pending
+        );
+    }
+
+    #[test]
+    fn above_range_order_is_filled_once_price_crosses_upper_tick() {
+        let env = Env::default();
+        let (provider, token_a, _token_b, client) = setup_pool(&env, 0);
+        let cl_addr = client.address.clone();
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &token_a,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        set_current_tick(&env, &cl_addr, 200);
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Filled
+        );
+    }
+
+    // ── Below-range order (deposit token B, fills as price falls) ────────────
+
+    #[test]
+    fn below_range_order_is_pending_at_placement() {
+        let env = Env::default();
+        // current_tick = 300, range = [100, 200] → a below-range order.
+        let (provider, _token_a, token_b, client) = setup_pool(&env, 300);
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &token_b,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Pending,
+            "a below-range order must not be reported as Filled before the price has moved"
+        );
+    }
+
+    #[test]
+    fn below_range_order_is_pending_while_price_is_still_above_range() {
+        let env = Env::default();
+        let (provider, _token_a, token_b, client) = setup_pool(&env, 300);
+        let cl_addr = client.address.clone();
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &token_b,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        // Price has fallen but has not yet reached the range.
+        set_current_tick(&env, &cl_addr, 250);
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Pending
+        );
+    }
+
+    #[test]
+    fn below_range_order_is_filled_once_price_crosses_lower_tick() {
+        let env = Env::default();
+        let (provider, _token_a, token_b, client) = setup_pool(&env, 300);
+        let cl_addr = client.address.clone();
+
+        client.place_range_order(
+            &provider,
+            &100_i32,
+            &200_i32,
+            &token_b,
+            &10_000_i128,
+            &1_i128,
+            &u64::MAX,
+        );
+
+        set_current_tick(&env, &cl_addr, 99);
+
+        assert_eq!(
+            client.check_range_order_filled(&provider, &100_i32, &200_i32),
+            RangeOrderStatus::Filled
         );
     }
 }


### PR DESCRIPTION
## Summary

`place_range_order` tagged a placed order with a bare `true` flag, so the original side (above vs. below the current tick) was never recorded. `check_range_order_filled` then inferred fill status purely from the current tick's position relative to the range, which meant every freshly placed order read as `Filled` immediately, before any price movement — and the only time it read `Pending` was after the price had moved into the range, the inverse of correct behavior.

## Fix

- `place_range_order` now stores the actual side (`is_above: bool`) under `DataKey::RangeOrder`, instead of a bare `true`.
- `check_range_order_filled` now uses `has()` to detect whether a position was tagged as a range order (since `false` is now a valid, meaningful value — a below-range order), then reports `Filled` only once the price has crossed all the way through the range in that order's original fill direction:
  - Above-range order: `Filled` when `current_tick >= upper_tick`, `Pending` otherwise.
  - Below-range order: `Filled` when `current_tick < lower_tick`, `Pending` otherwise.

## Tests

Added `test_range_order_fill_status` covering both sides:
- `above_range_order_is_pending_at_placement`
- `above_range_order_is_pending_while_price_is_still_below_range`
- `above_range_order_is_filled_once_price_crosses_upper_tick`
- `below_range_order_is_pending_at_placement`
- `below_range_order_is_pending_while_price_is_still_above_range`
- `below_range_order_is_filled_once_price_crosses_lower_tick`

closes #472
