### PR TITLE
fix(amm): replace unversioned event emissions with emit_versioned_eve…

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -767,9 +767,10 @@ impl AmmPool {
             .instance()
             .set(&DataKey::ProtocolFeeBps, &protocol_fee_bps);
         // Emit an event so LPs and indexers can monitor protocol-fee changes.
-        env.events().publish(
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
             (Symbol::new(&env, "protocol_fee_set"),),
-            (protocol_fee_bps, recipient),
+            (protocol_fee_bps, recipient)
         );
         Ok(())
     }
@@ -1150,8 +1151,11 @@ impl AmmPool {
             return Err(AmmError::InvalidFeeBps);
         }
         env.storage().instance().set(&DataKey::FeeBps, &new_fee_bps);
-        env.events()
-            .publish((symbol_short!("fee_upd"), admin.clone()), (new_fee_bps,));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (symbol_short!("fee_upd"), admin.clone()),
+            (new_fee_bps,)
+        );
         Ok(())
     }
 
@@ -1234,8 +1238,11 @@ impl AmmPool {
         admin.require_auth();
         env.deployer()
             .update_current_contract_wasm(new_wasm_hash.clone());
-        env.events()
-            .publish((Symbol::new(&env, "upgraded"),), (new_wasm_hash,));
+        soroban_amm_sdk::emit_versioned_event!(
+            env,
+            (Symbol::new(&env, "upgraded"),),
+            (new_wasm_hash,)
+        );
         Ok(())
     }
 


### PR DESCRIPTION
…nt! macro

- Fix update_fee fee_upd event (lib.rs:1153-1154) to use emit_versioned_event!
- Fix set_protocol_fee protocol_fee_set event (lib.rs:770-773) to use emit_versioned_event!
- Fix upgrade upgraded event (lib.rs:1237-1238) to use emit_versioned_event!
- Prevent indexers from misparsing EVENT_SCHEMA_VERSION on these three event types

Closes #574