### PR TITLE
fix: reject negative amounts in token::approve

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -210,6 +210,7 @@ impl LpToken {
         live_until_ledger: u32,
     ) {
         from.require_auth();
+        assert!(amount >= 0, "amount must be non-negative");
         if amount > 0 {
             assert!(
                 live_until_ledger >= env.ledger().sequence(),
@@ -566,6 +567,18 @@ mod tests {
         ts.env.ledger().with_mut(|l| l.sequence_number = 100);
         let past = ts.env.ledger().sequence() - 1;
         assert!(client.try_approve(&alice, &bob, &100_i128, &past).is_err());
+    }
+
+    #[test]
+    fn test_approve_negative_amount_panics() {
+        let ts = setup();
+        let client = LpTokenClient::new(&ts.env, &ts.contract_addr);
+        let alice = Address::generate(&ts.env);
+        let bob = Address::generate(&ts.env);
+        let live_until = ts.env.ledger().sequence() + 100;
+        assert!(client
+            .try_approve(&alice, &bob, &-100_i128, &live_until)
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Every other mutating entry point (transfer, transfer_from, mint, burn, lock, unlock) asserts amount > 0, but approve only validated live_until_ledger when amount > 0, letting a negative amount (e.g. -100) be stored verbatim in AllowanceValue and returned as-is by allowance() since its expiry check is skipped for non-positive values. Add the same amount >= 0 assertion the rest of the contract already enforces, plus a regression test.

close #562 