### PR TITLE
fix: correct sqrt_price_limit_x96 for CL pool hops in dex_aggregator

### DIFF
--- a/contracts/dex_aggregator/src/lib.rs
+++ b/contracts/dex_aggregator/src/lib.rs
@@ -104,6 +104,9 @@ impl DexAggregator {
     pub const BPS: i128 = 10_000;
     pub const CL_FEE_TIERS: [i128; 3] = [30, 100, 500];
 
+    pub const MIN_SQRT_PRICE: u128 = 4_295_128_739_u128;
+    pub const MAX_SQRT_PRICE: u128 = 340_275_971_719_517_849_884_931_781_110_561_029_923_u128;
+
     pub fn initialize(env: Env, factory: Address) {
         assert!(
             !env.storage().instance().has(&DataKey::Factory),
@@ -350,14 +353,21 @@ impl DexAggregator {
                     &hop_min,
                     &deadline,
                 ),
-                PoolKind::Cl => ClPoolClient::new(env, &hop.pool).swap(
-                    trader,
-                    &hop.zero_for_one,
-                    &current,
-                    &0u128,
-                    &hop_min,
-                    &deadline,
-                ),
+                PoolKind::Cl => {
+                    let limit = if hop.zero_for_one {
+                        Self::MIN_SQRT_PRICE + 1
+                    } else {
+                        Self::MAX_SQRT_PRICE - 1
+                    };
+                    ClPoolClient::new(env, &hop.pool).swap(
+                        trader,
+                        &hop.zero_for_one,
+                        &current,
+                        &limit,
+                        &hop_min,
+                        &deadline,
+                    )
+                }
             };
         }
         Ok(current)
@@ -458,7 +468,12 @@ impl DexAggregator {
         let mut best: i128 = 0;
         let mut zfo = true;
         for direction in [true, false] {
-            let est = client.estimate_price_impact(&direction, &amount_in, &0u128);
+            let limit = if direction {
+                Self::MIN_SQRT_PRICE + 1
+            } else {
+                Self::MAX_SQRT_PRICE - 1
+            };
+            let est = client.estimate_price_impact(&direction, &amount_in, &limit);
             if est.amount_out > best {
                 best = est.amount_out;
                 zfo = direction;


### PR DESCRIPTION
## Summary of Changes

Fixed a bug in `dex_aggregator` where `0u128` was hardcoded as the `sqrt_price_limit_x96` for all Concentrated Liquidity (CL) pool hops, regardless of the swap direction (`zero_for_one`). 

For `zero_for_one = false`, the price goes up, and passing 0 caused the CL pool's swap loop to instantly hit the price limit (since current price is always `>= 0`). This resulted in a zero-amount step that permanently corrupted the pool's tick and price state without moving any tokens. 

To fix this, `MIN_SQRT_PRICE` and `MAX_SQRT_PRICE` constants (matching the Uniswap V3 math limits) were added to the aggregator. The `execute_hops` and `quote_cl` functions now correctly thread a limit of `MIN_SQRT_PRICE + 1` for `zero_for_one = true` and `MAX_SQRT_PRICE - 1` for `zero_for_one = false`.

## Related Issue(s)

- Closes #583

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

- [x] `cargo fmt` has been run
- [x] `cargo clippy -- -D warnings` passes with no new warnings
- [x] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
