### PR TITLE
Fix CL order validation, factory storage growth, TWAP/TWAL floor lookup, staking boost accounting

### DIFF
--- a/contracts/batch_auction/src/lib.rs
+++ b/contracts/batch_auction/src/lib.rs
@@ -244,10 +244,18 @@ impl BatchAuction {
         // If a mismatched pair slipped through, settle_batch would call swap
         // with the wrong tokens and panic; since settlement is atomic, that
         // panic reverts the whole batch and locks every other trader's escrow
-        // until each order is cancelled individually (issue #361).
-        let info = AmmPoolClient::new(&env, &pool).get_info();
-        let valid_pair = (token_in == info.token_a && token_out == info.token_b)
-            || (token_in == info.token_b && token_out == info.token_a);
+        // until each order is cancelled individually (issue #361). AMM and CL
+        // pools expose their token pair through different interfaces, so the
+        // lookup must branch on pool_type (issue #470).
+        let (pool_token_a, pool_token_b) = match pool_type {
+            PoolType::Amm => {
+                let info = AmmPoolClient::new(&env, &pool).get_info();
+                (info.token_a, info.token_b)
+            }
+            PoolType::Cl => ConcentratedLiquidityClient::new(&env, &pool).get_tokens(),
+        };
+        let valid_pair = (token_in == pool_token_a && token_out == pool_token_b)
+            || (token_in == pool_token_b && token_out == pool_token_a);
         if !valid_pair {
             return Err(AuctionError::InvalidPoolTokenPair);
         }

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -1651,6 +1651,16 @@ impl ConcentratedLiquidity {
         }
     }
 
+    /// Returns the pool's `(token_a, token_b)` pair (issue #470).
+    ///
+    /// Unlike the AMM pool, a CL pool has no `get_info`; batch_auction and other
+    /// venue-agnostic callers use this to validate an order's token pair.
+    pub fn get_tokens(env: Env) -> (Address, Address) {
+        let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
+        let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
+        (token_a, token_b)
+    }
+
     // ── Issue #203: per-tick view functions ───────────────────────────────────
 
     /// Returns the `TickInfo` for an initialized tick.

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -251,7 +251,7 @@ impl Factory {
 
         if env
             .storage()
-            .instance()
+            .persistent()
             .has(&DataKey::Pool(ta.clone(), tb.clone()))
         {
             return Err(FactoryError::PoolAlreadyExists);
@@ -331,17 +331,21 @@ impl Factory {
         );
 
         // Register pool in lookup indexes and record the LP token address.
+        // These are per-pool entries and grow without bound as pools accumulate,
+        // so they belong in persistent storage (each with its own TTL) rather
+        // than instance storage, which is a single blob loaded on every call
+        // to the contract (issue #468).
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::Pool(ta.clone(), tb.clone()), &pool_addr);
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::LpToken(pool_addr.clone()), &lp_addr);
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::GovernanceFor(pool_addr.clone()), &gov_addr);
         // Store reverse token-pair lookup used by sweep_fees to forward tokens.
-        env.storage().instance().set(
+        env.storage().persistent().set(
             &DataKey::PoolTokens(pool_addr.clone()),
             &(ta.clone(), tb.clone()),
         );
@@ -515,7 +519,7 @@ impl Factory {
         };
 
         let cl_key = DataKey::ClPool(ta.clone(), tb.clone(), fee_bps);
-        if env.storage().instance().has(&cl_key) {
+        if env.storage().persistent().has(&cl_key) {
             return Err(FactoryError::ClPoolAlreadyExists);
         }
 
@@ -555,7 +559,7 @@ impl Factory {
             &tick_spacing,
         );
 
-        env.storage().instance().set(&cl_key, &pool_addr);
+        env.storage().persistent().set(&cl_key, &pool_addr);
 
         env.storage()
             .persistent()
@@ -661,13 +665,13 @@ impl Factory {
 
     /// Return the LP token address for the given pool, or `None` if unknown.
     pub fn get_lp_token(env: Env, pool: Address) -> Option<Address> {
-        env.storage().instance().get(&DataKey::LpToken(pool))
+        env.storage().persistent().get(&DataKey::LpToken(pool))
     }
 
     /// Return the governance address for the given pool, or `None` if unknown.
     pub fn get_governance(env: Env, pool: Address) -> Option<Address> {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::GovernanceFor(pool))
             .unwrap_or(None)
     }
@@ -702,7 +706,7 @@ impl Factory {
         } else {
             (token_b, token_a)
         };
-        env.storage().instance().get(&DataKey::Pool(ta, tb))
+        env.storage().persistent().get(&DataKey::Pool(ta, tb))
     }
 
     /// Return the CL pool address for `(token_a, token_b, fee_bps)`, or `None` if absent.
@@ -719,7 +723,7 @@ impl Factory {
             (token_b, token_a)
         };
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::ClPool(ta, tb, fee_bps))
     }
 
