### PR TITLE
fix: route degenerate mint_position_single_token branches through is_…

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -902,13 +902,31 @@ impl ConcentratedLiquidity {
             let sqrt_current = Self::tick_to_sqrt_price_x96(current_tick);
 
             if sqrt_current >= sqrt_upper {
-                // Degenerate: current at or above upper tick - treat as above-range for A
-                let liq = math::get_liquidity_for_amount0(sqrt_upper, sqrt_upper, amount_in);
-                (amount_in, 0_i128, liq.max(1), amount_in)
+                // Degenerate: current at or above upper tick
+                if is_token_a {
+                    let liq = math::get_liquidity_for_amount0(sqrt_current, sqrt_upper, amount_in);
+                    let liq = liq.max(1);
+                    let used = math::get_amount0_delta(sqrt_current, sqrt_upper, liq);
+                    (used, 0_i128, liq, used)
+                } else {
+                    let liq = math::get_liquidity_for_amount1(sqrt_lower, sqrt_current, amount_in);
+                    let liq = liq.max(1);
+                    let used = math::get_amount1_delta(sqrt_lower, sqrt_current, liq);
+                    (0_i128, used, liq, used)
+                }
             } else if sqrt_current <= sqrt_lower {
-                // Degenerate: current at or below lower tick - treat as below-range for B
-                let liq = math::get_liquidity_for_amount1(sqrt_lower, sqrt_lower, amount_in);
-                (0_i128, amount_in, liq.max(1), amount_in)
+                // Degenerate: current at or below lower tick
+                if is_token_a {
+                    let liq = math::get_liquidity_for_amount0(sqrt_current, sqrt_upper, amount_in);
+                    let liq = liq.max(1);
+                    let used = math::get_amount0_delta(sqrt_current, sqrt_upper, liq);
+                    (used, 0_i128, liq, used)
+                } else {
+                    let liq = math::get_liquidity_for_amount1(sqrt_lower, sqrt_current, amount_in);
+                    let liq = liq.max(1);
+                    let used = math::get_amount1_delta(sqrt_lower, sqrt_current, liq);
+                    (0_i128, used, liq, used)
+                }
             } else if is_token_a {
                 // Token A covers [current_price, upper_price].
                 // Liquidity is computed from the amount, then we back-compute actual token amount.


### PR DESCRIPTION
closes #511

## Summary of Changes

Both degenerate branches in contracts/concentrated_liquidity/src/lib.rs:904-929 now route through is_token_a checks using the same logic as the non-degenerate branches, with two effects:
1. Correct token matching — The token pulled always matches what the caller specified via is_token_a, instead of hard-coding token A for the sqrt_current >= sqrt_upper case and token B for the sqrt_current <= sqrt_lower case.
2. Real liquidity values — When the price is at the boundary and the caller deposits the "right" token (e.g., token A at current_tick == lower_tick), the computation uses (sqrt_current, sqrt_upper) which effectively covers the full range [lower, upper], producing a real liquidity amount instead of get_liquidity_for_amountX(x, x, ...) = 0 clamped to 1.


## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
