### PR TITLE
fix(oracle_aggregator): suppress stale_src/deviant events in get_pric…

### DIFF
--- a/contracts/oracle_aggregator/src/lib.rs
+++ b/contracts/oracle_aggregator/src/lib.rs
@@ -244,7 +244,7 @@ impl OracleAggregator {
             updated.push_back(source);
         }
 
-        if !stale_sources.is_empty() {
+        if persist_sources && !stale_sources.is_empty() {
             env.events()
                 .publish((symbol_short!("stale_src"),), (stale_sources,));
         }
@@ -279,7 +279,7 @@ impl OracleAggregator {
             }
         }
 
-        if !deviant_sources.is_empty() {
+        if persist_sources && !deviant_sources.is_empty() {
             env.events()
                 .publish((symbol_short!("deviant"),), (deviant_sources,));
         }


### PR DESCRIPTION
…e_safe (read-only path)

Issue closed: get_price_safe emits stale_src/deviant events unconditionally, enabling event-spam attacks from unpermissioned callers.

## Problem

aggregate_price() is the shared internal routine called by both get_price (persist_sources = true) and get_price_safe (persist_sources = false).

The stale_src event publish block at the end of the source-freshness loop and the deviant event publish block after the deviation-band filter were BOTH unconditional — they fired regardless of the persist_sources flag:

    // BEFORE (vulnerable)
    if !stale_sources.is_empty() {
        env.events().publish((symbol_short!("stale_src"),), (stale_sources,));
    }
    ...
    if !deviant_sources.is_empty() {
        env.events().publish((symbol_short!("deviant"),), (deviant_sources,));
    }

Because get_price_safe requires no auth and can be called by any account at any time (it is a pure-read preview function), an attacker — or simply a busy dApp polling for quotes — could continuously invoke get_price_safe and flood the ledger with stale_src and deviant events.  Off-chain monitors (indexers, alerting pipelines, dashboards) that treat these events as signals of genuine on-chain price feed degradation would receive a constant stream of false alerts, making it impossible to distinguish real feed problems from noise.  In extreme polling scenarios this also adds ledger event overhead to every simulation call.

## Root cause

The intent of persist_sources = false is that the call is side-effect-free: it reads sources, runs the aggregation, and returns without modifying any state.  Events are a side effect — they are permanently inscribed in the ledger — and must therefore respect the same guard.

## Fix

Both publish calls are gated on the same persist_sources boolean already used to guard the storage write:

    // AFTER (fixed)
    if persist_sources && !stale_sources.is_empty() {
        env.events().publish((symbol_short!("stale_src"),), (stale_sources,));
    }
    ...
    if persist_sources && !deviant_sources.is_empty() {
        env.events().publish((symbol_short!("deviant"),), (deviant_sources,));
    }

This means:
- get_price (persist_sources = true) continues to emit stale_src and deviant events exactly as before — off-chain monitors receive accurate, actionable signals whenever a real state-persisting price read detects a bad source.
- get_price_safe (persist_sources = false) is now fully side-effect-free: no storage writes, no events.  It may be called freely for simulation, previews, and quote polling without ledger or monitor pollution.

## Files changed

contracts/oracle_aggregator/src/lib.rs
  - Line ~246: added persist_sources && guard to stale_src publish block
  - Line ~282: added persist_sources && guard to deviant publish block

## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #536 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
