### PR TITLE
fix(oracle_aggregator): avoid i128 overflow in median midpoint

### DIFF
--- a/contracts/oracle_aggregator/src/lib.rs
+++ b/contracts/oracle_aggregator/src/lib.rs
@@ -345,7 +345,12 @@ fn median_i128(env: &Env, values: &Vec<i128>) -> i128 {
     if sorted.len() % 2 == 0 {
         let lo = sorted.get_unchecked(mid - 1);
         let hi = sorted.get_unchecked(mid);
-        (lo + hi) / 2
+        // Midpoint via `lo + (hi - lo) / 2` rather than `(lo + hi) / 2`.
+        // The sum of two individually-valid prices can exceed i128::MAX and
+        // overflow (panic in debug, wraparound in release). Since `sorted` is
+        // ascending, `hi >= lo`, and aggregated prices are strictly positive,
+        // so `hi - lo` stays within range and the midpoint never overflows.
+        lo + (hi - lo) / 2
     } else {
         sorted.get_unchecked(mid)
     }

--- a/contracts/oracle_aggregator/src/test.rs
+++ b/contracts/oracle_aggregator/src/test.rs
@@ -189,6 +189,27 @@ fn get_price_returns_two_way_median_average() {
 }
 
 #[test]
+fn get_price_two_way_median_does_not_overflow_on_large_prices() {
+    let env = Env::default();
+    let h = deploy(&env, 600);
+    // Two individually-valid prices whose sum exceeds i128::MAX. The old
+    // `(lo + hi) / 2` midpoint would overflow here (panic in debug, wrap in
+    // release); `lo + (hi - lo) / 2` stays in range.
+    let hi = i128::MAX;
+    let lo = i128::MAX - 2;
+    let s1 = deploy_source(&env, hi);
+    let s2 = deploy_source(&env, lo);
+    h.aggregator
+        .register_source(&h.admin, &s1, &OracleSourceType::AmmTwap);
+    h.aggregator
+        .register_source(&h.admin, &s2, &OracleSourceType::External);
+    set_now(&env, 1_000);
+    let result = h.aggregator.get_price(&h.token_a, &h.token_b);
+    assert_eq!(result.price, i128::MAX - 1);
+    assert_eq!(result.confidence, 2);
+}
+
+#[test]
 fn stale_source_excluded_after_window() {
     let env = Env::default();
     // Use max_staleness=600 so the 200s advance doesn't expire s1 or s3.


### PR DESCRIPTION
## Summary

`median_i128` averaged the two middle prices on the even-length path with `(lo + hi) / 2`. Both middle values are individually valid `i128` prices, but their sum can exceed `i128::MAX` and overflow. Because `MIN_VALID_SOURCES == 2`, the common two-source configuration always takes this even path, so a high-magnitude feed pair triggers it directly.

Impact:
- With debug overflow checks: a panic, turning a routine price read into a hard failure / DoS.
- Without overflow checks: wraparound to a nonsensical median that downstream consumers would treat as a real price.

This is independent of #423 (source disagreement / confidence); this is a numeric-overflow defect in the median computation itself.

## Fix

Compute the midpoint as `lo + (hi - lo) / 2` instead of `(lo + hi) / 2`. `sorted` is ascending so `hi >= lo`, and aggregated prices are strictly positive (the aggregator only pushes prices `> 0`), so `hi - lo` stays within range and the midpoint never overflows. The result is identical for non-overflowing inputs.

## Testing

- Added `get_price_two_way_median_does_not_overflow_on_large_prices` with prices `i128::MAX` and `i128::MAX - 2`, asserting the median is `i128::MAX - 1` (the old code overflowed here).
- `cargo test -p oracle-aggregator` — 15 passed.

closes #465