@@ -824,7 +828,7 @@ impl Factory {
 
     /// Return the token pair `(token_a, token_b)` recorded for `pool`, or `None`.
     pub fn get_pool_tokens(env: Env, pool: Address) -> Option<(Address, Address)> {
-        env.storage().instance().get(&DataKey::PoolTokens(pool))
+        env.storage().persistent().get(&DataKey::PoolTokens(pool))
     }
 
     /// Set and propagate the global protocol fee configuration to all
@@ -963,7 +967,7 @@ impl Factory {
                 // Skip governance-controlled pools.
                 let gov: Option<Option<Address>> = env
                     .storage()
-                    .instance()
+                    .persistent()
                     .get(&DataKey::GovernanceFor(pool_addr.clone()));
                 let is_governed = gov.flatten().is_some();
                 if is_governed {
@@ -972,7 +976,7 @@ impl Factory {
 
                 let Some((token_a, token_b)) = env
                     .storage()
-                    .instance()
+                    .persistent()
                     .get::<DataKey, (Address, Address)>(&DataKey::PoolTokens(pool_addr.clone()))
                 else {
                     continue;
@@ -1084,7 +1088,7 @@ impl Factory {
                 // so the factory cannot authorize their pool-level fee update.
                 let gov: Option<Option<Address>> = env
                     .storage()
-                    .instance()
+                    .persistent()
                     .get(&DataKey::GovernanceFor(pool_addr.clone()));
                 if gov.flatten().is_some() {
                     continue;

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -395,8 +395,16 @@ impl Staking {
         env.storage().persistent().set(&key_amount, &new_staked);
         env.storage().persistent().extend_ttl(&key_amount, MIN_TTL, BUMP_TO);
 
-        // Recompute effective amount for the whole position with the new boost.
-        let old_effective = Self::_effective_amount(current_staked, new_boost);
+        // Remove the position's existing contribution using the boost it was
+        // actually recorded with, not the freshly recomputed one — otherwise
+        // TotalEffectiveStaked (Σ raw_amount × stored_boost) is corrupted
+        // whenever the boost changes on a top-up (issue #467).
+        let old_boost: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BoostMultiplier(staker.clone()))
+            .unwrap_or(MIN_BOOST);
+        let old_effective = Self::_effective_amount(current_staked, old_boost);
         let new_effective = Self::_effective_amount(new_staked, new_boost);
 
         // Adjust total effective staked.
@@ -954,6 +962,41 @@ mod tests {
 
         let pool = staking.get_pool_info();
         assert_eq!(pool.total_effective_staked, 2_500);
+    }
+
+    // ── Issue #467: stake_locked must remove the old effective stake using the
+    // boost the position was actually recorded with, not the freshly
+    // recomputed one, or TotalEffectiveStaked drifts on every top-up ────────────
+
+    #[test]
+    fn test_stake_locked_top_up_after_boost_decay_keeps_total_effective_staked_correct() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let (_, staker, staking) = setup(&env);
+
+        // Lock for the max duration up front — boost starts at the maximum (2.5x).
+        staking.stake_locked(&staker, &1_000_i128, &MAX_LOCK_DURATION);
+        let info_before = staking.get_staker_info(&staker);
+        assert_eq!(info_before.boost_multiplier, DEFAULT_MAX_BOOST);
+
+        // Let half the lock elapse — the boost for the now-shorter remaining
+        // time is lower than the boost the position was recorded with.
+        env.ledger()
+            .set_timestamp(1_000 + MAX_LOCK_DURATION / 2);
+
+        // Top up without requesting a new lock (lock_duration_secs = 0): this
+        // recomputes the boost from the shrunken remaining lock time.
+        staking.stake_locked(&staker, &500_i128, &0);
+
+        let info_after = staking.get_staker_info(&staker);
+        assert!(info_after.boost_multiplier < DEFAULT_MAX_BOOST);
+
+        // With a single staker, TotalEffectiveStaked must equal this staker's
+        // own effective amount — the old, differently-boosted contribution
+        // must be fully replaced, not partially subtracted.
+        let pool = staking.get_pool_info();
+        assert_eq!(pool.total_effective_staked, info_after.effective_amount);
     }
 
     #[test]

--- a/contracts/twal_consumer/src/lib.rs
+++ b/contracts/twal_consumer/src/lib.rs
@@ -31,6 +31,11 @@ pub enum DataKey {
     Keeper,
     LiquiditySnapshot(Address, u64),
     TrackedPoolsPersistent,
+    /// Sorted (ascending, deduplicated) ledger timestamps at which a
+    /// liquidity snapshot was saved for this pool. Lets `get_twal_*`
+    /// binary-search for the most recent snapshot at or before an arbitrary
+    /// `then_ts` instead of requiring an exact-timestamp hit (issue #469).
+    SnapshotTimestamps(Address),
 }
 
 #[contracttype]
@@ -80,7 +85,73 @@ impl TwalConsumer {
             Self::SNAPSHOT_TTL_LEDGERS,
         );
         Self::register_tracked_pool(&env, &pool);
+        Self::record_snapshot_timestamp(&env, &pool, ledger_ts);
         Ok(())
+    }
+
+    /// Record `ts` in the pool's sorted snapshot-timestamp index. Ledger
+    /// timestamps are non-decreasing across calls, so appending keeps the
+    /// index sorted; skip if `ts` is already the most recent entry so a
+    /// keeper re-saving within the same ledger doesn't create a duplicate.
+    fn record_snapshot_timestamp(env: &Env, pool: &Address, ts: u64) {
+        let key = DataKey::SnapshotTimestamps(pool.clone());
+        let mut timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        if timestamps.last().map_or(true, |last| last != ts) {
+            timestamps.push_back(ts);
+        }
+        env.storage().persistent().set(&key, &timestamps);
+        env.storage().persistent().extend_ttl(
+            &key,
+            Self::SNAPSHOT_TTL_LEDGERS / 2,
+            Self::SNAPSHOT_TTL_LEDGERS,
+        );
+    }
+
+    fn remove_snapshot_timestamp(env: &Env, pool: &Address, ts: u64) {
+        let key = DataKey::SnapshotTimestamps(pool.clone());
+        let timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        let mut updated: Vec<u64> = Vec::new(env);
+        for i in 0..timestamps.len() {
+            let t = timestamps.get(i).unwrap();
+            if t != ts {
+                updated.push_back(t);
+            }
+        }
+        env.storage().persistent().set(&key, &updated);
+    }
+
+    /// Binary-search the pool's snapshot-timestamp index for the most recent
+    /// entry at or before `then_ts` (the "floor"). Returns `None` if no
+    /// snapshot that old exists.
+    fn floor_snapshot_ts(env: &Env, pool: &Address, then_ts: u64) -> Option<u64> {
+        let timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SnapshotTimestamps(pool.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        let mut lo: u32 = 0;
+        let mut hi: u32 = timestamps.len();
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            if timestamps.get(mid).unwrap() <= then_ts {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        if lo == 0 {
+            None
+        } else {
+            Some(timestamps.get(lo - 1).unwrap())
+        }
     }
 
     fn register_tracked_pool(env: &Env, pool: &Address) {
@@ -120,10 +191,12 @@ impl TwalConsumer {
             return Err(TwalError::InsufficientHistory);
         }
         let then_ts = ledger_ts_now - window_seconds;
+        let floor_ts =
+            Self::floor_snapshot_ts(&env, &pool, then_ts).ok_or(TwalError::InsufficientHistory)?;
         let snapshot: LiquiditySnapshot = env
             .storage()
             .persistent()
-            .get(&DataKey::LiquiditySnapshot(pool, then_ts))
+            .get(&DataKey::LiquiditySnapshot(pool, floor_ts))
             .ok_or(TwalError::NoSnapshotFound)?;
 
         let delta = (cum_now as u128).wrapping_sub(snapshot.cum_liquidity as u128) as i128;
@@ -166,6 +239,7 @@ impl TwalConsumer {
             Self::SNAPSHOT_TTL_LEDGERS,
         );
         Self::register_tracked_pool(&env, &pool);
+        Self::record_snapshot_timestamp(&env, &pool, ledger_ts);
         Ok(())
     }
 
@@ -177,6 +251,7 @@ impl TwalConsumer {
             return Err(TwalError::NoSnapshotFound);
         }
         env.storage().persistent().remove(&key);
+        Self::remove_snapshot_timestamp(&env, &pool, ledger_ts);
         env.events()
             .publish((Symbol::new(&env, "snapshot_deleted"),), (pool, ledger_ts));
         Ok(())
@@ -196,11 +271,13 @@ impl TwalConsumer {
         );
 
         let then_ts = ledger_ts_now - window_seconds;
+        let floor_ts = Self::floor_snapshot_ts(&env, &pool, then_ts)
+            .unwrap_or_else(|| panic!("no liquidity snapshot at or before {then_ts}"));
         let snapshot: LiquiditySnapshot = env
             .storage()
             .persistent()
-            .get(&DataKey::LiquiditySnapshot(pool, then_ts))
-            .unwrap_or_else(|| panic!("missing liquidity snapshot at {then_ts}"));
+            .get(&DataKey::LiquiditySnapshot(pool, floor_ts))
+            .unwrap_or_else(|| panic!("missing liquidity snapshot at {floor_ts}"));
 
         let delta = (active as u128).wrapping_sub(snapshot.cum_liquidity as u128) as i128;
         let elapsed = (pool_ts_now - snapshot.pool_ts) as i128;
@@ -383,15 +460,71 @@ mod tests {
         consumer.initialize(&admin);
         consumer.save_snapshot(&amm_addr);
 
-        // Snapshot stored at ledger timestamp 10_000; deleting it removes it so a
-        // later TWAL query over that window can no longer find it.
+        // Snapshot stored at ledger timestamp 10_000; deleting it removes it
+        // (and its entry in the timestamp index) so a later TWAL query whose
+        // window lands at or before that point has no floor snapshot left.
         consumer.delete_snapshot(&amm_addr, &10_000_u64);
 
         env.ledger().with_mut(|l| l.timestamp = 10_600);
         assert_eq!(
             consumer.try_get_twal_liquidity(&amm_addr, &600),
-            Err(Ok(TwalError::NoSnapshotFound))
+            Err(Ok(TwalError::InsufficientHistory))
         );
+    }
+
+    // ── Issue #469: arbitrary window_seconds should hit the nearest older
+    // snapshot instead of requiring an exact-timestamp match ──────────────────
+
+    #[test]
+    fn test_get_twal_liquidity_with_arbitrary_window_uses_floor_snapshot() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(10_000);
+
+        let admin = Address::generate(&env);
+        let amm_addr = env.register_contract(None, AmmPool);
+        let lp_addr = env.register_contract(None, LpToken);
+        let consumer_addr = env.register_contract(None, TwalConsumer);
+
+        token::LpTokenClient::new(&env, &lp_addr).initialize(
+            &amm_addr,
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &soroban_sdk::String::from_str(&env, "LP"),
+            &7u32,
+        );
+
+        let (ta, ta_sac) = create_sac(&env, &admin);
+        let (tb, tb_sac) = create_sac(&env, &admin);
+        AmmPoolClient::new(&env, &amm_addr).initialize(
+            &admin, &ta.address, &tb.address, &lp_addr, &30_i128, &admin, &0_i128,
+        );
+
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &1_000_000_i128);
+        tb_sac.mint(&provider, &1_000_000_i128);
+        AmmPoolClient::new(&env, &amm_addr).add_liquidity(
+            &provider, &1_000_000_i128, &1_000_000_i128, &0_i128, &u64::MAX,
+        );
+
+        let consumer = TwalConsumerClient::new(&env, &consumer_addr);
+        consumer.initialize(&admin);
+        consumer.save_snapshot(&amm_addr);
+
+        // A second snapshot 30s later, after more liquidity is added.
+        env.ledger().with_mut(|l| l.timestamp = 10_030);
+        ta_sac.mint(&provider, &100_000_i128);
+        tb_sac.mint(&provider, &100_000_i128);
+        AmmPoolClient::new(&env, &amm_addr).add_liquidity(
+            &provider, &100_000_i128, &100_000_i128, &0_i128, &u64::MAX,
+        );
+        consumer.save_snapshot(&amm_addr);
+
+        // window=50 at ts=10_075 asks for then_ts=10_025, which has no exact
+        // snapshot. Previously this reverted with NoSnapshotFound; now it
+        // must fall back to the floor (the ts=10_000 snapshot).
+        env.ledger().with_mut(|l| l.timestamp = 10_075);
+        let twal = consumer.get_twal_liquidity(&amm_addr, &50);
+        assert!(twal > 0);
     }
 
     #[test]

--- a/contracts/twap_consumer/src/lib.rs
+++ b/contracts/twap_consumer/src/lib.rs
@@ -33,6 +33,11 @@ pub enum DataKey {
     Keeper,
     Snapshot(Address, u64),
     TrackedPoolsPersistent,
+    /// Sorted (ascending, deduplicated) ledger timestamps at which a snapshot
+    /// was saved for this pool. Lets `get_twap_*` binary-search for the most
+    /// recent snapshot at or before an arbitrary `then_ts` instead of
+    /// requiring an exact-timestamp hit (issue #469).
+    SnapshotTimestamps(Address),
 }
 
 #[contracttype]
@@ -94,6 +99,7 @@ impl TwapConsumer {
             Self::SNAPSHOT_TTL_LEDGERS / 2,
             Self::SNAPSHOT_TTL_LEDGERS,
         );
+        Self::record_snapshot_timestamp(&env, &pool, ledger_ts);
 
         let mut tracked: Vec<Address> = env
             .storage()
@@ -126,11 +132,77 @@ impl TwapConsumer {
         Self::require_keeper(&env)?;
         let key = DataKey::Snapshot(pool.clone(), ledger_ts);
         env.storage().persistent().remove(&key);
+        Self::remove_snapshot_timestamp(&env, &pool, ledger_ts);
         env.events().publish(
             (symbol_short!("snap_del"), pool),
             ledger_ts,
         );
         Ok(())
+    }
+
+    /// Record `ts` in the pool's sorted snapshot-timestamp index. Ledger
+    /// timestamps are non-decreasing across calls, so appending keeps the
+    /// index sorted; skip if `ts` is already the most recent entry so a
+    /// keeper re-saving within the same ledger doesn't create a duplicate.
+    fn record_snapshot_timestamp(env: &Env, pool: &Address, ts: u64) {
+        let key = DataKey::SnapshotTimestamps(pool.clone());
+        let mut timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        if timestamps.last().map_or(true, |last| last != ts) {
+            timestamps.push_back(ts);
+        }
+        env.storage().persistent().set(&key, &timestamps);
+        env.storage().persistent().extend_ttl(
+            &key,
+            Self::SNAPSHOT_TTL_LEDGERS / 2,
+            Self::SNAPSHOT_TTL_LEDGERS,
+        );
+    }
+
+    fn remove_snapshot_timestamp(env: &Env, pool: &Address, ts: u64) {
+        let key = DataKey::SnapshotTimestamps(pool.clone());
+        let timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        let mut updated: Vec<u64> = Vec::new(env);
+        for i in 0..timestamps.len() {
+            let t = timestamps.get(i).unwrap();
+            if t != ts {
+                updated.push_back(t);
+            }
+        }
+        env.storage().persistent().set(&key, &updated);
+    }
+
+    /// Binary-search the pool's snapshot-timestamp index for the most recent
+    /// entry at or before `then_ts` (the "floor"). Returns `None` if no
+    /// snapshot that old exists.
+    fn floor_snapshot_ts(env: &Env, pool: &Address, then_ts: u64) -> Option<u64> {
+        let timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SnapshotTimestamps(pool.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        let mut lo: u32 = 0;
+        let mut hi: u32 = timestamps.len();
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            if timestamps.get(mid).unwrap() <= then_ts {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        if lo == 0 {
+            None
+        } else {
+            Some(timestamps.get(lo - 1).unwrap())
+        }
     }
 
     pub fn get_twap_price(env: Env, pool: Address, window_seconds: u64) -> Result<i128, TwapError> {
@@ -144,10 +216,12 @@ impl TwapConsumer {
             return Err(TwapError::InsufficientHistory);
         }
         let then_ts = ledger_ts_now - window_seconds;
+        let floor_ts =
+            Self::floor_snapshot_ts(&env, &pool, then_ts).ok_or(TwapError::InsufficientHistory)?;
         let snapshot: PriceSnapshot = env
             .storage()
             .persistent()
-            .get(&DataKey::Snapshot(pool.clone(), then_ts))
+            .get(&DataKey::Snapshot(pool.clone(), floor_ts))
             .ok_or(TwapError::NoSnapshotFound)?;
 
         let delta_a = (cum_a_now as u128).wrapping_sub(snapshot.cum_a as u128) as i128;
@@ -233,10 +307,12 @@ impl TwapConsumer {
             return Err(TwapError::InsufficientHistory);
         }
         let then_ts = ledger_ts_now - window_seconds;
+        let floor_ts =
+            Self::floor_snapshot_ts(&env, &pool, then_ts).ok_or(TwapError::InsufficientHistory)?;
         let snapshot: PriceSnapshot = env
             .storage()
             .persistent()
-            .get(&DataKey::Snapshot(pool.clone(), then_ts))
+            .get(&DataKey::Snapshot(pool.clone(), floor_ts))
             .ok_or(TwapError::NoSnapshotFound)?;
 
         let delta_a = (cum_a_now as u128).wrapping_sub(snapshot.cum_a as u128) as i128;
@@ -276,10 +352,12 @@ impl TwapConsumer {
             return Err(TwapError::InsufficientHistory);
         }
         let then_ts = ledger_ts_now - window_seconds;
+        let floor_ts =
+            Self::floor_snapshot_ts(&env, &pool, then_ts).ok_or(TwapError::InsufficientHistory)?;
         let snapshot: PriceSnapshot = env
             .storage()
             .persistent()
-            .get(&DataKey::Snapshot(pool.clone(), then_ts))
+            .get(&DataKey::Snapshot(pool.clone(), floor_ts))
             .ok_or(TwapError::NoSnapshotFound)?;
 
         let cum_then = snapshot.cum_a as i64;
@@ -299,13 +377,14 @@ impl TwapConsumer {
             cum_b: 0,
             pool_ts,
         };
-        let key = DataKey::Snapshot(pool, ledger_ts);
+        let key = DataKey::Snapshot(pool.clone(), ledger_ts);
         env.storage().persistent().set(&key, &snapshot);
         env.storage().persistent().extend_ttl(
             &key,
             Self::SNAPSHOT_TTL_LEDGERS / 2,
             Self::SNAPSHOT_TTL_LEDGERS,
         );
+        Self::record_snapshot_timestamp(&env, &pool, ledger_ts);
         Ok(())
     }
 }
@@ -731,8 +810,74 @@ mod tests {
 
         consumer.delete_snapshot(&amm_addr, &10_000);
 
+        // The only snapshot at/before then_ts=10_000 was removed from the
+        // timestamp index along with the snapshot itself, so there is no
+        // floor entry left — this is now InsufficientHistory rather than
+        // NoSnapshotFound (issue #469).
         let result = consumer.try_get_twap_price(&amm_addr, &60_u64);
-        assert_eq!(result, Err(Ok(TwapError::NoSnapshotFound)));
+        assert_eq!(result, Err(Ok(TwapError::InsufficientHistory)));
+    }
+
+    // ── Issue #469: arbitrary window_seconds should hit the nearest older
+    // snapshot instead of requiring an exact-timestamp match ──────────────────
+
+    #[test]
+    fn test_get_twap_price_with_arbitrary_window_uses_floor_snapshot() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(10_000);
+
+        let admin = Address::generate(&env);
+        let amm_addr = env.register_contract(None, AmmPool);
+        let lp_addr = env.register_contract(None, LpToken);
+        let consumer_addr = env.register_contract(None, TwapConsumer);
+
+        token::LpTokenClient::new(&env, &lp_addr).initialize(
+            &amm_addr,
+            &soroban_sdk::String::from_str(&env, "AMM LP Token"),
+            &soroban_sdk::String::from_str(&env, "ALP"),
+            &7u32,
+        );
+
+        let (ta, ta_sac) = create_sac(&env, &admin);
+        let (tb, tb_sac) = create_sac(&env, &admin);
+
+        let amm = AmmPoolClient::new(&env, &amm_addr);
+        amm.initialize(&admin, &ta.address, &tb.address, &lp_addr, &30_i128, &admin, &0_i128);
+
+        let provider = Address::generate(&env);
+        ta_sac.mint(&provider, &2_000_000_i128);
+        tb_sac.mint(&provider, &2_000_000_i128);
+        amm.add_liquidity(&provider, &2_000_000_i128, &2_000_000_i128, &0_i128, &10_000_u64);
+
+        let consumer = TwapConsumerClient::new(&env, &consumer_addr);
+        consumer.initialize(&admin);
+        consumer.save_snapshot(&amm_addr);
+
+        // A trade moves the pool's cumulative price, then a second snapshot
+        // is saved 30s after the first (at ts=10_030).
+        env.ledger().set_timestamp(10_030);
+        let whale = Address::generate(&env);
+        ta_sac.mint(&whale, &2_000_000_i128);
+        amm.swap(&whale, &ta.address, &1_000_000_i128, &0_i128, &10_030_u64);
+        consumer.save_snapshot(&amm_addr);
+
+        // A second trade 45s later advances the pool's own cumulative
+        // timestamp without a matching snapshot, so both queries below have
+        // a positive `elapsed` against their respective floor snapshot.
+        env.ledger().set_timestamp(10_075);
+        amm.swap(&whale, &ta.address, &1_000_000_i128, &0_i128, &10_075_u64);
+
+        // Query with window=45 at ts=10_075: then_ts = 10_030, an exact hit on
+        // the second snapshot, exercising the common case handled today.
+        let exact_hit = consumer.get_twap_price(&amm_addr, &45_u64);
+        assert!(exact_hit > 0);
+
+        // Query with window=50 at ts=10_075: then_ts = 10_025, which has no
+        // exact snapshot. Previously this reverted with NoSnapshotFound; now
+        // it must fall back to the floor (the ts=10_000 snapshot) instead.
+        let floor_hit = consumer.get_twap_price(&amm_addr, &50_u64);
+        assert!(floor_hit > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four independent bug fixes, bundled into one branch/PR:

- **#470** — `batch_auction::submit_order_cl` always reverted because `record_order` validated the token pair via the AMM-only `get_info`, even for CL pools. `record_order` now branches on `pool_type`: AMM pools still use `get_info`, CL pools use a new `ConcentratedLiquidityClient::get_tokens()` accessor.
- **#468** — `factory` stored its per-pool/per-pair lookup indexes (`Pool`, `ClPool`, `LpToken`, `GovernanceFor`, `PoolTokens`) in instance storage, which grows unboundedly and risks bricking the contract as pools accumulate. Moved all of them to persistent storage, mirroring the existing `PoolByIndex` pattern, and updated every read site (`get_pool`, `get_cl_pool`, `get_lp_token`, `get_governance`, `get_pool_tokens`, `sweep_fees_page`, `sync_global_fee_page`).
- **#469** — `twap_consumer`/`twal_consumer` required an exact-timestamp snapshot match, so arbitrary `window_seconds` values almost always returned `NoSnapshotFound`. Added a sorted per-pool snapshot-timestamp index and a binary-search "floor" lookup so `get_twap_price`, `get_twap_both`, `get_cl_twap`, `get_twal_liquidity`, and `get_cl_twal` use the most recent snapshot at or before the requested window. `delete_snapshot` now also prunes the timestamp index, and the case of no snapshot old enough now returns `InsufficientHistory` instead of `NoSnapshotFound`.
- **#467** — `staking::stake_locked` removed a staker's old effective stake using the *newly recomputed* boost instead of the boost the position was actually recorded with, corrupting `TotalEffectiveStaked` (the reward-distribution denominator) on every top-up after a boost change. Fixed to read the stored `BoostMultiplier` first, mirroring `extend_lock`.

Closes #467
Closes #468
Closes #469
Closes #470

## Test plan

- [x] `cargo test -p batch_auction` — 11/11 pass, including the previously-failing `test_submit_and_settle_cl_order` and `test_quote_and_settle_route_to_best_venue`
- [x] `cargo test -p concentrated_liquidity` — 122/122 pass
- [x] `cargo test -p factory` — 30/30 pass
- [x] `cargo test -p twap_consumer` — 13/13 pass (adds `test_get_twap_price_with_arbitrary_window_uses_floor_snapshot`)
- [x] `cargo test -p twal_consumer` — 8/8 pass (adds `test_get_twal_liquidity_with_arbitrary_window_uses_floor_snapshot`)
- [x] `cargo test -p staking` — 18/18 pass (adds `test_stake_locked_top_up_after_boost_decay_keeps_total_effective_staked_correct`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)