### PR TITLE
fix(oracle_aggregator): guard remove_source against dropping below MIN_VALID_SOURCES

### DIFF
--- a/contracts/oracle_aggregator/src/lib.rs
+++ b/contracts/oracle_aggregator/src/lib.rs
@@ -158,6 +158,10 @@ impl OracleAggregator {
             panic_with_error!(&env, OracleError::SourceNotFound);
         }
 
+        if new_sources.len() < MIN_VALID_SOURCES {
+            panic_with_error!(&env, OracleError::InsufficientSources);
+        }
+
         env.storage()
             .instance()
             .set(&DataKey::Sources, &new_sources);


### PR DESCRIPTION
## Description

`remove_source` previously only verified that the target address existed before removing it. It did not check whether the remaining source count would still satisfy `MIN_VALID_SOURCES` (2). An admin removing a source from a 2-source deployment (e.g. to swap out a faulty adapter) could silently leave the aggregator with 1 or 0 sources. After that, every call to `get_price` would panic with `InsufficientSources`, and `get_price_safe` would return `confidence == 0` — with no warning at removal time.

## Fix

After confirming the source was found and building `new_sources`, add a guard:

```rust
if new_sources.len() < MIN_VALID_SOURCES {
    panic_with_error!(&env, OracleError::InsufficientSources);
}
```

This prevents the removal from going through if it would leave fewer than 2 registered sources, giving the admin a clear error at removal time instead of silent degradation.

Closes #535