### PR TITLE
fix(amm-sdk): correct simulate_swap return type to SwapSimulation

### DIFF
--- a/contracts/amm-sdk/src/client.rs
+++ b/contracts/amm-sdk/src/client.rs
@@ -7,7 +7,7 @@
 
 use soroban_sdk::{contractclient, Address, Bytes, BytesN, Env};
 
-use crate::types::{LiquidityQuote, PoolInfo, SdkAmmError, SwapInQuote, SwapOutQuote};
+use crate::types::{LiquidityQuote, PoolInfo, SdkAmmError, SwapInQuote, SwapOutQuote, SwapSimulation};
 
 // ── Re-export the auto-generated contract client ──────────────────────────────
 
@@ -84,7 +84,7 @@ pub trait AmmPoolInterface {
         env: Env,
         token_in: Address,
         amount_in: i128,
-    ) -> Result<crate::types::PoolInfo, SdkAmmError>;
+    ) -> Result<SwapSimulation, SdkAmmError>;
     fn price_ratio(env: Env) -> Result<(i128, i128), SdkAmmError>;
     fn get_info(env: Env) -> PoolInfo;
     fn get_accrued_fees(env: Env) -> (i128, i128);

--- a/contracts/amm-sdk/src/types.rs
+++ b/contracts/amm-sdk/src/types.rs
@@ -86,7 +86,36 @@ pub struct SdkPoolInfo {
 /// change their code.
 pub type PoolInfo = SdkPoolInfo;
 
+// ── Swap simulation ───────────────────────────────────────────────────────────
+
+/// Detailed breakdown of a hypothetical swap, mirroring the on-chain
+/// `SwapSimulation` struct returned by `AmmPool::simulate_swap`.
+///
+/// Named `SdkSwapSimulation` (with a `SwapSimulation` alias below) for the
+/// same reason as `SdkPoolInfo`: avoiding a duplicate-type collision in the
+/// WASM spec when the AMM contract is compiled with this SDK crate as a
+/// dependency.
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SdkSwapSimulation {
+    /// Expected output amount after fees.
+    pub amount_out: i128,
+    /// Fee charged on the input (in input-token units).
+    pub fee_amount: i128,
+    /// Price impact in basis points — how far the execution price is from spot.
+    pub price_impact_bps: i128,
+    /// Effective execution price × 1 000 000 (amount_out / amount_in).
+    pub effective_price: i128,
+    /// Spot price of `token_out` in terms of `token_in` × 1 000 000.
+    pub spot_price: i128,
+}
+
+/// Backward-compatible type alias so existing SDK consumers do not need to
+/// change their code.
+pub type SwapSimulation = SdkSwapSimulation;
+
 // ── Quote types ───────────────────────────────────────────────────────────────
+
 
 /// Result of a `quote_swap_in` call — how much you receive for a known input.
 #[contracttype]


### PR DESCRIPTION
AmmPoolInterface::simulate_swap declared Result<PoolInfo, SdkAmmError>,
but the deployed amm contract's simulate_swap returns SwapSimulation
(amount_out, fee_amount, price_impact_bps, effective_price, spot_price)
— a structurally unrelated 5-field type, not the 10-field pool snapshot.
Any AmmPoolClient caller invoking simulate_swap would fail to decode
the on-chain XDR result against the wrong declared shape.

Add SdkSwapSimulation to amm-sdk::types, mirroring the on-chain
SwapSimulation field-for-field (same names, order, and i128 types),
with a SwapSimulation alias following the existing SdkPoolInfo/PoolInfo
convention used to avoid duplicate-type collisions in the WASM spec.
Update the trait declaration to return
Result<SwapSimulation, SdkAmmError>.

No other call sites depend on simulate_swap's SDK-side return type,
so this is an isolated, non-breaking fix.

Closes #505