### PR TITLE
feat: emit governance_proposed event in propose_governance

### DIFF
--- a/contracts/reserve_manager/src/lib.rs
+++ b/contracts/reserve_manager/src/lib.rs
@@ -128,6 +128,10 @@ impl ReserveManager {
         env.storage()
             .instance()
             .set(&DataKey::PendingGovernance, &Some(new_governance.clone()));
+        env.events().publish(
+            (Symbol::new(&env, "governance_proposed"),),
+            (current_governance, new_governance),
+        );
         Ok(())
     }
 


### PR DESCRIPTION
accept_governance already publishes governance_transferred on handoff completion, but propose_governance -- the step that actually initiates a change and stores PendingGovernance -- emitted nothing, leaving off-chain monitors blind to a pending nomination until it's already finalized. Mirrors the governance_proposed event already used by pol_vesting's two-step handover for consistency.
close #544 
