### PR TITLE
fix: compute migration refund from call-scoped balance delta

### DIFF
--- a/contracts/v2_to_v3_migration/src/lib.rs
+++ b/contracts/v2_to_v3_migration/src/lib.rs
@@ -215,6 +215,12 @@ impl MigrationContract {
         let tb_client = TokenClient::new(&env, &token_b);
         let contract_addr = env.current_contract_address();
 
+        // Snapshot balances before this migration's funds land, so the refund
+        // step below only ever returns the delta attributable to this call —
+        // never any balance already sitting at this shared contract address.
+        let balance_a_before = ta_client.balance(&contract_addr);
+        let balance_b_before = tb_client.balance(&contract_addr);
+
         ta_client.transfer(&provider, &contract_addr, &received_a);
         tb_client.transfer(&provider, &contract_addr, &received_b);
 
@@ -238,8 +244,11 @@ impl MigrationContract {
         );
 
         // ── Step 4: refund leftover dust to provider ──────────────────────────
-        let refund_a = ta_client.balance(&contract_addr);
-        let refund_b = tb_client.balance(&contract_addr);
+        // Computed as the call-scoped delta, not the contract's absolute
+        // balance, so pre-existing tokens at this shared address are never
+        // swept up and misattributed to this migration.
+        let refund_a = ta_client.balance(&contract_addr) - balance_a_before;
+        let refund_b = tb_client.balance(&contract_addr) - balance_b_before;
         if refund_a > 0 {
             ta_client.transfer(&contract_addr, &provider, &refund_a);
         }


### PR DESCRIPTION
migrate() previously refunded the contract's absolute token balance after depositing into V3, which sweeps up any tokens already sitting at this shared, publicly-addressable contract (accidental transfers, leftover dust from prior calls) and gifts them to whichever LP happens to call migrate() next. Snapshot balances before this call's funds land and refund only the delta, so unrelated balances are left alone.

closes #543 