### PR TITLE
fix: block NFT contract swap while positions are tokenized

### DIFF
--- a/SECURITY_FIX_NFT_CONTRACT_CHANGE.md
+++ b/SECURITY_FIX_NFT_CONTRACT_CHANGE.md
@@ -1,0 +1,97 @@
+# Security Fix: NFT Contract Change Vulnerability
+
+## Vulnerability Summary
+
+**Severity**: CRITICAL  
+**Component**: `contracts/concentrated_liquidity/src/lib.rs`  
+**Function**: `set_position_nft` (lines 301-313)  
+**Impact**: Permanent loss of LP position access; potential unauthorized control transfer
+
+## Description
+
+The `set_position_nft` function allowed the admin to change `DataKey::PositionNft` to a different NFT contract address at any time, without checking whether positions were already tokenized. This created a critical mismatch:
+
+1. **Index Orphaning**: The pool's `NftTokenToPosition(token_id)` and `PositionNftToken(provider, ticks)` indices still referenced token IDs minted against the **old** NFT contract.
+
+2. **Query Mismatch**: Any subsequent call to `resolve_token_owner` or `ensure_legacy_owner` would:
+   - Read a `token_id` from the old contract's index (stored on-chain)
+   - Query `PositionNftClient::new(env, &nft).owner_of(&token_id)` against the **new** contract using that stale ID
+
+3. **Attack Scenarios**:
+   - **Most likely**: Token ID doesn't exist in the new contract → `owner_of()` traps → position permanently locked (LP can't use token-id path or legacy address path)
+   - **ID collision**: New contract reused the same sequential ID (NFT IDs start at 0 and increment) → `owner_of()` returns an unrelated owner → wrong party gains control or legitimate owner is denied
+
+## Proof of Concept
+
+```rust
+// 1. Pool deployed with NFT_v1, Alice opens position → token_id = 0
+// 2. Admin calls set_position_nft(NFT_v2)  ← NO VALIDATION
+// 3. Pool storage still has:
+//    - NftTokenToPosition(0) = (Alice, -100, 100)
+//    - PositionNftToken(Alice, -100, 100) = 0
+// 4. Alice tries burn_position_by_token_id(0):
+//    ├─ resolve_token_owner reads NftTokenToPosition(0) ✓
+//    ├─ calls PositionNftClient::new(&NFT_v2).owner_of(0)
+//    └─ NFT_v2 has no token 0 → TRAP → Alice locked out
+// 5. Alice tries legacy burn_position(Alice, -100, 100):
+//    ├─ ensure_legacy_owner reads PositionNftToken(Alice, ticks) = 0 ✓
+//    ├─ calls PositionNftClient::new(&NFT_v2).owner_of(0)
+//    └─ TRAP → both paths blocked
+```
+
+## Fix
+
+Added validation in `set_position_nft` to **block changing from one NFT contract to a different one**:
+
+```rust
+let existing_nft: Option<Address> = env
+    .storage()
+    .instance()
+    .get(&DataKey::PositionNft)
+    .unwrap_or(None);
+
+// Only allow: None → Some (initial set) or Some → None (detach)
+// Block: Some(A) → Some(B) (would orphan indices)
+if existing_nft.is_some() && nft.is_some() && existing_nft != nft {
+    return Err(ClError::NftContractChangeBlocked);
+}
+```
+
+**Allowed transitions**:
+- `None → Some(A)` — Initial NFT contract wiring
+- `Some(A) → None` — Detach NFT (positions become legacy-only)
+- `Some(A) → Some(A)` — Re-setting the same contract (no-op)
+
+**Blocked transition**:
+- `Some(A) → Some(B)` — Returns `ClError::NftContractChangeBlocked`
+
+## Changes
+
+1. **contracts/concentrated_liquidity/src/lib.rs:308-330** — Added validation logic
+2. **contracts/concentrated_liquidity/src/lib.rs:61** — Added `NftContractChangeBlocked = 21` error variant
+3. **contracts/concentrated_liquidity/src/lib.rs:6209-6254** — Added regression test `cannot_change_nft_contract_after_positions_tokenized`
+
+## Testing
+
+The new test verifies:
+- ✅ Attempting to change NFT contract after position minting returns `NftContractChangeBlocked`
+- ✅ Detaching the NFT contract (→ None) is still allowed
+- ✅ Re-attaching the same contract is allowed
+
+## Recommendations
+
+1. **Deploy**: This fix must be deployed **before** any production positions are tokenized.
+2. **Migration**: If positions are already tokenized on a live contract, the NFT contract is now permanently locked — any migration would require redeploying the pool contract with a new storage model.
+3. **Audit**: Recommend third-party security review of all admin-controlled state transitions.
+
+## Related Code
+
+- `resolve_token_owner` (lines 1595-1617): Reads `token_id` from index, queries NFT
+- `ensure_legacy_owner` (lines 1619-1642): Guards legacy path by querying NFT ownership
+- `tokenize_position` (lines 1565-1590): Mints NFT and writes both index directions
+
+---
+
+**Reported**: 2026-07-28  
+**Fixed**: 2026-07-28  
+**Status**: Patched (pending build verification)

