### PR TITLE
fix(token): enforce locked balance in burn to preserve vote-lock invariant

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -227,9 +227,11 @@ impl LpToken {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         let bal = Self::balance(env.clone(), from.clone());
+        let locked = Self::locked_balance(env.clone(), from.clone());
         assert!(
-            bal >= amount,
-            "insufficient balance: available={bal}, requested={amount}"
+            bal - locked >= amount,
+            "insufficient unlocked balance: available={}, requested={amount}",
+            bal - locked
         );
         env.storage()
             .persistent()
@@ -628,5 +630,32 @@ mod tests {
         client.transfer(&alice, &bob, &700_i128);
         assert_eq!(client.balance(&alice), 0);
         assert_eq!(client.balance(&bob), 1_000);
+    }
+
+    #[test]
+    fn test_burn_blocked_by_lock() {
+        let ts = setup();
+        let client = LpTokenClient::new(&ts.env, &ts.contract_addr);
+        let alice = Address::generate(&ts.env);
+        let locker = Address::generate(&ts.env);
+
+        client.set_locker(&locker);
+        client.mint(&alice, &1_000_i128);
+        client.lock(&alice, &700_i128);
+        assert_eq!(client.locked_balance(&alice), 700);
+
+        // Burning more than the unlocked (300) portion must fail, even though
+        // the gross balance (1000) would otherwise cover it.
+        assert!(client.try_burn(&alice, &400_i128).is_err());
+        assert_eq!(client.balance(&alice), 1_000);
+
+        // Burning up to the unlocked amount still works.
+        client.burn(&alice, &300_i128);
+        assert_eq!(client.balance(&alice), 700);
+        assert_eq!(client.locked_balance(&alice), 700);
+
+        client.unlock(&alice, &700_i128);
+        client.burn(&alice, &700_i128);
+        assert_eq!(client.balance(&alice), 0);
     }
 }


### PR DESCRIPTION
## Summary

`token::burn` only checked the gross balance before destroying tokens, ignoring any amount held in `Locked`. `_transfer` already guards against moving locked balance (`from_bal - locked >= amount`), but `burn` did not apply the same check.

Because the AMM contract is the LP token's admin and calls `lp_client.burn(&provider, &shares)` from both `remove_liquidity` and `remove_liquidity_one_sided`, a liquidity provider whose LP shares were locked by governance (via `lock`, e.g. while an active vote is open) could still call `remove_liquidity` and burn the locked shares, receiving the underlying `token_a`/`token_b` payout. This fully bypasses the governance vote-lock and, since burning locked LP does not decrement `Locked`, leaves `locked_balance > balance` afterward — breaking the `locked <= balance` invariant that `_transfer`'s underflow guard depends on, and permanently blocking future transfers for that account.

## Fix

`burn` now computes `bal - locked` and asserts the requested amount does not exceed the unlocked portion, exactly mirroring the check already used in `_transfer`. Burning more than the unlocked balance now fails with `insufficient unlocked balance`, closing the vote-lock bypass and preserving the `locked <= balance` invariant.

## Changes

- `contracts/token/src/lib.rs`: `burn` now checks `bal - locked >= amount` instead of `bal >= amount`.
- Added `test_burn_blocked_by_lock`, which locks part of a balance, verifies burning the locked portion fails via `try_burn`, and verifies burning the remaining unlocked portion (and burning after `unlock`) still succeeds.

## Test plan

- [x] `cargo build -p token --target wasm32v1-none --release` succeeds
- [x] Added regression test `test_burn_blocked_by_lock` exercising the exact scenario in the issue
- [ ] `cargo test -p token` (blocked in this environment by an unrelated Windows/mingw linker limitation — `export ordinal too large` — reproducible on unmodified `main` as well; not caused by this change. CI on Linux should run the full test suite normally.)

closes #471