### PR TITLE
fix: validate lp_token matches pool in create_campaign

### DIFF
--- a/contracts/incentive_campaigns/src/lib.rs
+++ b/contracts/incentive_campaigns/src/lib.rs
@@ -45,6 +45,7 @@ use soroban_sdk::{
 pub trait LpTokenInterface {
     fn balance(env: Env, id: Address) -> i128;
     fn total_supply(env: Env) -> i128;
+    fn admin(env: Env) -> Address;
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +210,9 @@ impl IncentiveCampaigns {
         assert!(end_time > start_time, "invalid campaign window");
         assert!(reward_rate > 0, "reward_rate must be positive");
         assert!(funding_amount > 0, "funding required");
+
+        let lp_admin = LpTokenClient::new(&env, &lp_token).admin();
+        assert!(lp_admin == pool, "lp_token does not match pool");
 
         let id: u64 = env
             .storage()


### PR DESCRIPTION
Closes #549 
This PR resolves a critical issue in incentive_campaigns::create_campaign where the contract would accept pool and lp_token as independent, unchecked parameters.

Previously, claim_rewards computed a provider's reward share strictly from LpTokenClient::balance and total_supply on campaign.lp_token—without ever using campaign.pool again. This allowed a misconfigured or malicious governance call to supply an lp_token that had nothing to do with the pool, silently paying out the campaign's reward budget based on an unrelated token's holder distribution without any on-chain validation.

Changes Made
Extend LpTokenInterface: We added the standard Soroban token interface admin(env: Env) -> Address; method to LpTokenInterface in contracts/incentive_campaigns/src/lib.rs.
On-chain Validation: We added a strict validation step in create_campaign to verify the relationship between the pool and its token before the campaign is initialized.
rust

let lp_admin = LpTokenClient::new(&env, &lp_token).admin();
assert!(lp_admin == pool, "lp_token does not match pool");
Since the AMM pool acts as the sole admin of its lp_token by design, this effectively guarantees the lp_token actually corresponds to the provided pool.
Testing
Tests fail to build locally on this specific Windows environment due to a missing GNU dlltool.exe binary in the rust toolchain (could not compile backtrace), however, the code logic successfully addresses the validation flaw using the standard token interface check.