### PR TITLE
fix: remove unused REWARD_SCALE constant and correct reward_rate docs

### DIFF
--- a/contracts/incentive_campaigns/src/lib.rs
+++ b/contracts/incentive_campaigns/src/lib.rs
@@ -38,7 +38,8 @@ pub struct Campaign {
     pub reward_token: Address,
     pub start_time: u64,
     pub end_time: u64,
-    /// Rewards per second, scaled by REWARD_SCALE
+    /// Rewards per second, in raw base units of `reward_token` (no fixed-point
+    /// scaling — a rate smaller than 1 base unit/sec rounds down to 0 rewards).
     pub reward_rate: i128,
     pub active: bool,
     pub total_distributed: i128,
@@ -60,8 +61,6 @@ pub struct IncentiveCampaigns;
 
 #[contractimpl]
 impl IncentiveCampaigns {
-    pub const REWARD_SCALE: i128 = 1_000_000_000_000_000_000; // 1e18
-
     pub fn initialize(env: Env, governance: Address) {
         assert!(
             !env.storage().instance().has(&DataKey::Governance),


### PR DESCRIPTION
## Summary

`Campaign.reward_rate` was documented as "Rewards per second, scaled by REWARD_SCALE", and the contract defined `REWARD_SCALE = 1_000_000_000_000_000_000` (1e18) — but the constant was never referenced anywhere in the reward math. `grep -rn REWARD_SCALE` only ever matched its own definition and the doc comment.

## Investigation

Both accrual paths use `reward_rate` raw, with no descaling:

- `claim_rewards`: `pool_rewards = campaign.reward_rate * elapsed`
- `recover_leftover_funds`: `max_distributable = campaign.reward_rate * campaign_duration`

The existing test suite already assumes this raw interpretation (`reward_rate = 100` is expected to mean 100 base units/sec, not `100 / 1e18`). Since every call site and every test already relies on the raw, unscaled behavior, and since fixing this "the other way" (actually scaling by `REWARD_SCALE`) would break all existing campaigns' expected math and required a coordinated change to `create_campaign`'s input contract, I brought the constant and docs in line with the code instead:

## Fix

- Removed the unused `REWARD_SCALE` constant.
- Corrected the `reward_rate` doc comment on `Campaign` to describe it as a raw per-second rate in the reward token's base units (and noted that sub-1-unit/sec rates round down to 0, since there's no fixed-point precision).

No behavioral change — this only removes dead code and fixes documentation that was actively misleading integrators about the expected `reward_rate` encoding.

closes #474
