### PR TITLE
fix: use relative live_until_ledger in migration contract approvals

### DIFF
--- a/contracts/v2_to_v3_migration/src/lib.rs
+++ b/contracts/v2_to_v3_migration/src/lib.rs
@@ -218,8 +218,12 @@ impl MigrationContract {
         tb_client.transfer(&provider, &contract_addr, &received_b);
 
         // Approve V3 pool to pull from this contract.
-        ta_client.approve(&contract_addr, &v3_pool, &received_a, &200u32);
-        tb_client.approve(&contract_addr, &v3_pool, &received_b, &200u32);
+        // live_until_ledger must be >= current ledger sequence when amount > 0.
+        // Adding a small lookahead is sufficient because the approval is consumed
+        // in the very next call (add_liquidity_range) within the same transaction.
+        let approve_expiry = env.ledger().sequence() + 100;
+        ta_client.approve(&contract_addr, &v3_pool, &received_a, &approve_expiry);
+        tb_client.approve(&contract_addr, &v3_pool, &received_b, &approve_expiry);
 
         let position_id = v3_client.add_liquidity_range(
             &contract_addr,


### PR DESCRIPTION
The approve() calls in MigrationContract::migrate were passing a hardcoded absolute live_until_ledger of 200. On any live network the current ledger sequence is far beyond 200, causing SAC to reject the call immediately (live_until_ledger must be >= current ledger sequence when amount > 0). Migration could never succeed in production; tests passed only because the test ledger sequence starts near 0.

Fix: compute expiry as env.ledger().sequence() + 100. The +100 ledger lookahead (~8 min) is more than sufficient since the approval is consumed in the immediately following add_liquidity_range call.

## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

closes #428