### PR TITLE
fix(amm): enforce strict > inequality in update_fee to match set_protocol_fee invariant

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -1152,7 +1152,12 @@ impl AmmPool {
             .instance()
             .get(&DataKey::ProtocolFeeBps)
             .unwrap_or(0);
-        if new_fee_bps < protocol_fee_bps {
+        // Must mirror set_protocol_fee's invariant: when protocol fees are
+        // active (protocol_fee_bps > 0), fee_bps must be *strictly* greater
+        // than protocol_fee_bps so LPs always retain a portion of swap income.
+        // Allowing fee_bps == protocol_fee_bps would route 100% of swap fees to
+        // the protocol, leaving LPs with nothing.
+        if protocol_fee_bps > 0 && new_fee_bps <= protocol_fee_bps {
             return Err(AmmError::InvalidFeeBps);
         }
         env.storage().instance().set(&DataKey::FeeBps, &new_fee_bps);

--- a/contracts/amm/src/tests.rs
+++ b/contracts/amm/src/tests.rs
@@ -480,6 +480,75 @@ fn test_set_protocol_fee_rejects_full_capture() {
     );
 }
 
+/// update_fee must reject values equal to or below protocol_fee_bps,
+/// matching set_protocol_fee's strict-less-than invariant.
+#[test]
+fn test_update_fee_rejects_equal_or_below_protocol_fee() {
+    let (env, admin, amm_addr, lp_addr, _) = setup();
+    let (ta, _) = create_sac(&env, &admin);
+    let (tb, _) = create_sac(&env, &admin);
+    let fee_recipient = Address::generate(&env);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    // fee_bps = 30, protocol_fee = 10
+    amm.initialize(
+        &admin,
+        &ta.address,
+        &tb.address,
+        &lp_addr,
+        &30_i128,
+        &fee_recipient,
+        &10_i128,
+    );
+
+    // Values above protocol_fee_bps (10) are valid.
+    let ok = amm.try_update_fee(&11_i128);
+    assert!(ok.is_ok(), "fee_bps > protocol_fee_bps must be accepted");
+    assert_eq!(amm.get_fee_bps(), 11);
+
+    // Re-set to 30 for the next checks.
+    amm.update_fee(&30_i128);
+
+    // Equal to protocol_fee_bps (10) must be rejected (the bug fix).
+    let result = amm.try_update_fee(&10_i128);
+    assert!(
+        result.is_err(),
+        "fee_bps == protocol_fee_bps must be rejected"
+    );
+
+    // Below protocol_fee_bps must be rejected.
+    let result2 = amm.try_update_fee(&9_i128);
+    assert!(
+        result2.is_err(),
+        "fee_bps < protocol_fee_bps must be rejected"
+    );
+}
+
+/// When protocol_fee is 0 (disabled), update_fee with any valid fee succeeds.
+#[test]
+fn test_update_fee_works_with_zero_protocol_fee() {
+    let (env, admin, amm_addr, lp_addr, _) = setup();
+    let (ta, _) = create_sac(&env, &admin);
+    let (tb, _) = create_sac(&env, &admin);
+    let fee_recipient = Address::generate(&env);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    // fee_bps = 30, protocol_fee = 0 (disabled)
+    amm.initialize(
+        &admin,
+        &ta.address,
+        &tb.address,
+        &lp_addr,
+        &30_i128,
+        &fee_recipient,
+        &0_i128,
+    );
+
+    // Both zero is valid.
+    assert!(amm.try_update_fee(&0_i128).is_ok(), "fee_bps=0 with protocol_fee=0 must be accepted");
+
+    // Setting fee to any valid value when protocol is disabled is fine.
+    assert!(amm.try_update_fee(&50_i128).is_ok(), "fee_bps=50 with protocol_fee=0 must be accepted");
+}
+
 #[test]
 fn test_add_and_swap() {
     let ts = setup_pool(30);


### PR DESCRIPTION
## Problem Being Solved

### Issue #506: `update_fee` lets `fee_bps` drop to exactly `protocol_fee_bps`

`set_protocol_fee` explicitly enforces, with an inline comment documenting the invariant, that `protocol_fee_bps` must be **strictly less than** `fee_bps`:

```rust
// Fix M-02: protocol_fee_bps must be *strictly* less than fee_bps so LPs
// always retain a portion of swap income. Allowing protocol_fee_bps == fee_bps
// would route 100% of swap fees to the protocol, leaving LPs with nothing.
```

But `update_fee` — the other function that can move `fee_bps` relative to the stored `protocol_fee_bps` — only rejects a value *strictly lower* than the protocol fee, allowing equality:

```rust
if new_fee_bps < protocol_fee_bps {          // should be `<=`
    return Err(AmmError::InvalidFeeBps);
}
```

Example: pool starts with `fee_bps = 100`, `protocol_fee_bps = 50` (valid). Admin calls `update_fee(50)`. The check `50 < 50` is false, so it succeeds, setting `fee_bps = 50 == protocol_fee_bps` — exactly the "100% of swap fees to the protocol, nothing for LPs" state `set_protocol_fee` was fixed to forbid, reached via a second code path with a weaker invariant.

## Implemented Solution

Changed `update_fee`'s fee validation to mirror `set_protocol_fee`'s strict inequality: when `protocol_fee_bps > 0`, `new_fee_bps` must be **strictly greater** than `protocol_fee_bps`. When protocol fees are disabled (`protocol_fee_bps == 0`), any valid fee is accepted (matching `set_protocol_fee`'s symmetric logic for the zero-fee disabled state).

## Files and Components Changed

- `contracts/amm/src/lib.rs`: Changed `update_fee` validation from `new_fee_bps < protocol_fee_bps` to `protocol_fee_bps > 0 && new_fee_bps <= protocol_fee_bps` (line 1155).
- `contracts/amm/src/tests.rs`: Added two new test functions.

## Tests Added or Updated

- `test_update_fee_rejects_equal_or_below_protocol_fee`: Verifies that `update_fee` with `new_fee_bps == protocol_fee_bps` (the bug) and `new_fee_bps < protocol_fee_bps` are both rejected; values strictly above are accepted.
- `test_update_fee_works_with_zero_protocol_fee`: Verifies that when `protocol_fee_bps == 0` (fees disabled), setting `fee_bps` to 0 or any positive value succeeds.

## Validation Steps Performed

1. Both entry points (`set_protocol_fee` and `update_fee`) now enforce the identical strict inequality invariant.
2. Existing `test_set_protocol_fee_rejects_full_capture` test continues to validate the `set_protocol_fee` side.
3. New tests cover all boundary cases for `update_fee`.

## Technical Decisions Made

- The fix uses the guard `protocol_fee_bps > 0` so that the zero-fee disabled state (`protocol_fee_bps == 0`) permits any `fee_bps >= 0` (already validated by `validate_fee_bps`). This exactly mirrors `set_protocol_fee`'s special case for `fee_bps == 0`.
- No structural changes to the fee model — only tightening the validation to match the existing documented invariant.

Closes #506
