### PR TITLE
Guard legacy NFT ownership in concentrated liquidity mint/modify

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -515,6 +515,7 @@ impl ConcentratedLiquidity {
             return Err(ClError::Paused);
         }
         provider.require_auth();
+        Self::ensure_legacy_owner(&env, &provider, lower_tick, upper_tick)?;
         if lower_tick >= upper_tick {
             return Err(ClError::TickOutOfRange);
         }
@@ -665,6 +666,7 @@ impl ConcentratedLiquidity {
             return Err(ClError::Paused);
         }
         provider.require_auth();
+        Self::ensure_legacy_owner(&env, &provider, lower_tick, upper_tick)?;
         if lower_tick >= upper_tick {
             return Err(ClError::TickOutOfRange);
         }
@@ -5771,6 +5773,46 @@ mod test_single_token_deposit {
             f.client.position_token_id(&f.alice, &f.lower, &f.upper),
             None
         );
+    }
+
+    #[test]
+    fn legacy_provider_mutation_rejected_after_transfer() {
+        let env = Env::default();
+        let f = setup_with_nft(&env);
+        let bob = Address::generate(&env);
+        f.nft.transfer(&f.alice, &f.alice, &bob, &0_u64);
+
+        let mint_err = f
+            .client
+            .try_mint_position(
+                &f.alice,
+                &f.lower,
+                &f.upper,
+                &10_000_i128,
+                &10_000_i128,
+                &0_i128,
+                &0_i128,
+            )
+            .err()
+            .unwrap()
+            .unwrap();
+        assert_eq!(mint_err, ClError::NotNftOwner);
+
+        let modify_err = f
+            .client
+            .try_modify_position(
+                &f.alice,
+                &f.lower,
+                &f.upper,
+                &1_000_i128,
+                &0_i128,
+                &0_i128,
+                &u64::MAX,
+            )
+            .err()
+            .unwrap()
+            .unwrap();
+        assert_eq!(modify_err, ClError::NotNftOwner);
     }
 
     #[test]


### PR DESCRIPTION
Closes #509 

## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format


## PR Summary

This PR fixes a legacy-ownership bug in the concentrated liquidity contract for tokenized positions.

Previously, `mint_position` and `modify_position` could still mutate a position after the original provider had transferred the position NFT. That behavior was inconsistent with the contract’s documented ownership model, which states that legacy address-keyed entry points should defer control to the current NFT owner once a position is tokenized.

## Changes

- Added the `ensure_legacy_owner` guard to `mint_position`
- Added the same `ensure_legacy_owner` guard to `modify_position`
- Added a regression test covering the case where:
  - the NFT is transferred to a new owner
  - the original provider later calls the legacy address-keyed mint/modify path
  - the call is rejected with `ClError::NotNftOwner`

## Why

This prevents a seller from continuing to grow a position they no longer control after transferring their receipt NFT. It brings the remaining legacy mutation entry points in line with the protections already enforced for `burn_position` and `collect_fees`.

## Impact

- Enforces NFT-based ownership consistently for all legacy position mutations
- Prevents unauthorized liquidity growth through the legacy path
- Aligns contract behavior with the documented ownership model for tokenized positions

## Testing

- Added regression coverage for the transferred-NFT ownership scenario
