### PR TITLE
fix: reject partial UpdateFactoryGlobalFee execution in governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Source: [`contracts/governance/src/lib.rs`](contracts/governance/src/lib.rs).
 | 31 | `InsufficientSnapshotBal` | The snapshot balance is below the required threshold. |
 | 32 | `VetoMultisigNotSet` | The veto multisig address has not been configured. |
 | 33 | `NoPendingAdmin` | An admin transfer was accepted while no pending admin is set. |
+| 34 | `PartialFactoryUpdate` | An `UpdateFactoryGlobalFee` proposal's `offset`/`limit` window does not start at 0 or does not cover every pool in the factory; execution is rejected to prevent the proposal from being marked executed while pools remain untouched. |
 
 ### LP Token Contract Errors
 

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -69,6 +69,11 @@ pub enum GovernanceError {
     InsufficientSnapshotBal = 31,
     VetoMultisigNotSet = 32,
     NoPendingAdmin = 33,
+    /// The `UpdateFactoryGlobalFee` proposal's `offset` / `limit` window does
+    /// not cover every pool registered in the factory.  Execution is rejected
+    /// so the proposal cannot be permanently marked executed while only a
+    /// partial set of pools was updated.
+    PartialFactoryUpdate = 34,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -349,6 +354,8 @@ pub trait AmmPoolInterface {
 pub trait FactoryInterface {
     fn set_treasury(env: Env, admin: Address, treasury: Address, global_protocol_fee_bps: i128);
     fn set_global_fee_paginated(env: Env, admin: Address, offset: u32, limit: u32) -> u32;
+    /// Return the total number of AMM pools registered in the factory.
+    fn get_pool_count(env: Env) -> u64;
 }
 
 // ── POL Vesting client ────────────────────────────────────────────────────────
@@ -586,7 +593,14 @@ impl Governance {
                     return Err(GovernanceError::InvalidFeeBps);
                 }
             }
-            ProposalKind::UpdateFactoryGlobalFee(_) => {}
+            ProposalKind::UpdateFactoryGlobalFee(params) => {
+                // offset must be zero (all pools must be covered from the start)
+                // and limit must be non-zero.  These are cheap eager checks that
+                // catch obviously invalid proposals before they enter voting.
+                if params.offset != 0 || params.limit == 0 {
+                    return Err(GovernanceError::PartialFactoryUpdate);
+                }
+            }
             ProposalKind::CreatePolVesting(_) => {}
             ProposalKind::PauseClPool(_) => {}
             ProposalKind::UnpauseClPool(_) => {}
@@ -868,6 +882,20 @@ impl Governance {
             ProposalKind::UpdateFactoryGlobalFee(params) => {
                 let self_addr = env.current_contract_address();
                 let factory_client = FactoryClient::new(&env, &params.factory);
+                // Ensure the pagination window covers every pool registered in
+                // the factory.  If it does not, the transaction is aborted so
+                // the proposal cannot be marked executed while pools remain
+                // untouched.
+                let pool_count: u64 = factory_client.get_pool_count();
+                let window_end: u64 = (params.offset as u64)
+                    .saturating_add(params.limit as u64);
+                // Both conditions must hold:
+                //  - offset == 0: the window starts from the first pool
+                //  - window_end >= pool_count: the window reaches the last pool
+                // A non-zero offset would silently skip the leading pools.
+                if params.offset != 0 || window_end < pool_count {
+                    return Err(GovernanceError::PartialFactoryUpdate);
+                }
                 let _updated = factory_client.set_global_fee_paginated(
                     &self_addr,
                     &params.offset,
@@ -2751,6 +2779,251 @@ mod tests {
             }),
         );
         assert!(r.is_err());
+    }
+
+    // ── UpdateFactoryGlobalFee regression tests ───────────────────────────────
+    //
+    // These tests verify the fix for the partial-execution bug: a proposal
+    // whose offset/limit window does not cover all factory pools must be
+    // rejected so the proposal is never marked executed while pools remain
+    // un-updated.
+
+    /// Minimal mock factory that tracks a configurable pool count and records
+    /// whether `set_global_fee_paginated` was called.  Only the three methods
+    /// declared in `FactoryInterface` are implemented; every other call would
+    /// trap, which is fine for these unit tests.
+    #[contract]
+    struct MockFactory;
+
+    #[contractimpl]
+    impl MockFactory {
+        /// Store the pool count that this mock should report.
+        pub fn set_pool_count(env: Env, count: u64) {
+            env.storage().instance().set(&Symbol::new(&env, "count"), &count);
+        }
+
+        /// Return the number of pools set via `set_pool_count`.
+        pub fn get_pool_count(env: Env) -> u64 {
+            env.storage()
+                .instance()
+                .get(&Symbol::new(&env, "count"))
+                .unwrap_or(0_u64)
+        }
+
+        /// Record that this was called so tests can assert it ran.
+        pub fn set_global_fee_paginated(env: Env, _admin: Address, _offset: u32, limit: u32) -> u32 {
+            let prev: u32 = env
+                .storage()
+                .instance()
+                .get(&Symbol::new(&env, "called"))
+                .unwrap_or(0u32);
+            env.storage()
+                .instance()
+                .set(&Symbol::new(&env, "called"), &(prev + 1));
+            limit
+        }
+
+        /// Satisfy the FactoryInterface trait; not exercised by these tests.
+        pub fn set_treasury(
+            _env: Env,
+            _admin: Address,
+            _treasury: Address,
+            _global_protocol_fee_bps: i128,
+        ) {
+        }
+
+        /// Return how many times `set_global_fee_paginated` was called.
+        pub fn call_count(env: Env) -> u32 {
+            env.storage()
+                .instance()
+                .get(&Symbol::new(&env, "called"))
+                .unwrap_or(0u32)
+        }
+    }
+
+    /// Suite returned by `setup_factory_gov`.
+    struct FactoryGovSuite {
+        env: Env,
+        gov_addr: Address,
+        proposer: Address,
+        factory_addr: Address,
+    }
+
+    impl FactoryGovSuite {
+        fn gov(&self) -> GovernanceClient {
+            GovernanceClient::new(&self.env, &self.gov_addr)
+        }
+        fn factory(&self) -> MockFactoryClient {
+            MockFactoryClient::new(&self.env, &self.factory_addr)
+        }
+    }
+
+    /// Helper: set up a governance + lp-token environment backed by a mock
+    /// factory that reports `pool_count` pools.
+    fn setup_factory_gov(pool_count: u64) -> FactoryGovSuite {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(&env);
+
+        // Deploy mock factory and configure its pool count.
+        let factory_addr = env.register_contract(None, MockFactory);
+        MockFactoryClient::new(&env, &factory_addr).set_pool_count(&pool_count);
+
+        // Deploy LP token.
+        let lp_addr = env.register_contract(None, LpToken);
+        token::LpTokenClient::new(&env, &lp_addr).initialize(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "AMM LP"),
+            &soroban_sdk::String::from_str(&env, "ALP"),
+            &7u32,
+        );
+
+        // Deploy a bare AMM as the governance target (governance needs an amm
+        // address at initialization time).
+        let ta = env.register_stellar_asset_contract_v2(admin.clone());
+        let tb = env.register_stellar_asset_contract_v2(admin.clone());
+        let amm_addr = env.register_contract(None, AmmPool);
+        amm::AmmPoolClient::new(&env, &amm_addr).initialize(
+            &admin,
+            &ta.address(),
+            &tb.address(),
+            &lp_addr,
+            &30_i128,
+            &admin,
+            &0_i128,
+        );
+
+        // Deploy and initialize governance.
+        let gov_addr = env.register_contract(None, Governance);
+        GovernanceClient::new(&env, &gov_addr).initialize(
+            &admin,
+            &amm_addr,
+            &lp_addr,
+            &(7 * 24 * 60 * 60_u64), // voting_period_secs
+            &(2 * 24 * 60 * 60_u64), // timelock_secs
+            &1_000_i128,             // quorum_bps 10%
+            &0_i128,                 // min_proposer_stake_bps (0 → anyone can propose)
+        );
+        token::LpTokenClient::new(&env, &lp_addr).set_locker(&gov_addr);
+
+        // Mint LP tokens to a proposer so they have voting power.
+        let proposer = Address::generate(&env);
+        token::LpTokenClient::new(&env, &lp_addr).mint(&proposer, &1_000_i128);
+
+        FactoryGovSuite { env, gov_addr, proposer, factory_addr }
+    }
+
+    /// propose() must reject a proposal with limit == 0.
+    #[test]
+    fn test_update_factory_global_fee_propose_rejects_zero_limit() {
+        let s = setup_factory_gov(5);
+        let gov = s.gov();
+
+        let err = gov
+            .try_propose(
+                &s.proposer,
+                &ProposalKind::UpdateFactoryGlobalFee(UpdateFactoryGlobalFeeParams {
+                    factory: s.factory_addr.clone(),
+                    offset: 0,
+                    limit: 0, // invalid: zero limit
+                }),
+            )
+            .unwrap_err()
+            .unwrap();
+
+        assert_eq!(err, GovernanceError::PartialFactoryUpdate);
+    }
+
+    /// execute() must reject a proposal whose window covers fewer pools than
+    /// the factory currently reports, leaving proposal.executed == false.
+    #[test]
+    fn test_update_factory_global_fee_execute_rejects_partial_window() {
+        let s = setup_factory_gov(10);
+        let gov = s.gov();
+
+        // Propose with limit=5, which only covers half of the 10 pools.
+        let pid = gov.propose(
+            &s.proposer,
+            &ProposalKind::UpdateFactoryGlobalFee(UpdateFactoryGlobalFeeParams {
+                factory: s.factory_addr.clone(),
+                offset: 0,
+                limit: 5, // covers pools 0-4 only; factory has 10
+            }),
+        );
+
+        gov.vote(&s.proposer, &pid, &Vote::For);
+        let proposal = gov.get_proposal(&pid);
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+        // execute() must return PartialFactoryUpdate and NOT mark the proposal done.
+        let err = gov.try_execute(&pid).unwrap_err().unwrap();
+        assert_eq!(err, GovernanceError::PartialFactoryUpdate);
+
+        // The proposal must still be in Queued (not Executed) state.
+        let status = gov.proposal_status(&pid);
+        assert_eq!(status, ProposalStatus::Queued);
+
+        // set_global_fee_paginated must NOT have been called (tx rolled back).
+        let call_count = s.factory().call_count();
+        assert_eq!(call_count, 0);
+    }
+
+    /// execute() must succeed and mark the proposal executed when limit covers
+    /// all pools (offset=0, limit >= pool_count).
+    #[test]
+    fn test_update_factory_global_fee_execute_succeeds_full_coverage() {
+        let s = setup_factory_gov(3);
+        let gov = s.gov();
+
+        // Propose with limit=u32::MAX — covers all 3 pools and any future ones.
+        let pid = gov.propose(
+            &s.proposer,
+            &ProposalKind::UpdateFactoryGlobalFee(UpdateFactoryGlobalFeeParams {
+                factory: s.factory_addr.clone(),
+                offset: 0,
+                limit: u32::MAX,
+            }),
+        );
+
+        gov.vote(&s.proposer, &pid, &Vote::For);
+        let proposal = gov.get_proposal(&pid);
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+        // execute() must succeed.
+        gov.execute(&pid);
+
+        // Proposal must now be marked Executed.
+        assert_eq!(gov.proposal_status(&pid), ProposalStatus::Executed);
+
+        // set_global_fee_paginated must have been called exactly once.
+        let call_count = s.factory().call_count();
+        assert_eq!(call_count, 1);
+    }
+
+    /// execute() must succeed when the factory has zero pools (empty factory is
+    /// a degenerate but valid case: any limit > 0 satisfies 0 + limit >= 0).
+    #[test]
+    fn test_update_factory_global_fee_execute_succeeds_empty_factory() {
+        let s = setup_factory_gov(0);
+        let gov = s.gov();
+
+        let pid = gov.propose(
+            &s.proposer,
+            &ProposalKind::UpdateFactoryGlobalFee(UpdateFactoryGlobalFeeParams {
+                factory: s.factory_addr.clone(),
+                offset: 0,
+                limit: 1,
+            }),
+        );
+
+        gov.vote(&s.proposer, &pid, &Vote::For);
+        let proposal = gov.get_proposal(&pid);
+        s.env.ledger().set_timestamp(proposal.execute_after + 1);
+
+        gov.execute(&pid);
+        assert_eq!(gov.proposal_status(&pid), ProposalStatus::Executed);
     }
 }
 


