### PR TITLE
fix(dex_aggregator): split ClPools storage into capped individual ent…

### DIFF
--- a/contracts/dex_aggregator/src/lib.rs
+++ b/contracts/dex_aggregator/src/lib.rs
@@ -94,7 +94,8 @@ pub struct RouteQuote {
 pub enum DataKey {
     Factory,
     MaxHops,
-    ClPools,
+    ClPoolCount,
+    ClPool(u32),
 }
 
 #[contract]
@@ -105,6 +106,7 @@ impl DexAggregator {
     pub const DEFAULT_MAX_HOPS: u32 = 4;
     pub const PRICE_TOLERANCE_BPS: i128 = 10;
     pub const BPS: i128 = 10_000;
+    pub const MAX_CL_POOLS: u32 = 50;
     pub const CL_FEE_TIERS: [i128; 3] = [30, 100, 500];
 
     pub fn initialize(env: Env, factory: Address) {
@@ -118,7 +120,7 @@ impl DexAggregator {
             .set(&DataKey::MaxHops, &Self::DEFAULT_MAX_HOPS);
         env.storage()
             .instance()
-            .set(&DataKey::ClPools, &Vec::<ClPoolInfo>::new(&env));
+            .set(&DataKey::ClPoolCount, &0u32);
     }
 
     pub fn register_cl_pool(
@@ -129,26 +131,40 @@ impl DexAggregator {
         fee_bps: i128,
     ) {
         Self::extend_ttl(&env);
-        let mut cl_pools: Vec<ClPoolInfo> = env
+        let count: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::ClPools)
-            .unwrap_or_else(|| Vec::new(&env));
+            .get(&DataKey::ClPoolCount)
+            .unwrap_or(0);
 
-        for i in 0..cl_pools.len() {
-            let entry = cl_pools.get(i).unwrap();
+        for i in 0..count {
+            let entry: ClPoolInfo = env
+                .storage()
+                .instance()
+                .get(&DataKey::ClPool(i))
+                .unwrap();
             if entry.pool == pool {
                 return;
             }
         }
 
-        cl_pools.push_back(ClPoolInfo {
-            pool: pool.clone(),
-            token_a: token_a.clone(),
-            token_b: token_b.clone(),
-            fee_bps,
-        });
-        env.storage().instance().set(&DataKey::ClPools, &cl_pools);
+        assert!(
+            count < Self::MAX_CL_POOLS,
+            "max CL pools reached"
+        );
+
+        env.storage().instance().set(
+            &DataKey::ClPool(count),
+            &ClPoolInfo {
+                pool: pool.clone(),
+                token_a: token_a.clone(),
+                token_b: token_b.clone(),
+                fee_bps,
+            },
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::ClPoolCount, &(count + 1));
     }
 
     /// Find the best route up to `max_hops` pools deep (#319).
@@ -405,9 +421,9 @@ impl DexAggregator {
             }
         }
 
-        let cl_pools = Self::registered_cl_pools(env);
-        for i in 0..cl_pools.len() {
-            let info = cl_pools.get(i).unwrap();
+        let cl_count: u32 = env.storage().instance().get(&DataKey::ClPoolCount).unwrap_or(0);
+        for i in 0..cl_count {
+            let info: ClPoolInfo = env.storage().instance().get(&DataKey::ClPool(i)).unwrap();
             if !(Self::is_cl_pool_match(&info, token_in, token_out)) {
                 continue;
             }
@@ -489,20 +505,13 @@ impl DexAggregator {
             Self::push_unique(&mut tokens, info.token_b);
         }
 
-        let cl_pools = Self::registered_cl_pools(env);
-        for i in 0..cl_pools.len() {
-            let info = cl_pools.get(i).unwrap();
+        let cl_count: u32 = env.storage().instance().get(&DataKey::ClPoolCount).unwrap_or(0);
+        for i in 0..cl_count {
+            let info: ClPoolInfo = env.storage().instance().get(&DataKey::ClPool(i)).unwrap();
             Self::push_unique(&mut tokens, info.token_a.clone());
             Self::push_unique(&mut tokens, info.token_b.clone());
         }
         tokens
-    }
-
-    fn registered_cl_pools(env: &Env) -> Vec<ClPoolInfo> {
-        env.storage()
-            .instance()
-            .get(&DataKey::ClPools)
-            .unwrap_or_else(|| Vec::new(env))
     }
 
     fn is_cl_pool_match(info: &ClPoolInfo, token_in: &Address, token_out: &Address) -> bool {


### PR DESCRIPTION
closes #580 
Done. Here's a summary of the changes to contracts/dex_aggregator/src/lib.rs:

Problem: register_cl_pool stored all CL pools as a single Vec under the ClPools key. Every write appended to and re-wrote the entire vector, and every quote_hop/discover_tokens call read the whole thing. No cap meant eventual ledger-entry size overflow → permanent brick.

Fix:
1. DataKey enum — Replaced ClPools with ClPoolCount (counter) + ClPool(u32) (individual indexed entries). Each pool is now its own storage entry, so writes are O(1) and no single entry can exceed the size limit.
2. MAX_CL_POOLS = 50 — Hard cap on registrations (line 109). A guard assertion in register_cl_pool prevents exceeding it (line 151-154).
3. register_cl_pool — Reads the count, scans existing entries for duplicates (reads each individually), asserts count < MAX, then writes the new pool at ClPool(count) and increments the counter.
4. quote_hop (line 424) and discover_tokens (line 508) — Inline the iteration over ClPool(0)..ClPool(count-1) instead of building an intermediate Vec via registered_cl_pools. Each reads and deserializes only what's needed.
5. Removed registered_cl_pools helper.

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