--- a/contracts/concentrated_liquidity/src/lib.rs
+++ b/contracts/concentrated_liquidity/src/lib.rs
@@ -55,8 +55,9 @@ pub enum ClError {
     InvalidToken = 16,       // token_in is not token_a or token_b
     RangeOrderInRange = 17,  // range order must be fully out-of-range at creation
     OracleDeviationExceeded = 18,
-    NftNotConfigured = 19, // no position-NFT contract is wired into the pool
-    NotNftOwner = 20,      // caller does not currently own the position NFT
+    NftNotConfigured = 19,        // no position-NFT contract is wired into the pool
+    NotNftOwner = 20,             // caller does not currently own the position NFT
+    NftContractChangeBlocked = 21, // changing NFT contract while positions are tokenized would orphan indices
 }
 
 /// Status of a range order (issue #295).
@@ -310,6 +311,23 @@ impl ConcentratedLiquidity {
             return Err(ClError::Unauthorized);
         }
         admin.require_auth();
+
+        // Safety check: prevent changing NFT contract when positions are tokenized.
+        // Changing the contract would orphan existing token_id → position indices,
+        // causing resolve_token_owner/ensure_legacy_owner to query the wrong NFT
+        // and either trap (id doesn't exist) or authorize the wrong owner (id collision).
+        let existing_nft: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PositionNft)
+            .unwrap_or(None);
+        
+        // Only allow changing from Some → None (detach) or None → Some (initial set).
+        // Changing from Some(A) → Some(B) is forbidden.
+        if existing_nft.is_some() && nft.is_some() && existing_nft != nft {
+            return Err(ClError::NftContractChangeBlocked);
+        }
+
         env.storage().instance().set(&DataKey::PositionNft, &nft);
         Ok(())
     }
@@ -6185,6 +6203,60 @@ mod test_single_token_deposit {
             f.client.position_token_id(&f.alice, &f.lower, &f.upper),
             None
         );
+    }
+
+    #[test]
+    fn cannot_change_nft_contract_after_positions_tokenized() {
+        // Regression test for vulnerability: changing DataKey::PositionNft to a
+        // different contract after positions have been minted would orphan the
+        // existing NftTokenToPosition / PositionNftToken indices. Later calls to
+        // resolve_token_owner or ensure_legacy_owner would query the new contract
+        // with stale token_ids from the old contract, causing:
+        // 1. Trap if token_id doesn't exist in new contract (locks LP out)
+        // 2. Wrong owner if new contract reused the same sequential id (authorization bypass)
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_a = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let token_b = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        
+        let cl_addr = env.register_contract(None, ConcentratedLiquidity);
+        let client = ConcentratedLiquidityClient::new(&env, &cl_addr);
+        client.initialize(&admin, &token_a, &token_b, &30_i128, &0_i32, &1_i32);
+
+        // Wire NFT contract v1 and mint a position.
+        let nft_v1 = env.register_contract(None, ClPositionNft);
+        let nft_v1_client = ClPositionNftClient::new(&env, &nft_v1);
+        nft_v1_client.initialize(&admin, &cl_addr);
+        client.set_position_nft(&admin, &Some(nft_v1.clone()));
+
+        let alice = Address::generate(&env);
+        StellarAssetClient::new(&env, &token_a).mint(&alice, &1_000_000_i128);
+        StellarAssetClient::new(&env, &token_b).mint(&alice, &1_000_000_i128);
+        
+        client.mint_position(&alice, &-100, &100, &100_000_i128, &100_000_i128, &0, &0);
+        assert_eq!(client.position_token_id(&alice, &-100, &100), Some(0_u64));
+
+        // Attempt to change to NFT contract v2 — must be rejected.
+        let nft_v2 = env.register_contract(None, ClPositionNft);
+        let err = client
+            .try_set_position_nft(&admin, &Some(nft_v2))
+            .err()
+            .unwrap()
+            .unwrap();
+        assert_eq!(err, ClError::NftContractChangeBlocked);
+
+        // Changing to None (detach) should still be allowed.
+        client.set_position_nft(&admin, &None);
+        assert_eq!(client.position_nft(), None);
+
+        // Re-attaching the same contract is allowed.
+        client.set_position_nft(&admin, &Some(nft_v1.clone()));
+        assert_eq!(client.position_nft(), Some(nft_v1));
     }
 }
 


