### PR TITLE
fix(amm): add MINIMUM_LIQUIDITY lock to add_liquidity_fot for first deposit

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -2783,7 +2783,25 @@ impl AmmPool {
         if shares <= 0 {
             return Err(AmmError::ZeroAmount);
         }
-        if shares < min_shares {
+
+        // Issue #294: on the very first deposit, permanently lock MINIMUM_LIQUIDITY
+        // LP tokens to the contract address so the pool can never be fully drained.
+        const MINIMUM_LIQUIDITY: i128 = 1_000;
+        let already_locked: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinLiquidityLocked)
+            .unwrap_or(false);
+        let (shares_to_provider, shares_locked) = if total_shares == 0 && !already_locked {
+            if shares <= MINIMUM_LIQUIDITY {
+                return Err(AmmError::InsufficientShares);
+            }
+            (shares - MINIMUM_LIQUIDITY, MINIMUM_LIQUIDITY)
+        } else {
+            (shares, 0)
+        };
+
+        if shares_to_provider < min_shares {
             return Err(AmmError::SlippageExceeded);
         }
 
@@ -2795,17 +2813,27 @@ impl AmmPool {
             .set(&DataKey::ReserveB, &(reserve_b + actual_b));
         env.storage()
             .instance()
-            .set(&DataKey::TotalShares, &(total_shares + shares));
+            .set(
+                &DataKey::TotalShares,
+                &(total_shares + shares_to_provider + shares_locked),
+            );
 
-        LpTokenClient::new(&env, &lp_token).mint(&provider, &shares);
+        let lp_client = LpTokenClient::new(&env, &lp_token);
+        if shares_locked > 0 {
+            lp_client.mint(&env.current_contract_address(), &shares_locked);
+            env.storage()
+                .instance()
+                .set(&DataKey::MinLiquidityLocked, &true);
+        }
+        lp_client.mint(&provider, &shares_to_provider);
 
         soroban_amm_sdk::emit_versioned_event!(
             env,
             (Symbol::new(&env, "add_liquidity"), provider),
-            (actual_a, actual_b, shares)
+            (actual_a, actual_b, shares_to_provider)
         );
 
-        Ok(shares)
+        Ok(shares_to_provider)
     }
 
     // ── Internals ─────────────────────────────────────────────────────────────

--- a/contracts/amm/src/tests.rs
+++ b/contracts/amm/src/tests.rs
@@ -1686,3 +1686,170 @@ fn bench_add_liquidity_cost() {
     std::println!("=== ADD_LIQ BUDGET ===");
     std::println!("{}", env.budget());
 }
+
+// ── add_liquidity_fot minimum-liquidity lock ─────────────────────────────────
+
+/// First deposit via add_liquidity_fot must lock MINIMUM_LIQUIDITY shares
+/// to the contract, matching add_liquidity's behavior (Issue #294).
+#[test]
+fn test_fot_first_deposit_locks_minimum_liquidity() {
+    let (env, admin, amm_addr, lp_addr, _) = setup();
+    let (ta, _) = create_sac(&env, &admin);
+    let (tb, _) = create_sac(&env, &admin);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    amm.initialize(
+        &admin,
+        &ta.address,
+        &tb.address,
+        &lp_addr,
+        &30_i128,
+        &admin,
+        &0_i128,
+    );
+
+    let provider = Address::generate(&env);
+    let ta_sac = StellarAssetClient::new(&env, &ta.address);
+    let tb_sac = StellarAssetClient::new(&env, &tb.address);
+    ta_sac.mint(&provider, &2_000_000);
+    tb_sac.mint(&provider, &2_000_000);
+
+    // First FOT deposit: amount_a=2_000_000, amount_b=2_000_000.
+    // sqrt(2_000_000 * 2_000_000) = 2_000_000 shares.
+    // After MINIMUM_LIQUIDITY lock, provider gets 2_000_000 - 1_000 = 1_999_000.
+    let shares = amm
+        .try_add_liquidity_fot(
+            &provider,
+            &2_000_000,
+            &2_000_000,
+            &0,
+            &0,
+            &0,
+            &u64::MAX,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(shares, 1_999_000);
+
+    let info = amm.get_info();
+    // Total shares = provider shares + locked 1_000.
+    assert_eq!(info.total_shares, 2_000_000);
+    // Locked 1_000 are held by the contract.
+    let lp_client = token::LpTokenClient::new(&env, &lp_addr);
+    assert_eq!(lp_client.balance(&amm_addr), 1_000);
+    assert_eq!(lp_client.balance(&provider), 1_999_000);
+}
+
+/// First deposit where shares <= MINIMUM_LIQUIDITY must be rejected.
+#[test]
+fn test_fot_first_deposit_rejects_insufficient_shares() {
+    let (env, admin, amm_addr, lp_addr, _) = setup();
+    let (ta, _) = create_sac(&env, &admin);
+    let (tb, _) = create_sac(&env, &admin);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    amm.initialize(
+        &admin,
+        &ta.address,
+        &tb.address,
+        &lp_addr,
+        &30_i128,
+        &admin,
+        &0_i128,
+    );
+
+    let provider = Address::generate(&env);
+    let ta_sac = StellarAssetClient::new(&env, &ta.address);
+    let tb_sac = StellarAssetClient::new(&env, &tb.address);
+    // sqrt(1_000 * 1_000) = 1_000 shares → equal to MINIMUM_LIQUIDITY → rejected.
+    ta_sac.mint(&provider, &1_000);
+    tb_sac.mint(&provider, &1_000);
+    let result = amm.try_add_liquidity_fot(
+        &provider,
+        &1_000,
+        &1_000,
+        &0,
+        &0,
+        &0,
+        &u64::MAX,
+    );
+    assert_eq!(result, Err(Ok(AmmError::InsufficientShares)));
+
+    // Even smaller: sqrt(500 * 500) = 500 → rejected.
+    let provider2 = Address::generate(&env);
+    ta_sac.mint(&provider2, &500);
+    tb_sac.mint(&provider2, &500);
+    let result2 = amm.try_add_liquidity_fot(
+        &provider2,
+        &500,
+        &500,
+        &0,
+        &0,
+        &0,
+        &u64::MAX,
+    );
+    assert_eq!(result2, Err(Ok(AmmError::InsufficientShares)));
+}
+
+/// Subsequent deposits via add_liquidity_fot must not lock additional liquidity.
+#[test]
+fn test_fot_subsequent_deposit_no_extra_lock() {
+    let (env, admin, amm_addr, lp_addr, _) = setup();
+    let (ta, _) = create_sac(&env, &admin);
+    let (tb, _) = create_sac(&env, &admin);
+    let amm = AmmPoolClient::new(&env, &amm_addr);
+    amm.initialize(
+        &admin,
+        &ta.address,
+        &tb.address,
+        &lp_addr,
+        &30_i128,
+        &admin,
+        &0_i128,
+    );
+
+    let provider = Address::generate(&env);
+    let ta_sac = StellarAssetClient::new(&env, &ta.address);
+    let tb_sac = StellarAssetClient::new(&env, &tb.address);
+    ta_sac.mint(&provider, &2_000_000);
+    tb_sac.mint(&provider, &2_000_000);
+
+    // First deposit locks MINIMUM_LIQUIDITY.
+    let shares1 = amm
+        .try_add_liquidity_fot(
+            &provider,
+            &2_000_000,
+            &2_000_000,
+            &0,
+            &0,
+            &0,
+            &u64::MAX,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(shares1, 1_999_000);
+
+    // Second deposit: proportional, no additional lock.
+    ta_sac.mint(&provider, &1_000_000);
+    tb_sac.mint(&provider, &1_000_000);
+    let shares2 = amm
+        .try_add_liquidity_fot(
+            &provider,
+            &1_000_000,
+            &1_000_000,
+            &0,
+            &0,
+            &0,
+            &u64::MAX,
+        )
+        .unwrap()
+        .unwrap();
+
+    let info = amm.get_info();
+    let lp_client = token::LpTokenClient::new(&env, &lp_addr);
+
+    // Contract still holds exactly 1_000 locked shares.
+    assert_eq!(lp_client.balance(&amm_addr), 1_000);
+    // Provider's total balance = 1_999_000 + second deposit shares.
+    assert_eq!(lp_client.balance(&provider), shares1 + shares2);
+    // Total shares = provider total + 1_000 lock.
+    assert_eq!(info.total_shares, shares1 + shares2 + 1_000);
+}


### PR DESCRIPTION
## Problem Being Solved

### Issue #503: `add_liquidity_fot` omits the `MINIMUM_LIQUIDITY` lock, reopening the drain-to-zero vector for FOT-token pools

`add_liquidity` implements the Issue #294 invariant: on a pool's very first deposit (`total_shares == 0`), it permanently locks `MINIMUM_LIQUIDITY = 1_000` LP shares to the contract so `total_shares` can never return to zero and the pool can never be fully drained by a single LP burning all shares.

`add_liquidity_fot` computes `shares` the same way for `total_shares == 0` (`sqrt(actual_a * actual_b)`) but mints the **entire** amount to `provider`, with no `MinLiquidityLocked` check and no minimum-liquidity carve-out at all. If a pool's very first liquidity deposit goes through the FOT-aware entry point — exactly what should happen whenever either token is fee-on-transfer — the "pool can never be fully drained" invariant from #294 is never established for that pool, reopening the drain-to-zero / first-depositor share-manipulation vector #294 was written to close.

## Implemented Solution

Mirrored `add_liquidity`'s `MINIMUM_LIQUIDITY` lock (and `MinLiquidityLocked` flag) in `add_liquidity_fot`'s `total_shares == 0` branch:

1. After computing `shares`, check if `total_shares == 0 && !already_locked`
2. If `shares <= MINIMUM_LIQUIDITY`, return `AmmError::InsufficientShares`
3. Split shares: mint `shares - MINIMUM_LIQUIDITY` to provider, lock `MINIMUM_LIQUIDITY` to the contract address
4. Set the `MinLiquidityLocked` storage flag so subsequent deposits skip the lock
5. Update `TotalShares` to reflect the full amount (`shares_to_provider + shares_locked`)

## Files and Components Changed

- `contracts/amm/src/lib.rs`: Added minimum-liquidity lock logic to `add_liquidity_fot` (lines 2787-2827), mirroring the exact same pattern used in `add_liquidity` (lines 1454-1501).
- `contracts/amm/src/tests.rs`: Added three new test functions covering the lock behavior.

## Tests Added or Updated

- `test_fot_first_deposit_locks_minimum_liquidity`: Verifies that the first deposit via `add_liquidity_fot` locks 1_000 shares to the contract and returns `shares - 1_000` to the provider.
- `test_fot_first_deposit_rejects_insufficient_shares`: Verifies that deposits with `shares <= 1_000` are rejected with `InsufficientShares`.
- `test_fot_subsequent_deposit_no_extra_lock`: Verifies that after the first deposit, subsequent `add_liquidity_fot` calls do not lock additional liquidity.

## Validation Steps Performed

1. The fix exactly mirrors `add_liquidity`'s MINIMUM_LIQUIDITY logic, which has been verified and deployed.
2. All three new tests cover the critical edge cases (first deposit lock, insufficient shares rejection, subsequent deposit no extra lock).
3. Existing `add_liquidity` minimum-liquidity tests continue to pass.
4. Both code paths (`add_liquidity` and `add_liquidity_fot`) now enforce the identical invariant.

## Technical Decisions Made

- Used the same `MINIMUM_LIQUIDITY = 1_000` constant and `DataKey::MinLiquidityLocked` flag shared with `add_liquidity`, so the lock state is consistent regardless of which entry point processes the first deposit.
- Locked shares are minted to `env.current_contract_address()` (the pool contract itself), matching `add_liquidity`'s approach.
- The `min_shares` slippage check now applies to `shares_to_provider` rather than the raw `shares`, consistent with `add_liquidity`'s behavior.

Closes #503
