### PR TITLE
Fix orphaned AMM snapshot module

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -23,6 +23,9 @@ pub const WASM: &[u8] = include_bytes!(concat!(
 // Standard SEP-41 interface for pool tokens (token_a, token_b)
 use soroban_sdk::token::Client as SepTokenClient;
 
+mod snapshots;
+pub use snapshots::{Snapshot, MAX_SNAPSHOTS};
+
 /// Interface for the LP token contract.
 ///
 /// We define this locally rather than importing the `token` crate to avoid
@@ -182,6 +185,8 @@ pub enum DataKey {
     OracleAggregator,
     /// Max allowed spot-vs-oracle deviation in basis points (e.g. 500 = 5 %).
     MaxOracleDeviationBps,
+    /// Periodic pool snapshots captured by `snapshot_position`.
+    Snapshots,
 }
 
 // ── Pool info returned by `get_info` ─────────────────────────────────────────
@@ -2440,6 +2445,16 @@ impl AmmPool {
         (reserve_in * amount_out * 10_000) / ((reserve_out - amount_out) * (10_000 - fee_bps)) + 1
     }
 
+    /// Record a lightweight pool snapshot for diagnostics and off-chain monitoring.
+    pub fn snapshot_position(env: Env) {
+        snapshots::snapshot_position(&env);
+    }
+
+    /// Return the stored pool snapshots.
+    pub fn get_snapshots(env: Env) -> soroban_sdk::Vec<Snapshot> {
+        snapshots::get_snapshots(&env)
+    }
+
     /// Return full pool state.
     /// Return a snapshot of the full pool state.
     ///
@@ -2830,25 +2845,39 @@ impl AmmPool {
         (price_cum_a, price_cum_b, last_timestamp)
     }
 
-    fn get_reserve_a(env: Env) -> i128 {
+    pub(crate) fn get_reserve_a(env: Env) -> i128 {
         env.storage()
             .instance()
             .get(&DataKey::ReserveA)
             .unwrap_or(0)
     }
 
-    fn get_reserve_b(env: Env) -> i128 {
+    pub(crate) fn get_reserve_b(env: Env) -> i128 {
         env.storage()
             .instance()
             .get(&DataKey::ReserveB)
             .unwrap_or(0)
     }
 
-    fn get_total_shares(env: Env) -> i128 {
+    pub(crate) fn get_total_shares(env: Env) -> i128 {
         env.storage()
             .instance()
             .get(&DataKey::TotalShares)
             .unwrap_or(0)
+    }
+
+    pub(crate) fn get_accrued_fees_internal(env: Env) -> (i128, i128) {
+        let fee_a: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccruedFeeA)
+            .unwrap_or(0);
+        let fee_b: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccruedFeeB)
+            .unwrap_or(0);
+        (fee_a, fee_b)
     }
 
     fn get_flash_loan_fee_bps(env: Env) -> i128 {

--- a/contracts/amm/src/snapshots.rs
+++ b/contracts/amm/src/snapshots.rs
@@ -1,5 +1,6 @@
-use soroban_sdk::{Env, Symbol, Bytes, Address};
+use soroban_sdk::{contracttype, Env, Vec};
 
+#[contracttype]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Snapshot {
     pub ledger: u32,
@@ -19,10 +20,9 @@ pub fn snapshot_position(env: &Env) {
     let reserve_a = super::AmmPool::get_reserve_a(env.clone());
     let reserve_b = super::AmmPool::get_reserve_b(env.clone());
     let total_shares = super::AmmPool::get_total_shares(env.clone());
-    let accrued_a = env.storage().instance().get(&super::DataKey::AccruedFeeA).unwrap_or(0);
-    let accrued_b = env.storage().instance().get(&super::DataKey::AccruedFeeB).unwrap_or(0);
-    // simple price range: +/-10% around current price
-    let price = reserve_b * 1_000_000 / reserve_a; // scaled price
+    let (accrued_a, accrued_b) = super::AmmPool::get_accrued_fees_internal(env.clone());
+
+    let price = if reserve_a > 0 { reserve_b * 1_000_000 / reserve_a } else { 0 };
     let low = price * 9 / 10;
     let high = price * 11 / 10;
     let snap = Snapshot {
@@ -35,11 +35,18 @@ pub fn snapshot_position(env: &Env) {
         price_range_low: low,
         price_range_high: high,
     };
-    // store in a vector under a storage key
-    let mut snaps: Vec<Snapshot> = env.storage().instance().get(&super::DataKey::Snapshots).unwrap_or_else(|| Vec::new());
-    if snaps.len() >= MAX_SNAPSHOTS {
+
+    let mut snaps: Vec<Snapshot> = get_snapshots(env);
+    if snaps.len() >= MAX_SNAPSHOTS as u32 {
         snaps.remove(0);
     }
-    snaps.push(snap);
+    snaps.push_back(snap);
     env.storage().instance().set(&super::DataKey::Snapshots, &snaps);
+}
+
+pub fn get_snapshots(env: &Env) -> Vec<Snapshot> {
+    env.storage()
+        .instance()
+        .get(&super::DataKey::Snapshots)
+        .unwrap_or_else(|| Vec::new(env))
 }

--- a/contracts/amm/src/tests.rs
+++ b/contracts/amm/src/tests.rs
@@ -1081,6 +1081,34 @@ fn test_swap_emits_token_out_in_event_payload() {
 }
 
 #[test]
+fn test_snapshot_position_records_pool_state() {
+    let ts = setup_pool(30);
+    let env = &ts.env;
+    let amm = AmmPoolClient::new(env, &ts.amm_addr);
+    let ta_sac = StellarAssetClient::new(env, &ts.ta_addr);
+    let tb_sac = StellarAssetClient::new(env, &ts.tb_addr);
+
+    let provider = Address::generate(env);
+    ta_sac.mint(&provider, &1_000_000_i128);
+    tb_sac.mint(&provider, &1_000_000_i128);
+    AddLiquidity::new(&amm, &provider, 1_000_000, 1_000_000).execute();
+
+    let snapshots = amm.get_snapshots();
+    assert_eq!(snapshots.len(), 0);
+
+    amm.snapshot_position();
+
+    let snapshots = amm.get_snapshots();
+    assert_eq!(snapshots.len(), 1);
+    let snapshot = snapshots.get(0).unwrap();
+    assert_eq!(snapshot.reserve_a, 1_000_000);
+    assert_eq!(snapshot.reserve_b, 1_000_000);
+    assert_eq!(snapshot.total_shares, 1_000_000);
+    assert_eq!(snapshot.price_range_low, 900_000);
+    assert_eq!(snapshot.price_range_high, 1_100_000);
+}
+
+#[test]
 fn test_twap_oracle() {
     let ts = setup_pool(30);
     let env = &ts.env;


### PR DESCRIPTION
# Fix orphaned AMM snapshot module

## Summary

Fixes the orphaned AMM snapshot module that was never wired into the contract and referenced nonexistent storage types and private helpers.

## What changed

- Wired the snapshot module into the AMM contract so it is compiled and reachable.
- Added a dedicated `Snapshots` storage key for persistent snapshot history.
- Exposed `snapshot_position` and `get_snapshots` through the contract interface.
- Reworked snapshot capture to read the pool’s actual reserve/share/fee state safely.
- Added a regression test covering snapshot recording and returned values.

## Verification

- Ran `cargo test -p amm`
- Result: 73 tests passed, 0 failed

Closes: #577