### PR DESCRIPTION

  fix: reject partial UpdateFactoryGlobalFee execution in governance
  
  Problem
  
  execute() for ProposalKind::UpdateFactoryGlobalFee called
  factory_client.set_global_fee_paginated(offset, limit) and then unconditionally set
  proposal.executed = true, regardless of how many pools were actually updated.
  
  This meant a proposal with offset=0, limit=1 on a factory with 100 pools would:
  
  - Update exactly one pool's fee
  - Be permanently marked as executed
  - Leave the remaining 99 pools untouched with no on-chain signal and no way to re-run the
  proposal
  
  Two contributing gaps made this reachable:
  
  1. propose() had an empty match arm for UpdateFactoryGlobalFee — no validation on offset or
  limit whatsoever
  2. execute() discarded the return value (let _updated = ...) and never checked coverage
  
  Fix
  
  propose() — eager rejection of structurally invalid proposals:
  
  - Rejects offset != 0 (a non-zero start silently skips leading pools)
  - Rejects limit == 0 (zero limit updates nothing)
  - Returns GovernanceError::PartialFactoryUpdate for both cases, preventing obviously broken
  proposals from entering the voting queue
  
  execute() — live coverage check before applying the change:
  
  - Calls factory_client.get_pool_count() to read the current pool count
  - Verifies offset == 0 and offset + limit >= pool_count
  - Returns GovernanceError::PartialFactoryUpdate if the window does not cover all pools — before
   set_global_fee_paginated is called and before proposal.executed = true is set
  - The proposal remains in Queued state and can be superseded by a correctly-scoped proposal
  
  The check is evaluated at execution time (not proposal time), so a proposal that was valid when
  proposed but became partial because the factory grew in the interim is also caught.
  
  Changes
  
  - GovernanceError::PartialFactoryUpdate = 34 — new error variant
  - FactoryInterface::get_pool_count — added to the governance-side factory client trait so
  execute() can query the live count
  - propose() — validation for UpdateFactoryGlobalFee (was an empty arm)
  - execute() — coverage guard for UpdateFactoryGlobalFee before the factory call
  - Four regression tests using an inline MockFactory contract:
    - test_update_factory_global_fee_propose_rejects_zero_limit
    - test_update_factory_global_fee_execute_rejects_partial_window (also asserts
  set_global_fee_paginated was never called and proposal stays Queued)
    - test_update_factory_global_fee_execute_succeeds_full_coverage
    - test_update_factory_global_fee_execute_succeeds_empty_factory
  
  - README.md — governance error table updated with code 34
  
  Testing
  
  cargo build --release --target wasm32v1-none
  cargo test -p governance

▸ Closes #563 
