### PR TITLE
fix(staking): compile and run tests.rs, fix cap test infra (#564)

### DIFF
--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -984,6 +984,10 @@ impl Staking {
 }
 
 #[cfg(test)]
+#[path = "tests.rs"]
+mod cap_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -2,71 +2,123 @@
 
 #![cfg(test)]
 
+extern crate std;
+
 use super::*;
-use soroban_sdk::{Env, Address, testutils::Address as _};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use std::panic::AssertUnwindSafe;
 
 #[test]
 fn test_set_max_reward_pool_balance() {
     let env = Env::default();
-    // Initialize with dummy parameters
-    let lp_token = Address::random(&env);
-    let reward_token = Address::random(&env);
-    let admin = Address::random(&env);
-    Staking::initialize(&env, &lp_token, &reward_token, &admin);
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Staking);
+    env.as_contract(&contract_id, || {
+        // Initialize with dummy parameters
+        let lp_token = Address::generate(&env);
+        let reward_token = Address::generate(&env);
+        let admin = Address::generate(&env);
+        Staking::initialize(
+            env.clone(),
+            lp_token.clone(),
+            reward_token.clone(),
+            admin.clone(),
+        );
 
-    // Initially, cap is 0 (no limit)
-    let initial_cap: i128 = env.storage().instance().get(&DataKey::ConfigMaxRewardPoolBalance).unwrap_or(0);
-    assert_eq!(initial_cap, 0);
+        // Initially, cap is 0 (no limit)
+        let initial_cap: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ConfigMaxRewardPoolBalance)
+            .unwrap_or(0);
+        assert_eq!(initial_cap, 0);
 
-    // Set a positive cap
-    Staking::set_max_reward_pool_balance(&env, &admin, 1_000_000);
-    let cap: i128 = env.storage().instance().get(&DataKey::ConfigMaxRewardPoolBalance).unwrap();
-    assert_eq!(cap, 1_000_000);
+        // Set a positive cap
+        Staking::set_max_reward_pool_balance(env.clone(), admin.clone(), 1_000_000);
+        let cap: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ConfigMaxRewardPoolBalance)
+            .unwrap();
+        assert_eq!(cap, 1_000_000);
 
-    // Setting cap lower than current balance should panic
-    // Simulate a current reward pool balance
-    env.storage().instance().set(&DataKey::RewardPoolBalance, &2_000_000);
-    // This should panic because max_balance < current_balance
-    let result = std::panic::catch_unwind(|| {
-        Staking::set_max_reward_pool_balance(&env, &admin, 1_000_000);
+        // Setting cap lower than current balance should panic
+        // Simulate a current reward pool balance
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardPoolBalance, &2_000_000);
+        // This should panic because max_balance < current_balance
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            Staking::set_max_reward_pool_balance(env.clone(), admin.clone(), 1_000_000);
+        }));
+        assert!(result.is_err());
     });
