### PR TITLE
fix(batch_auction): emit order_settled event on successful order settlement

### DIFF
--- a/contracts/batch_auction/src/lib.rs
+++ b/contracts/batch_auction/src/lib.rs
@@ -489,6 +489,10 @@ impl BatchAuction {
                         );
                     } else {
                         results.push_back(amount_out);
+                        env.events().publish(
+                            (Symbol::new(&env, "order_settled"), order.trader.clone()),
+                            (order_id, amount_out),
+                        );
                     }
                 }
                 Err(()) => {


### PR DESCRIPTION
Closes #552

## Summary
Fixes batch_auction settlement to emit a per-order success event when orders are successfully settled. Previously, only failure events and an aggregate settled count were published, preventing off-chain indexers from determining which specific orders settled or their output amounts.

## Changes
- Added `order_settled` event emission in `settle_batch` (contracts/batch_auction/src/lib.rs:492-495)
- Event published on successful order settlement with order_id and amount_out
- Event includes trader address and settlement amount for proper indexing

## Acceptance Criteria
- ✅ Per-order success event (order_settled) is emitted when order settles successfully
- ✅ Event contains order_id and amount_out for indexer tracking
- ✅ Event includes trader for proper event grouping
- ✅ All settlement outcomes now have corresponding events (success, failure, expiration, refund_failed)
- ✅ No breaking changes to existing event structure
- ✅ Build succeeds without errors

## Technical Details
- Emission point: Success branch after successful token transfer to trader (line 492)
- Event signature: `(Symbol::new(&env, "order_settled"), order.trader.clone()), (order_id, amount_out)`
- Complements existing events: order_failed, order_expired, order_cancelled, order_refund_failed

## Testing
The implementation has been verified to:
- Compile successfully with no warnings related to the changes
- Maintain existing contract functionality
- Follow the same event emission pattern as other settlement outcomes