### PR TITLE
fix: add legacy owner check in mint_position_single_token

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -826,6 +826,7 @@ impl ConcentratedLiquidity {
             return Err(ClError::Paused);
         }
         provider.require_auth();
+        Self::ensure_legacy_owner(&env, &provider, lower_tick, upper_tick)?;
 
         // ── Validate tick range ───────────────────────────────────────────────
         if lower_tick >= upper_tick {


### PR DESCRIPTION
closes #521 

Title: fix: add ensure_legacy_owner guard to mint_position_single_token
Body:
mint_position_single_token was the only legacy address-keyed entry point that could add liquidity to a Position without calling ensure_legacy_owner. A provider could transfer their position's NFT and still call mint_position_single_token with their own address to keep adding liquidity — violating the module's ownership model where the NFT holder controls the position.
burn_position and collect_fees already guard against this:
Self::ensure_legacy_owner(&env, &provider, lower_tick, upper_tick)?;
Added the same check to mint_position_single_token immediately after provider.require_auth(), closing the gap.
Fix:
provider.require_auth();
Self::ensure_legacy_owner(&env, &provider, lower_tick, upper_tick)?;
Impact: After transferring a position NFT, the previous owner can no longer add liquidity via the single-token deposit path. Only the NFT holder can now modify the position.
Testing: Verified the guard call matches the pattern in burn_position and collect_fees. Run cargo test --workspace to confirm.