### PR TITLE
fix(factory): use wider tick spacing for 500 bps CL pools

### DIFF
--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -13,6 +13,7 @@ testutils = ["soroban-sdk/testutils", "amm/testutils", "token/testutils", "conce
 [dependencies]
 soroban-sdk = { workspace = true }
 soroban-amm-sdk = { path = "../amm-sdk" }
+concentrated_liquidity = { path = "../concentrated_liquidity" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -46,6 +46,8 @@ pub trait ClPoolInterface {
         initial_tick: i32,
         tick_spacing: i32,
     );
+
+    fn get_pool_state(env: Env) -> concentrated_liquidity::PoolState;
 }
 
 #[contractclient(name = "AmmPoolClient")]
@@ -558,11 +560,15 @@ impl Factory {
             .with_current_contract(cl_salt)
             .deploy(cl_wasm);
 
-        // Derive tick_spacing from fee tier (matching Uniswap v3 conventions).
+        // Derive tick_spacing from fee tier using the same tiering as the
+        // dex_aggregator and the standard concentrated-liquidity fee tiers.
+        // The 500 bps tier is an actively routed fee tier and must not fall
+        // back to the near-zero-fee spacing.
         let tick_spacing: i32 = match fee_bps {
             5 => 1,
             30 => 10,
             100 => 60,
+            500 => 200,
             _ => 1,
         };
         ClPoolClient::new(&env, &pool_addr).initialize(
@@ -1684,6 +1690,33 @@ mod tests {
 
         // Missing tier returns None.
         assert_eq!(factory.get_cl_pool(&ta, &tb, &500_i128), None);
+    }
+
+    #[test]
+    fn test_create_cl_pool_500_bps_uses_wider_tick_spacing() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let amm_hash = env.deployer().upload_contract_wasm(amm::WASM);
+        let token_hash = env.deployer().upload_contract_wasm(token::WASM);
+        let cl_hash = env
+            .deployer()
+            .upload_contract_wasm(concentrated_liquidity::WASM);
+
+        let admin = Address::generate(&env);
+        let factory_addr = env.register_contract(None, Factory);
+        let factory = FactoryClient::new(&env, &factory_addr);
+        factory.initialize(&admin, &amm_hash, &token_hash);
+        factory.set_cl_wasm_hash(&cl_hash);
+
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        let pool_addr = factory.create_cl_pool(&admin, &ta, &tb, &500_i128, &0_i32);
+        let state = ClPoolClient::new(&env, &pool_addr).get_pool_state();
+
+        assert_eq!(state.tick_spacing, 200);
     }
 
     #[test]


### PR DESCRIPTION
# fix(factory): use wider tick spacing for 500 bps CL pools

The 500 bps concentrated-liquidity pool path now uses a wider tick spacing of 200 instead of falling back to 1, which aligns with the supported tiering used by the aggregator.

### What changed
- Updated lib.rs to map the 500 bps fee tier to tick spacing 200.
- Added a regression test in lib.rs to ensure a 500 bps CL pool initializes with the expected spacing.
- Updated Cargo.toml so the factory can query the CL pool state type during testing.

### Verification
- Ran: `cargo test -p factory`
- Result: 33 tests passed, 0 failed

Closes: #588