### PR TITLE
fix(migration): validate V2/V3 token pair match in initialize and migrate

### DIFF
--- a/contracts/integration-tests/tests/v2_to_v3_migration.rs
+++ b/contracts/integration-tests/tests/v2_to_v3_migration.rs
@@ -77,6 +77,12 @@ impl MockV3Pool {
     pub fn get_current_tick(_env: Env) -> i32 {
         0_i32
     }
+
+    pub fn get_tokens(env: Env) -> (Address, Address) {
+        let token_a: Address = env.storage().instance().get(&0u32).unwrap();
+        let token_b: Address = env.storage().instance().get(&1u32).unwrap();
+        (token_a, token_b)
+    }
 }
 
 // ── Test fixture ──────────────────────────────────────────────────────────────
@@ -375,27 +381,12 @@ fn test_unauthorized_pool_pair_reverts() {
 
     let migration_addr = env.register_contract(None, MigrationContract);
     let migration = MigrationContractClient::new(&env, &migration_addr);
-    migration.initialize(&admin, &v2_addr, &v3_bad_addr);
 
-    let shares = LpTokenClient::new(&env, &v2_lp_addr).balance(&lp);
-
-    // The mock will try to pull token_c (which the migration never received)
-    // causing the transfer to fail
-    let result = migration.try_migrate(
-        &lp,
-        &shares,
-        &0_i128,
-        &0_i128,
-        &i32::MIN,
-        &i32::MAX,
-        &500_i32,
-        &0_i128,
-        &DEADLINE,
-    );
-
+    // initialize must reject a V3 pool trading a different pair
+    let init_result = migration.try_initialize(&admin, &v2_addr, &v3_bad_addr);
     assert!(
-        result.is_err(),
-        "migration with wrong V3 pool token pair should fail"
+        matches!(init_result, Err(Ok(MigrationError::TokenMismatch))),
+        "initialize with mismatched token pairs should return TokenMismatch"
     );
 }
 

--- a/contracts/v2_to_v3_migration/src/lib.rs
+++ b/contracts/v2_to_v3_migration/src/lib.rs
@@ -31,6 +31,7 @@ pub enum MigrationError {
     InvalidRange = 5,
     SlippageExceeded = 6,
     MigrationFailed = 7,
+    TokenMismatch = 8,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -94,6 +95,9 @@ pub trait V3PoolInterface {
     ) -> Result<i128, soroban_sdk::Error>;
 
     fn get_current_tick(env: Env) -> i32;
+
+    /// Returns the V3 pool's token pair (token_a, token_b).
+    fn get_tokens(env: Env) -> (Address, Address);
 }
 
 // ── Migration result ──────────────────────────────────────────────────────────
@@ -142,6 +146,18 @@ impl MigrationContract {
             return Err(MigrationError::AlreadyInitialized);
         }
         admin.require_auth();
+
+        // Verify V2 and V3 pools trade the same token pair.
+        let v2_client = V2PoolClient::new(&env, &v2_pool);
+        let v2_info = v2_client.get_info();
+        let v3_client = V3PoolClient::new(&env, &v3_pool);
+        let (v3_token_a, v3_token_b) = v3_client.get_tokens();
+        if !((v2_info.token_a == v3_token_a && v2_info.token_b == v3_token_b)
+            || (v2_info.token_a == v3_token_b && v2_info.token_b == v3_token_a))
+        {
+            return Err(MigrationError::TokenMismatch);
+        }
+
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::V2Pool, &v2_pool);
         env.storage().instance().set(&DataKey::V3Pool, &v3_pool);
@@ -194,18 +210,25 @@ impl MigrationContract {
         let v2_pool: Address = env.storage().instance().get(&DataKey::V2Pool).unwrap();
         let v3_pool: Address = env.storage().instance().get(&DataKey::V3Pool).unwrap();
 
-        // ── Step 1: withdraw from V2 ─────────────────────────────────────────
+        // ── Step 0: verify V2 and V3 pools trade the same pair ──────────────
         let v2_client = V2PoolClient::new(&env, &v2_pool);
         let pool_info = v2_client.get_info();
         let token_a = pool_info.token_a.clone();
         let token_b = pool_info.token_b.clone();
 
-        // Remove liquidity from V2; tokens land in provider's wallet.
+        let v3_client = V3PoolClient::new(&env, &v3_pool);
+        let (v3_token_a, v3_token_b) = v3_client.get_tokens();
+        if !((token_a == v3_token_a && token_b == v3_token_b)
+            || (token_a == v3_token_b && token_b == v3_token_a))
+        {
+            return Err(MigrationError::TokenMismatch);
+        }
+
+        // ── Step 1: withdraw from V2 ─────────────────────────────────────────
         let (received_a, received_b) =
             v2_client.remove_liquidity(&provider, &v2_shares, &min_a, &min_b, &deadline);
 
         // ── Step 2: compute optimal V3 tick range ────────────────────────────
-        let v3_client = V3PoolClient::new(&env, &v3_pool);
         let (final_tick_lower, final_tick_upper) =
             Self::compute_range(&env, &v3_client, tick_lower, tick_upper, range_width_ticks)?;
 


### PR DESCRIPTION
## Description

`MigrationContract::migrate` reads `token_a`/`token_b` from the V2 pool via `get_info` and deposits them into the configured V3 pool without ever checking that the V3 pool actually trades that same pair. If the migration contract is initialized (or upgraded) with a mismatched V2/V3 pair, `add_liquidity_range` receives the wrong tokens — the deposit either reverts deep in the V3 contract or, worse, the dust-refund accounting silently misattributes balances.

## Fix

1. **Expose `get_tokens()` on `V3PoolInterface`** — mirrors the V3 pool's existing `ConcentratedLiquidity::get_tokens` query (added in issue #470).

2. **Assert token pair match in `initialize()`** — reads the V2 pair via `get_info` and the V3 pair via `get_tokens`, returning a new `TokenMismatch` error if they differ (in either order).

3. **Belt-and-suspenders guard in `migrate()`** — repeats the same assertion at the top of `migrate` so that even if the contract was incorrectly upgraded after initialization, the misconfiguration is caught before any tokens move.

4. **Updates integration tests** — adds `get_tokens` to `MockV3Pool` and rewrites the "unauthorized pool pair" test to expect `TokenMismatch` from `try_initialize`, rather than relying on a downstream failure during `migrate`.

## Impact

- **Fail fast, fail loud** — mismatched pool pairs are caught during contract setup rather than causing subtle ledger corruption later.
- **Order-independent comparison** — the check tolerates `(a, b)` vs `(b, a)` ordering between the V2 and V3 pools.
- **Low overhead** — two additional read-only cross-contract calls that execute before any token transfers.

Closes #429