### PR TITLE
fix: fail-safe oracle deviation check on stale confidence

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -1135,8 +1135,11 @@ impl AmmPool {
 
         let agg =
             OracleAggregatorClient::new(env, &oracle_addr).get_price_safe(token_in, token_out);
-        if amount_in <= 0 || agg.confidence == 0 || agg.price <= 0 {
+        if amount_in <= 0 {
             return Ok(());
+        }
+        if agg.confidence == 0 || agg.price <= 0 {
+            return Err(AmmError::OracleDeviationExceeded);
         }
 
         let spot_price = amount_out * 1_000_000 / amount_in;


### PR DESCRIPTION
When the oracle aggregator reports `confidence == 0` (stale sources) or `price <= 0`, `check_oracle_deviation` now rejects the swap with `OracleDeviationExceeded` instead of silently skipping the price-safety check.

Closes #576