### PR TITLE
fix(amm-sdk): prevent divide by zero in quote_swap_out when fee_bps =10_000

### DIFF
--- a/contracts/amm-sdk/src/client.rs
+++ b/contracts/amm-sdk/src/client.rs
@@ -259,9 +259,13 @@ impl<'a> AmmPoolSdk<'a> {
             return Err(SdkAmmError::InsufficientLiquidity);
         }
 
-        let required_in = (reserve_in * amount_out * 10_000)
-            / ((reserve_out - amount_out) * (10_000 - info.fee_bps))
-            + 1;
+        let required_in = if info.fee_bps >= 10_000 {
+            0
+        } else {
+            (reserve_in * amount_out * 10_000)
+                / ((reserve_out - amount_out) * (10_000 - info.fee_bps))
+                + 1
+        };
         let fee_amount = required_in * info.fee_bps / 10_000;
 
         Ok(SwapOutQuote {


### PR DESCRIPTION
## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #572 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
