### PR TITLE
fix(amm): move get_info's PoolInfo doc block to get_info

### DIFF
--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -2477,6 +2477,16 @@ impl AmmPool {
         (reserve_in * amount_out * 10_000) / ((reserve_out - amount_out) * (10_000 - fee_bps)) + 1
     }
 
+    /// Return the current swap fee in basis points.
+    ///
+    /// This is a read-only view function; it makes no state changes.
+    ///
+    /// # Returns
+    /// The pool's `fee_bps` as an `i128`. For the full pool state, see [`AmmPool::get_info`].
+    pub fn get_fee_info(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::FeeBps).unwrap()
+    }
+
     /// Return full pool state.
     /// Return a snapshot of the full pool state.
     ///
@@ -2492,10 +2502,6 @@ impl AmmPool {
     /// - `admin` — the pool administrator.
     /// - `fee_recipient` — recipient of accrued protocol fees.
     /// - `protocol_fee_bps` — protocol fee in basis points (subset of `fee_bps`).
-    pub fn get_fee_info(env: Env) -> i128 {
-        env.storage().instance().get(&DataKey::FeeBps).unwrap()
-    }
-
     pub fn get_info(env: Env) -> PoolInfo {
         PoolInfo {
             token_a: env.storage().instance().get(&DataKey::TokenA).unwrap(),


### PR DESCRIPTION
## Summary of Changes

<!-- Explain *what* changed and *why*. Keep it concise but complete enough
     for a reviewer who has no prior context. -->

The doc block for `AmmPool::get_fee_info` incorrectly described a full `PoolInfo` struct return, when the function actually returns only the raw `fee_bps` `i128`. This was a copy-paste mismatch: the `PoolInfo`-describing doc comment belongs to `AmmPool::get_info`, which had no doc comment at all.

- Moved the full `PoolInfo` doc comment from `get_fee_info` onto `get_info` (contracts/amm/src/lib.rs).
- Added an accurate doc comment to `get_fee_info` describing its actual `i128` `fee_bps` return value and cross-referencing `get_info`.

This prevents rustdoc from misleading integrators who expect `get_fee_info` to return the full pool struct.

## Related Issue(s)

<!-- Link every issue this PR addresses.
     Use "Closes #<n>" to auto-close on merge, or "Related to #<n>" for partial work. -->

- Closes #571

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Tests only
- [ ] Documentation only
- [ ] Chore (build, tooling, dependencies)

## Checklist

<!-- Complete every item before requesting review. -->

- [ ] `cargo fmt` has been run
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [ ] New behaviour is covered by tests
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] `CHANGELOG.md` has been updated with any notable changes
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
