### PR TITLE
feat: quote_add_liquidity omits the on-chain MINIMUM_LIQUIDITY lock

### DIFF
--- a/contracts/amm-sdk/src/client.rs
+++ b/contracts/amm-sdk/src/client.rs
@@ -281,8 +281,9 @@ impl<'a> AmmPoolSdk<'a> {
     /// Estimate LP shares minted for depositing `amount_a` and `amount_b`.
     ///
     /// On an empty pool (first deposit) any ratio is accepted and shares equal
-    /// the geometric mean.  On a non-empty pool the lesser of the two ratios
-    /// is used, matching the on-chain logic.
+    /// the geometric mean, minus the `MINIMUM_LIQUIDITY` amount permanently
+    /// locked on-chain to prevent full pool drainage. On a non-empty pool the
+    /// lesser of the two ratios is used, matching the on-chain logic.
     pub fn quote_add_liquidity(
         &self,
         amount_a: i128,
@@ -297,7 +298,12 @@ impl<'a> AmmPoolSdk<'a> {
         let reserve_b = info.reserve_b;
 
         let shares = if total_shares == 0 {
-            isqrt(amount_a * amount_b)
+            const MINIMUM_LIQUIDITY: i128 = 1_000;
+            let raw_shares = isqrt(amount_a * amount_b);
+            if raw_shares <= MINIMUM_LIQUIDITY {
+                return Err(SdkAmmError::InsufficientShares);
+            }
+            raw_shares - MINIMUM_LIQUIDITY
         } else {
             let shares_a = amount_a * total_shares / reserve_a;
             let shares_b = amount_b * total_shares / reserve_b;


### PR DESCRIPTION
## Summary

Closes #494 

Fix `amm-sdk::quote_add_liquidity` to account for the on-chain `MINIMUM_LIQUIDITY` lock, so first-deposit quotes match what `add_liquidity` actually credits the caller.

## Problem

On the very first deposit into an empty pool, the on-chain contract mints `isqrt(amount_a * amount_b)` total shares but permanently locks `MINIMUM_LIQUIDITY = 1_000` of them, crediting the depositor only `shares - MINIMUM_LIQUIDITY` (`contracts/amm/src/lib.rs:1478-1493`).

`quote_add_liquidity` mirrored only the pre-lock formula, so it always over-quoted first-deposit shares by exactly `1_000`. An integrator deriving `min_shares` from the quote (e.g. `quote.shares * 99 / 100`) would see the real transaction revert with `SlippageExceeded` (or `InsufficientShares` for small deposits), with the relative error worst for small first deposits (up to >20x for a quote near the minimum).

## Fix

In `contracts/amm-sdk/src/client.rs` (`quote_add_liquidity`), when `total_shares == 0`:

- Subtract `MINIMUM_LIQUIDITY` (1,000, matching the `amm` contract's constant) from the raw `isqrt(amount_a * amount_b)` result before returning the quote.
- Return `SdkAmmError::InsufficientShares` when the raw shares don't exceed `MINIMUM_LIQUIDITY`, mirroring the on-chain `AmmError::InsufficientShares` revert.

Non-empty-pool quoting (proportional shares) is unaffected.