### PR DESCRIPTION
Summary
  
  Fixes a critical vulnerability in set_position_nft that allowed the admin to change the NFT contract address after
  positions were tokenized, orphaning existing token_id indices and permanently locking LPs out of their positions.
  
  Problem
  
  set_position_nft (lines 301-313) stored a new NFT contract address unconditionally, with no validation that positions
  were already tokenized. This created a dangerous mismatch:
  
  1. Orphaned indices: NftTokenToPosition(token_id) and PositionNftToken(provider, ticks) still referenced token IDs
  minted against the old NFT contract
  2. Query mismatch: resolve_token_owner and ensure_legacy_owner read those stale token IDs, then query owner_of(token_id)
   against the new NFT contract
  3. Two failure modes:
    - Trap/permanent lock: If the new contract doesn't have that token ID, owner_of() panics → LP locked out of both
  token-id and legacy paths
    - Authorization bypass: If the new contract reused the same sequential ID (likely, since IDs start at 0), owner_of()
   returns an unrelated owner → wrong party gains control
  
  Proof of Concept
  
  // 1. Pool deployed with NFT_v1, Alice opens position → token_id = 0
  // 2. Admin calls set_position_nft(NFT_v2)
  // 3. Pool storage still holds:
  //    - NftTokenToPosition(0) = (Alice, -100, 100)
  //    - PositionNftToken(Alice, -100, 100) = 0
  // 4. Alice tries burn_position_by_token_id(0):
  //    ├─ resolve_token_owner reads token_id=0 from index ✓
  //    ├─ calls PositionNftClient::new(&NFT_v2).owner_of(0)
  //    └─ NFT_v2 has no token 0 → TRAP → Alice locked out
  
  Solution
  
  Added validation in set_position_nft to block changing from one NFT contract to a different one:
  
  let existing_nft: Option<Address> = env
      .storage()
      .instance()
      .get(&DataKey::PositionNft)
      .unwrap_or(None);
  
  // Block Some(A) → Some(B) to prevent orphaning indices
  if existing_nft.is_some() && nft.is_some() && existing_nft != nft {
      return Err(ClError::NftContractChangeBlocked);
  }
  
  Allowed transitions:
  
  - ✅ None → Some(A) — Initial NFT contract wiring
  - ✅ Some(A) → None — Detach NFT (positions become legacy-only)
  - ✅ Some(A) → Some(A) — Re-setting the same contract (no-op)
  
  Blocked transition:
  
  - ❌ Some(A) → Some(B) — Returns ClError::NftContractChangeBlocked
  
  Changes
  
  1. contracts/concentrated_liquidity/src/lib.rs:308-330 — Added validation logic in set_position_nft
  2. contracts/concentrated_liquidity/src/lib.rs:61 — Added ClError::NftContractChangeBlocked = 21
  3. contracts/concentrated_liquidity/src/lib.rs:6209-6254 — Added regression test
  cannot_change_nft_contract_after_positions_tokenized
  4. SECURITY_FIX_NFT_CONTRACT_CHANGE.md — Security advisory documenting the vulnerability and fix
  
  Testing
  
  The new test verifies:
  
  - ✅ Attempting to change NFT contract after position minting returns NftContractChangeBlocked
  - ✅ Detaching the NFT contract (Some → None) is still allowed
  - ✅ Re-attaching the same contract is allowed
  - ✅ Initial wiring (None → Some) works as before
  
  Severity
  
  CRITICAL — This vulnerability could permanently lock LPs out of their positions or allow unauthorized control transfer.
  The fix must be deployed before any production positions are tokenized.
  
  Related Code
  
  - resolve_token_owner (lines 1595-1617)
  - ensure_legacy_owner (lines 1619-1642)
  - tokenize_position (lines 1565-1590)
  - cleanup_nft_if_closed (lines 1644-1662)
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Checklist:
  
  - [x] Added validation to prevent NFT contract swap
  - [x] Added new error variant with clear documentation
  - [x] Added comprehensive regression test
  - [x] Documented security implications
  - [ ] Needs review before merge (build verification pending)




closes #596 