-    assert!(result.is_err());
 }
 
 #[test]
 fn test_add_rewards_respects_cap() {
     let env = Env::default();
-    let lp_token = Address::random(&env);
-    let reward_token = Address::random(&env);
-    let admin = Address::random(&env);
-    Staking::initialize(&env, &lp_token, &reward_token, &admin);
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Staking);
+    env.as_contract(&contract_id, || {
+        let lp_token = Address::generate(&env);
+        let reward_token = Address::generate(&env);
+        let admin = Address::generate(&env);
+        Staking::initialize(env.clone(), lp_token, reward_token, admin.clone());
 
-    // Set a cap of 500
-    Staking::set_max_reward_pool_balance(&env, &admin, 500);
+        // Set a cap of 500
+        Staking::set_max_reward_pool_balance(env.clone(), admin, 500);
 
-    // Simulate adding 300 rewards (should succeed)
-    env.storage().instance().set(&DataKey::RewardPoolBalance, &0i128);
-    let received = 300i128;
-    let current = env.storage().instance().get(&DataKey::RewardPoolBalance).unwrap_or(0);
-    let new_balance = current + received;
-    let max = env.storage().instance().get(&DataKey::ConfigMaxRewardPoolBalance).unwrap_or(0);
-    if max != 0 {
-        assert!(new_balance <= max, "exceeds max reward pool balance");
-    }
-    env.storage().instance().set(&DataKey::RewardPoolBalance, &new_balance);
-    let stored = env.storage().instance().get(&DataKey::RewardPoolBalance).unwrap();
-    assert_eq!(stored, 300);
-
-    // Attempt to add 250 (would exceed cap) – should panic
-    let result = std::panic::catch_unwind(|| {
-        let received = 250i128;
-        let current = env.storage().instance().get(&DataKey::RewardPoolBalance).unwrap_or(0);
+        // Simulate adding 300 rewards (should succeed)
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardPoolBalance, &0i128);
+        let received = 300i128;
+        let current = env
+            .storage()
+            .instance()
+            .get(&DataKey::RewardPoolBalance)
+            .unwrap_or(0);
         let new_balance = current + received;
-        let max = env.storage().instance().get(&DataKey::ConfigMaxRewardPoolBalance).unwrap_or(0);
+        let max = env
+            .storage()
+            .instance()
+            .get(&DataKey::ConfigMaxRewardPoolBalance)
+            .unwrap_or(0);
         if max != 0 {
             assert!(new_balance <= max, "exceeds max reward pool balance");
         }
-        env.storage().instance().set(&DataKey::RewardPoolBalance, &new_balance);
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardPoolBalance, &new_balance);
+        let stored: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RewardPoolBalance)
+            .unwrap();
+        assert_eq!(stored, 300);
+
+        // Attempt to add 250 (would exceed cap) – should panic
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let received = 250i128;
+            let current = env
+                .storage()
+                .instance()
+                .get(&DataKey::RewardPoolBalance)
+                .unwrap_or(0);
+            let new_balance = current + received;
+            let max = env
+                .storage()
+                .instance()
+                .get(&DataKey::ConfigMaxRewardPoolBalance)
+                .unwrap_or(0);
+            if max != 0 {
+                assert!(new_balance <= max, "exceeds max reward pool balance");
+            }
+            env.storage()
+                .instance()
+                .set(&DataKey::RewardPoolBalance, &new_balance);
+        }));
+        assert!(result.is_err());
     });
-    assert!(result.is_err());
 }


### PR DESCRIPTION
## Related Issue(s)
- Closes #564

## Summary of Changes
`contracts/staking/src/tests.rs` had two tests — `test_set_max_reward_pool_balance` and `test_add_rewards_respects_cap` — but they never actually ran. `lib.rs` only declared an inline `mod tests { ... }` block for unrelated tests, and nothing pointed at this file. Running `cargo test -p staking test_add_rewards_respects_cap` confirmed it: **"running 0 tests."** The reward pool cap logic had zero real coverage.

Once I wired the file in, it turned out to be broken on its own too:
- It called `Address::random(&env)`, which doesn't exist anymore in `soroban-sdk v21.7.7`
- It passed arguments to `Staking::initialize` by reference, but the function takes owned values
- It never registered a contract instance, entered a contract context, or mocked auths — all things every other test in this crate does

So this ended up being two bugs: the file wasn't compiled, and even if it had been, it wouldn't have worked.

**What I changed:**
- Added `#[cfg(test)] #[path = "tests.rs"] mod cap_tests;` in `lib.rs` so the file actually compiles and runs
- Swapped `Address::random` → `Address::generate`
- Added `env.register_contract`, `env.as_contract`, and `env.mock_all_auths()`
- Fixed `Staking::initialize` to take owned values instead of references

I didn't touch any assertions or cap values — just the plumbing needed to get these tests actually executing.

## Type of Change
- [x] Bug fix
- [x] Tests only

## Checklist
- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes
- [x] New behaviour is covered by tests
- [ ] If I changed a hot-path contract... (N/A — staking isn't in that list)
- [ ] Public interface changes are reflected in the README (N/A — no public interface changed)
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [x] Commit messages follow Conventional Commits format