### PR TITLE
fix: correct liquidity_from_amounts in-range branch

### DIFF
--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -2563,7 +2563,12 @@ impl ConcentratedLiquidity {
             let sqrt_upper = Self::tick_to_sqrt_price_x96(ut);
             math::get_liquidity_for_amount1(sqrt_lower, sqrt_upper, b).max(1)
         } else {
-            a.min(b).max(1)
+            let sqrt_lower = Self::tick_to_sqrt_price_x96(lt);
+            let sqrt_upper = Self::tick_to_sqrt_price_x96(ut);
+            let sqrt_current = Self::tick_to_sqrt_price_x96(ct);
+            let liquidity_from_amount0 = math::get_liquidity_for_amount0(sqrt_current, sqrt_upper, a);
+            let liquidity_from_amount1 = math::get_liquidity_for_amount1(sqrt_lower, sqrt_current, b);
+            liquidity_from_amount0.min(liquidity_from_amount1).max(1)
         }
     }
 


### PR DESCRIPTION
Replace raw a.min(b).max(1) with proper two-sided liquidity formula for in-range deposits:
- Use math::get_liquidity_for_amount0(sqrt_current, sqrt_upper, a) for token A part
- Use math::get_liquidity_for_amount1(sqrt_lower, sqrt_current, b) for token B part
- Take min(liquidity_from_amount0, liquidity_from_amount1).max(1) to ensure consistent Q96 scaling

This ensures in-range deposits have liquidity values that correspond to actual token amounts received.

Closes: #510

## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

 Closes #510 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
