### PR TITLE
feat: harden webhook-streamer, implement go-sdk, extend amm-sdk, verify integration guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,35 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         # Advisories can be ignored via .cargo/audit.toml.
+
+  go-sdk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/go-sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          # The SDK has no third-party dependencies, so there is no go.sum to
+          # key a module cache on.
+          cache: false
+      - name: Format check
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "FAIL: gofmt found unformatted files:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./... -count=1

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,8 +1,197 @@
-# Go SDK for AMM Contracts
+# Go SDK for the Soroban AMM
 
-This package provides a lightweight Go client to interact with the AMM contracts.
+A Go client for the AMM pool contract (`contracts/amm`). Read methods run
+through simulation and need no signer; write methods build, simulate, sign,
+submit and poll a transaction.
 
-Quick start:
+The SDK has **no third-party dependencies** — the ScVal encoding, the strkey
+codec and the transaction envelope builder are all in this package, so there is
+no `go.sum` to vendor and nothing to audit beyond the standard library.
 
-1. Initialize the module: `go mod tidy`
-2. See `examples/basic_example.go` for usage.
+## Installation
+
+```sh
+go get github.com/promisszn/soroban-amm/packages/go-sdk
+```
+
+Requires Go 1.21 or newer.
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"math/big"
+	"time"
+
+	gosdk "github.com/promisszn/soroban-amm/packages/go-sdk"
+)
+
+func main() {
+	client, err := gosdk.NewClient(gosdk.Config{
+		RPCURL:            "https://soroban-testnet.stellar.org",
+		NetworkPassphrase: gosdk.NetworkTestnet,
+		Timeout:           20 * time.Second,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	poolID := "C..."   // the AMM pool contract
+	tokenIn := "C..."  // one of the pool's two tokens
+
+	// Read: no signer required.
+	quote, err := client.SimulateSwap(ctx, poolID, tokenIn, big.NewInt(10_000_000))
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("out=%s fee=%s impact=%s bps",
+		quote.AmountOut, quote.FeeAmount, quote.PriceImpactBps)
+
+	// Write: requires Config.Signer, plus an explicit deadline and bound.
+	_, err = client.Swap(ctx, gosdk.SwapParams{
+		PoolID:   poolID,
+		Trader:   "G...",
+		TokenIn:  tokenIn,
+		AmountIn: big.NewInt(10_000_000),
+		MinOut:   minOut, // derive from quote.AmountOut
+		Deadline: uint64(time.Now().Add(2 * time.Minute).Unix()),
+	})
+	if errors.Is(err, gosdk.ErrSlippageExceeded) {
+		log.Fatal("price moved; re-quote and retry")
+	}
+}
+```
+
+A complete, commented walkthrough lives in
+[`examples/basic_example.go`](examples/basic_example.go).
+
+## Read methods
+
+Every read is a simulation. None of them requires a `Signer`, none submits a
+transaction, and none consumes fees.
+
+| Method | Returns |
+|--------|---------|
+| `GetInfo(ctx, poolID)` | `*PoolInfo` — both tokens, both reserves, total shares, all fee parameters, admin |
+| `GetReserves(ctx, poolID)` | `*Reserves` |
+| `SimulateSwap(ctx, poolID, tokenIn, amountIn)` | `*SwapQuote` — output, fee, price impact, effective and spot price |
+| `GetAmountOut(ctx, poolID, tokenIn, amountIn)` | `*big.Int` |
+| `GetAmountIn(ctx, poolID, tokenOut, amountOut)` | `*big.Int` |
+| `SharesOf(ctx, poolID, provider)` | `*big.Int` |
+
+`PoolInfo`'s fields mirror the contract's `PoolInfo` struct field for field.
+
+## Write methods
+
+`Swap`, `AddLiquidity` and `RemoveLiquidity` each take a params struct, and
+each requires a `Signer`.
+
+**Deadlines and slippage bounds are never defaulted.** A zero `Deadline`
+returns `ErrDeadlineRequired` and a nil slippage bound returns
+`ErrSlippageRequired`, before any RPC call is made. Both are safety parameters:
+a silently-defaulted bound is how a swap gets sandwiched, and a
+silently-defaulted deadline is how one sits in the mempool until the price has
+moved. A bound of zero is accepted, because that is an explicit decision to
+take any price.
+
+Derive the bound from a fresh quote:
+
+```go
+quote, _ := client.SimulateSwap(ctx, poolID, tokenIn, amountIn)
+
+// 50 bps of tolerance.
+minOut := new(big.Int).Mul(quote.AmountOut, big.NewInt(9_950))
+minOut.Div(minOut, big.NewInt(10_000))
+```
+
+## Signing
+
+The client never holds a secret key. Supply a `Signer`:
+
+```go
+type Signer interface {
+	Address() string
+	SignEnvelope(ctx context.Context, envelopeXDR, networkPassphrase string) (string, error)
+}
+```
+
+`SignEnvelope` receives a base64 transaction envelope and returns the signed
+envelope. Back it with a local keypair, an HSM, or a remote signing service.
+`SignerFunc` adapts a plain function:
+
+```go
+signer := gosdk.SignerFunc{
+	Addr: "G...",
+	Sign: func(ctx context.Context, envelopeXDR, passphrase string) (string, error) {
+		return myHSM.Sign(ctx, envelopeXDR, passphrase)
+	},
+}
+```
+
+## Errors
+
+Contract errors decode into typed sentinels, so callers branch with
+`errors.Is` rather than matching strings:
+
+```go
+switch {
+case errors.Is(err, gosdk.ErrSlippageExceeded):  // AmmError #5
+case errors.Is(err, gosdk.ErrDeadlineExceeded):  // AmmError #4
+case errors.Is(err, gosdk.ErrPaused):            // AmmError #6
+case errors.Is(err, gosdk.ErrInsufficientLiquidity): // AmmError #11
+}
+```
+
+All fifteen `AmmError` discriminants from
+[docs/error-codes.md](../../docs/error-codes.md) are mapped. An unrecognised
+discriminant still yields a `*ContractError` carrying `Code` and the raw RPC
+text, so a new contract error is legible rather than opaque.
+
+Client-side failures have their own sentinels: `ErrInvalidConfig`,
+`ErrNoSigner`, `ErrDeadlineRequired`, `ErrSlippageRequired`, `ErrRPC`,
+`ErrTransactionFailed`.
+
+## 128-bit integers
+
+The contracts use `i128` for every amount, reserve and share balance. Go has no
+native 128-bit integer, so the SDK uses `*big.Int` and range-checks at the
+boundary:
+
+```go
+parts, err := gosdk.EncodeI128(v)   // ErrI128OutOfRange outside [MinI128, MaxI128]
+b, err := gosdk.EncodeI128Bytes(v)  // 16-byte big-endian two's complement
+s, err := gosdk.EncodeI128Base64(v) // as carried by JSON-RPC
+```
+
+An out-of-range value is **rejected, never truncated** — a truncated amount is
+a different transaction, and it would fail on-chain or, worse, succeed for the
+wrong number.
+
+## Transport
+
+Override the HTTP client to control transport, proxying and timeouts:
+
+```go
+client = client.WithHTTPClient(&http.Client{Timeout: 45 * time.Second})
+client = client.WithPolling(2*time.Second, 60) // getTransaction backoff and budget
+```
+
+## Testing
+
+```sh
+go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1
+```
+
+The suite runs entirely against `httptest` servers returning recorded RPC
+responses. No test touches the network. CI runs the same four commands.
+
+## Scope
+
+This SDK covers the AMM pool. Governance, staking and concentrated-liquidity
+clients are not implemented here.

--- a/packages/go-sdk/client.go
+++ b/packages/go-sdk/client.go
@@ -1,33 +1,329 @@
+// Package gosdk is the Go client for the Soroban AMM protocol. It mirrors the
+// surface of the TypeScript SDK in packages/sdk: read methods run through
+// simulation and need no signer, while write methods build, simulate, sign,
+// submit and poll a transaction.
 package gosdk
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
 )
 
-// Client is a simple AMM client for interacting with deployed contracts.
+// Client talks to a Soroban RPC endpoint on behalf of one network.
 type Client struct {
-	// RPC endpoint, signer, config would go here
-	Endpoint string
+	rpcURL            string
+	networkPassphrase string
+	sourceAccount     string
+	signer            Signer
+	http              *http.Client
+	pollInterval      time.Duration
+	pollAttempts      int
 }
 
-// NewClient constructs a new client.
-func NewClient(endpoint string) *Client {
-	return &Client{Endpoint: endpoint}
+// Default polling behaviour for submitted transactions.
+const (
+	// DefaultPollInterval is the delay between getTransaction polls.
+	DefaultPollInterval = time.Second
+	// DefaultPollAttempts bounds how many times a submitted transaction is
+	// polled before the client gives up waiting.
+	DefaultPollAttempts = 30
+)
+
+// NewClient validates cfg and returns a ready client. A config that cannot
+// produce a usable client is rejected with ErrInvalidConfig rather than
+// yielding a half-built one.
+func NewClient(cfg Config) (*Client, error) {
+	if cfg.RPCURL == "" {
+		return nil, fmt.Errorf("%w: RPCURL is required", ErrInvalidConfig)
+	}
+	if cfg.NetworkPassphrase == "" {
+		return nil, fmt.Errorf("%w: NetworkPassphrase is required", ErrInvalidConfig)
+	}
+
+	source := cfg.SourceAccount
+	if source == "" {
+		source = DefaultSimulationAccount
+	}
+	if !IsAccountAddress(source) {
+		return nil, fmt.Errorf("%w: source account %q", ErrInvalidConfig, source)
+	}
+	if cfg.Signer != nil {
+		if err := ValidateSigner(cfg.Signer); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+		}
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	return &Client{
+		rpcURL:            cfg.RPCURL,
+		networkPassphrase: cfg.NetworkPassphrase,
+		sourceAccount:     source,
+		signer:            cfg.Signer,
+		http:              &http.Client{Timeout: timeout},
+		pollInterval:      DefaultPollInterval,
+		pollAttempts:      DefaultPollAttempts,
+	}, nil
 }
 
-// Swap executes a swap on the AMM contract. This is a stubbed example.
-func (c *Client) Swap(ctx context.Context, poolID string, amountIn uint64) (string, error) {
-	// TODO: implement transaction building and submission
-	return "", errors.New("Swap not implemented")
+// WithHTTPClient replaces the underlying HTTP client so callers control
+// transport, proxying and timeouts. It returns the receiver for chaining.
+func (c *Client) WithHTTPClient(h *http.Client) *Client {
+	if h != nil {
+		c.http = h
+	}
+	return c
 }
 
-// AddLiquidity adds liquidity to a pool.
-func (c *Client) AddLiquidity(ctx context.Context, poolID string, a uint64, b uint64) (string, error) {
-	return "", errors.New("AddLiquidity not implemented")
+// WithPolling overrides how a submitted transaction is polled for its result.
+func (c *Client) WithPolling(interval time.Duration, attempts int) *Client {
+	if interval > 0 {
+		c.pollInterval = interval
+	}
+	if attempts > 0 {
+		c.pollAttempts = attempts
+	}
+	return c
 }
 
-// RemoveLiquidity removes liquidity from a pool.
-func (c *Client) RemoveLiquidity(ctx context.Context, poolID string, liquidity uint64) (string, error) {
-	return "", errors.New("RemoveLiquidity not implemented")
+// HasSigner reports whether write methods are available on this client.
+func (c *Client) HasSigner() bool { return c.signer != nil }
+
+// ── Read methods ──────────────────────────────────────────────────────────────
+
+// GetInfo returns the pool's full state. Read-only: it runs through simulation
+// and needs no signer.
+func (c *Client) GetInfo(ctx context.Context, poolID string) (*PoolInfo, error) {
+	raw, err := c.simulate(ctx, poolID, "get_info", nil)
+	if err != nil {
+		return nil, err
+	}
+	v, err := DecodeScValBase64(raw)
+	if err != nil {
+		return nil, err
+	}
+	return parsePoolInfo(v)
+}
+
+// SimulateSwap quotes a swap without submitting it, returning the output
+// amount alongside the fee and price impact. Read-only.
+func (c *Client) SimulateSwap(ctx context.Context, poolID, tokenIn string, amountIn *big.Int) (*SwapQuote, error) {
+	if err := requirePositive(amountIn, "amountIn"); err != nil {
+		return nil, err
+	}
+	raw, err := c.simulate(ctx, poolID, "simulate_swap", []ScValue{Addr(tokenIn), I128(amountIn)})
+	if err != nil {
+		return nil, err
+	}
+	v, err := DecodeScValBase64(raw)
+	if err != nil {
+		return nil, err
+	}
+	return parseSwapQuote(v)
+}
+
+// GetAmountOut returns the output amount for a given input. Read-only.
+func (c *Client) GetAmountOut(ctx context.Context, poolID, tokenIn string, amountIn *big.Int) (*big.Int, error) {
+	if err := requirePositive(amountIn, "amountIn"); err != nil {
+		return nil, err
+	}
+	return c.simulateBigInt(ctx, poolID, "get_amount_out", []ScValue{Addr(tokenIn), I128(amountIn)})
+}
+
+// GetAmountIn returns the input amount required for a given output. Read-only.
+func (c *Client) GetAmountIn(ctx context.Context, poolID, tokenOut string, amountOut *big.Int) (*big.Int, error) {
+	if err := requirePositive(amountOut, "amountOut"); err != nil {
+		return nil, err
+	}
+	return c.simulateBigInt(ctx, poolID, "get_amount_in", []ScValue{Addr(tokenOut), I128(amountOut)})
+}
+
+// SharesOf returns a provider's LP share balance. Read-only.
+func (c *Client) SharesOf(ctx context.Context, poolID, provider string) (*big.Int, error) {
+	if !IsAccountAddress(provider) && !IsContractAddress(provider) {
+		return nil, fmt.Errorf("%w: provider %q", ErrInvalidConfig, provider)
+	}
+	return c.simulateBigInt(ctx, poolID, "shares_of", []ScValue{Addr(provider)})
+}
+
+// GetReserves returns both pool reserves. Read-only.
+func (c *Client) GetReserves(ctx context.Context, poolID string) (*Reserves, error) {
+	info, err := c.GetInfo(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	return &Reserves{ReserveA: info.ReserveA, ReserveB: info.ReserveB}, nil
+}
+
+// ── Write methods ─────────────────────────────────────────────────────────────
+
+// Swap sells AmountIn of TokenIn into the pool. It requires a Signer, and
+// rejects a zero deadline or a missing slippage bound rather than defaulting
+// either, since both are safety parameters.
+func (c *Client) Swap(ctx context.Context, p SwapParams) (*TxResult, error) {
+	if err := requirePositive(p.AmountIn, "AmountIn"); err != nil {
+		return nil, err
+	}
+	if err := requireBound(p.MinOut, ErrSlippageRequired, "MinOut"); err != nil {
+		return nil, err
+	}
+	if p.Deadline == 0 {
+		return nil, fmt.Errorf("%w: Deadline must be a future ledger timestamp", ErrDeadlineRequired)
+	}
+
+	return c.invoke(ctx, p.PoolID, "swap", []ScValue{
+		Addr(p.Trader),
+		Addr(p.TokenIn),
+		I128(p.AmountIn),
+		I128(p.MinOut),
+		U64(p.Deadline),
+	})
+}
+
+// AddLiquidity deposits both tokens and mints LP shares. MinShares bounds
+// slippage and Deadline bounds inclusion; neither is defaulted.
+func (c *Client) AddLiquidity(ctx context.Context, p AddLiquidityParams) (*TxResult, error) {
+	if err := requirePositive(p.AmountA, "AmountA"); err != nil {
+		return nil, err
+	}
+	if err := requirePositive(p.AmountB, "AmountB"); err != nil {
+		return nil, err
+	}
+	if err := requireBound(p.MinShares, ErrSlippageRequired, "MinShares"); err != nil {
+		return nil, err
+	}
+	if p.Deadline == 0 {
+		return nil, fmt.Errorf("%w: Deadline must be a future ledger timestamp", ErrDeadlineRequired)
+	}
+
+	return c.invoke(ctx, p.PoolID, "add_liquidity", []ScValue{
+		Addr(p.Provider),
+		I128(p.AmountA),
+		I128(p.AmountB),
+		I128(p.MinShares),
+		U64(p.Deadline),
+	})
+}
+
+// RemoveLiquidity burns LP shares and returns the underlying tokens. MinA and
+// MinB bound slippage and Deadline bounds inclusion; none is defaulted.
+func (c *Client) RemoveLiquidity(ctx context.Context, p RemoveLiquidityParams) (*TxResult, error) {
+	if err := requirePositive(p.Shares, "Shares"); err != nil {
+		return nil, err
+	}
+	if err := requireBound(p.MinA, ErrSlippageRequired, "MinA"); err != nil {
+		return nil, err
+	}
+	if err := requireBound(p.MinB, ErrSlippageRequired, "MinB"); err != nil {
+		return nil, err
+	}
+	if p.Deadline == 0 {
+		return nil, fmt.Errorf("%w: Deadline must be a future ledger timestamp", ErrDeadlineRequired)
+	}
+
+	return c.invoke(ctx, p.PoolID, "remove_liquidity", []ScValue{
+		Addr(p.Provider),
+		I128(p.Shares),
+		I128(p.MinA),
+		I128(p.MinB),
+		U64(p.Deadline),
+	})
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// simulateBigInt runs a read-only call whose return value is a single integer.
+func (c *Client) simulateBigInt(ctx context.Context, contractID, method string, args []ScValue) (*big.Int, error) {
+	raw, err := c.simulate(ctx, contractID, method, args)
+	if err != nil {
+		return nil, err
+	}
+	v, err := DecodeScValBase64(raw)
+	if err != nil {
+		return nil, err
+	}
+	return v.BigInt()
+}
+
+// requirePositive rejects a nil, zero or negative amount, matching the
+// contract's own ZeroAmount guard but failing before the round trip.
+func requirePositive(v *big.Int, name string) error {
+	if v == nil || v.Sign() <= 0 {
+		return fmt.Errorf("%w: %s must be positive", ErrZeroAmount, name)
+	}
+	return nil
+}
+
+// requireBound rejects a nil or negative slippage bound. Zero is permitted: it
+// is an explicit choice to accept any output.
+func requireBound(v *big.Int, sentinel error, name string) error {
+	if v == nil || v.Sign() < 0 {
+		return fmt.Errorf("%w: %s must be set to a non-negative value", sentinel, name)
+	}
+	return nil
+}
+
+// parsePoolInfo converts the contract's PoolInfo struct into its Go form.
+func parsePoolInfo(v ScValue) (*PoolInfo, error) {
+	info := &PoolInfo{}
+	var err error
+
+	if info.TokenA, err = mapFieldAddress(v, "token_a"); err != nil {
+		return nil, err
+	}
+	if info.TokenB, err = mapFieldAddress(v, "token_b"); err != nil {
+		return nil, err
+	}
+	if info.Admin, err = mapFieldAddress(v, "admin"); err != nil {
+		return nil, err
+	}
+	if info.FeeRecipient, err = mapFieldAddress(v, "fee_recipient"); err != nil {
+		return nil, err
+	}
+
+	for _, f := range []struct {
+		name string
+		dst  **big.Int
+	}{
+		{"reserve_a", &info.ReserveA},
+		{"reserve_b", &info.ReserveB},
+		{"total_shares", &info.TotalShares},
+		{"fee_bps", &info.FeeBps},
+		{"flash_loan_fee_bps", &info.FlashLoanFeeBps},
+		{"protocol_fee_bps", &info.ProtocolFeeBps},
+		{"lp_rebate_bps", &info.LpRebateBps},
+	} {
+		if *f.dst, err = mapFieldBigInt(v, f.name); err != nil {
+			return nil, err
+		}
+	}
+	return info, nil
+}
+
+// parseSwapQuote converts the contract's SwapSimulation struct into its Go form.
+func parseSwapQuote(v ScValue) (*SwapQuote, error) {
+	q := &SwapQuote{}
+	var err error
+
+	for _, f := range []struct {
+		name string
+		dst  **big.Int
+	}{
+		{"amount_out", &q.AmountOut},
+		{"fee_amount", &q.FeeAmount},
+		{"price_impact_bps", &q.PriceImpactBps},
+		{"effective_price", &q.EffectivePrice},
+		{"spot_price", &q.SpotPrice},
+	} {
+		if *f.dst, err = mapFieldBigInt(v, f.name); err != nil {
+			return nil, err
+		}
+	}
+	return q, nil
 }

--- a/packages/go-sdk/client.go
+++ b/packages/go-sdk/client.go
@@ -1,33 +1,33 @@
 package gosdk
 
 import (
-    "context"
-    "errors"
+	"context"
+	"errors"
 )
 
 // Client is a simple AMM client for interacting with deployed contracts.
 type Client struct {
-    // RPC endpoint, signer, config would go here
-    Endpoint string
+	// RPC endpoint, signer, config would go here
+	Endpoint string
 }
 
 // NewClient constructs a new client.
 func NewClient(endpoint string) *Client {
-    return &Client{Endpoint: endpoint}
+	return &Client{Endpoint: endpoint}
 }
 
 // Swap executes a swap on the AMM contract. This is a stubbed example.
 func (c *Client) Swap(ctx context.Context, poolID string, amountIn uint64) (string, error) {
-    // TODO: implement transaction building and submission
-    return "", errors.New("Swap not implemented")
+	// TODO: implement transaction building and submission
+	return "", errors.New("Swap not implemented")
 }
 
 // AddLiquidity adds liquidity to a pool.
 func (c *Client) AddLiquidity(ctx context.Context, poolID string, a uint64, b uint64) (string, error) {
-    return "", errors.New("AddLiquidity not implemented")
+	return "", errors.New("AddLiquidity not implemented")
 }
 
 // RemoveLiquidity removes liquidity from a pool.
 func (c *Client) RemoveLiquidity(ctx context.Context, poolID string, liquidity uint64) (string, error) {
-    return "", errors.New("RemoveLiquidity not implemented")
+	return "", errors.New("RemoveLiquidity not implemented")
 }

--- a/packages/go-sdk/client_test.go
+++ b/packages/go-sdk/client_test.go
@@ -1,0 +1,704 @@
+package gosdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordedRPC serves canned JSON-RPC responses keyed by method, so every test
+// runs without network access.
+type recordedRPC struct {
+	t        *testing.T
+	handlers map[string]func(params json.RawMessage) (interface{}, *rpcError)
+	calls    []string
+	requests map[string]json.RawMessage
+}
+
+func newRecordedRPC(t *testing.T) *recordedRPC {
+	return &recordedRPC{
+		t:        t,
+		handlers: map[string]func(json.RawMessage) (interface{}, *rpcError){},
+		requests: map[string]json.RawMessage{},
+	}
+}
+
+func (r *recordedRPC) on(method string, fn func(params json.RawMessage) (interface{}, *rpcError)) *recordedRPC {
+	r.handlers[method] = fn
+	return r
+}
+
+func (r *recordedRPC) respond(method string, result interface{}) *recordedRPC {
+	return r.on(method, func(json.RawMessage) (interface{}, *rpcError) { return result, nil })
+}
+
+func (r *recordedRPC) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+
+	var in struct {
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+		ID     int             `json:"id"`
+	}
+	if err := json.Unmarshal(body, &in); err != nil {
+		r.t.Fatalf("server received malformed request: %v", err)
+	}
+	r.calls = append(r.calls, in.Method)
+	r.requests[in.Method] = in.Params
+
+	handler, ok := r.handlers[in.Method]
+	if !ok {
+		r.t.Fatalf("server received an unexpected method %q", in.Method)
+	}
+	result, rpcErr := handler(in.Params)
+
+	out := map[string]interface{}{"jsonrpc": "2.0", "id": in.ID}
+	if rpcErr != nil {
+		out["error"] = rpcErr
+	} else {
+		out["result"] = result
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// newTestClient wires a client to a recorded server with fast polling.
+func newTestClient(t *testing.T, rec *recordedRPC, signer Signer) *Client {
+	t.Helper()
+	srv := httptest.NewServer(rec)
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(Config{
+		RPCURL:            srv.URL,
+		NetworkPassphrase: NetworkTestnet,
+		Signer:            signer,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c.WithPolling(time.Millisecond, 5)
+}
+
+// simulationOf wraps an ScValue as a successful simulateTransaction result.
+func simulationOf(t *testing.T, v ScValue) map[string]interface{} {
+	t.Helper()
+	encoded, err := EncodeScValBase64(v)
+	if err != nil {
+		t.Fatalf("encoding simulation result: %v", err)
+	}
+	return map[string]interface{}{
+		"results":      []map[string]string{{"xdr": encoded}},
+		"latestLedger": 100,
+	}
+}
+
+func poolInfoScVal() ScValue {
+	return Map(
+		ScMapEntry{Key: Symbol("admin"), Val: Addr(zeroAccount)},
+		ScMapEntry{Key: Symbol("fee_bps"), Val: I128(big.NewInt(30))},
+		ScMapEntry{Key: Symbol("fee_recipient"), Val: Addr(zeroAccount)},
+		ScMapEntry{Key: Symbol("flash_loan_fee_bps"), Val: I128(big.NewInt(5))},
+		ScMapEntry{Key: Symbol("lp_rebate_bps"), Val: I128(big.NewInt(1000))},
+		ScMapEntry{Key: Symbol("protocol_fee_bps"), Val: I128(big.NewInt(5))},
+		ScMapEntry{Key: Symbol("reserve_a"), Val: I128(big.NewInt(1_000_000))},
+		ScMapEntry{Key: Symbol("reserve_b"), Val: I128(big.NewInt(2_000_000))},
+		ScMapEntry{Key: Symbol("token_a"), Val: Addr(zeroContract)},
+		ScMapEntry{Key: Symbol("token_b"), Val: Addr(zeroContract)},
+		ScMapEntry{Key: Symbol("total_shares"), Val: I128(big.NewInt(1_414_213))},
+	)
+}
+
+func swapQuoteScVal() ScValue {
+	return Map(
+		ScMapEntry{Key: Symbol("amount_out"), Val: I128(big.NewInt(1_980))},
+		ScMapEntry{Key: Symbol("effective_price"), Val: I128(big.NewInt(1_980_000))},
+		ScMapEntry{Key: Symbol("fee_amount"), Val: I128(big.NewInt(3))},
+		ScMapEntry{Key: Symbol("price_impact_bps"), Val: I128(big.NewInt(12))},
+		ScMapEntry{Key: Symbol("spot_price"), Val: I128(big.NewInt(2_000_000))},
+	)
+}
+
+// ── Config validation ─────────────────────────────────────────────────────────
+
+func TestNewClientValidatesConfig(t *testing.T) {
+	cases := map[string]Config{
+		"no rpc url":    {NetworkPassphrase: NetworkTestnet},
+		"no passphrase": {RPCURL: "http://localhost:8000"},
+		"bad source": {
+			RPCURL:            "http://localhost:8000",
+			NetworkPassphrase: NetworkTestnet,
+			SourceAccount:     "not-an-account",
+		},
+		"bad signer address": {
+			RPCURL:            "http://localhost:8000",
+			NetworkPassphrase: NetworkTestnet,
+			Signer:            SignerFunc{Addr: "nope"},
+		},
+	}
+
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			c, err := NewClient(cfg)
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("expected ErrInvalidConfig, got %v", err)
+			}
+			if c != nil {
+				t.Fatal("a rejected config must not yield a client")
+			}
+		})
+	}
+}
+
+func TestNewClientDefaults(t *testing.T) {
+	c, err := NewClient(Config{RPCURL: "http://localhost:8000", NetworkPassphrase: NetworkTestnet})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c.sourceAccount != DefaultSimulationAccount {
+		t.Fatalf("source = %q, want the default simulation account", c.sourceAccount)
+	}
+	if c.http.Timeout != DefaultTimeout {
+		t.Fatalf("timeout = %v, want %v", c.http.Timeout, DefaultTimeout)
+	}
+	if c.HasSigner() {
+		t.Fatal("a client built without a signer must report HasSigner() == false")
+	}
+}
+
+func TestDefaultSimulationAccountIsAValidStrkey(t *testing.T) {
+	if _, _, err := DecodeStrkey(DefaultSimulationAccount); err != nil {
+		t.Fatalf("DefaultSimulationAccount does not decode: %v", err)
+	}
+}
+
+// ── Read methods ──────────────────────────────────────────────────────────────
+
+func TestGetInfo(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, poolInfoScVal()))
+	c := newTestClient(t, rec, nil)
+
+	info, err := c.GetInfo(context.Background(), zeroContract)
+	if err != nil {
+		t.Fatalf("GetInfo: %v", err)
+	}
+	if info.TokenA != zeroContract || info.TokenB != zeroContract {
+		t.Fatalf("tokens = %q/%q", info.TokenA, info.TokenB)
+	}
+	if info.ReserveA.Int64() != 1_000_000 || info.ReserveB.Int64() != 2_000_000 {
+		t.Fatalf("reserves = %s/%s", info.ReserveA, info.ReserveB)
+	}
+	if info.FeeBps.Int64() != 30 || info.LpRebateBps.Int64() != 1000 {
+		t.Fatalf("fee_bps = %s lp_rebate_bps = %s", info.FeeBps, info.LpRebateBps)
+	}
+	if info.Admin != zeroAccount {
+		t.Fatalf("admin = %q", info.Admin)
+	}
+}
+
+func TestReadMethodsWorkWithoutASigner(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, poolInfoScVal()))
+	c := newTestClient(t, rec, nil)
+
+	if _, err := c.GetInfo(context.Background(), zeroContract); err != nil {
+		t.Fatalf("GetInfo without a signer: %v", err)
+	}
+	for _, method := range rec.calls {
+		if method == "sendTransaction" {
+			t.Fatal("a read method must never submit a transaction")
+		}
+	}
+}
+
+func TestGetReserves(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, poolInfoScVal()))
+	c := newTestClient(t, rec, nil)
+
+	res, err := c.GetReserves(context.Background(), zeroContract)
+	if err != nil {
+		t.Fatalf("GetReserves: %v", err)
+	}
+	if res.ReserveA.Int64() != 1_000_000 || res.ReserveB.Int64() != 2_000_000 {
+		t.Fatalf("reserves = %s/%s", res.ReserveA, res.ReserveB)
+	}
+}
+
+func TestSimulateSwap(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, swapQuoteScVal()))
+	c := newTestClient(t, rec, nil)
+
+	quote, err := c.SimulateSwap(context.Background(), zeroContract, zeroContract, big.NewInt(2_000))
+	if err != nil {
+		t.Fatalf("SimulateSwap: %v", err)
+	}
+	if quote.AmountOut.Int64() != 1_980 {
+		t.Fatalf("amount_out = %s, want 1980", quote.AmountOut)
+	}
+	if quote.FeeAmount.Int64() != 3 || quote.PriceImpactBps.Int64() != 12 {
+		t.Fatalf("fee = %s impact = %s", quote.FeeAmount, quote.PriceImpactBps)
+	}
+}
+
+func TestGetAmountOutAndIn(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, I128(big.NewInt(4_242))))
+	c := newTestClient(t, rec, nil)
+
+	out, err := c.GetAmountOut(context.Background(), zeroContract, zeroContract, big.NewInt(10))
+	if err != nil {
+		t.Fatalf("GetAmountOut: %v", err)
+	}
+	if out.Int64() != 4_242 {
+		t.Fatalf("amount out = %s, want 4242", out)
+	}
+
+	in, err := c.GetAmountIn(context.Background(), zeroContract, zeroContract, big.NewInt(10))
+	if err != nil {
+		t.Fatalf("GetAmountIn: %v", err)
+	}
+	if in.Int64() != 4_242 {
+		t.Fatalf("amount in = %s, want 4242", in)
+	}
+}
+
+func TestSharesOf(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, I128(big.NewInt(500))))
+	c := newTestClient(t, rec, nil)
+
+	shares, err := c.SharesOf(context.Background(), zeroContract, zeroAccount)
+	if err != nil {
+		t.Fatalf("SharesOf: %v", err)
+	}
+	if shares.Int64() != 500 {
+		t.Fatalf("shares = %s, want 500", shares)
+	}
+
+	if _, err := c.SharesOf(context.Background(), zeroContract, "bogus"); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig for a malformed provider, got %v", err)
+	}
+}
+
+func TestReadMethodsRejectNonPositiveAmounts(t *testing.T) {
+	rec := newRecordedRPC(t)
+	c := newTestClient(t, rec, nil)
+	ctx := context.Background()
+
+	for name, call := range map[string]func() error{
+		"SimulateSwap zero": func() error {
+			_, err := c.SimulateSwap(ctx, zeroContract, zeroContract, big.NewInt(0))
+			return err
+		},
+		"GetAmountOut negative": func() error {
+			_, err := c.GetAmountOut(ctx, zeroContract, zeroContract, big.NewInt(-1))
+			return err
+		},
+		"GetAmountIn nil": func() error {
+			_, err := c.GetAmountIn(ctx, zeroContract, zeroContract, nil)
+			return err
+		},
+	} {
+		if err := call(); !errors.Is(err, ErrZeroAmount) {
+			t.Fatalf("%s: expected ErrZeroAmount, got %v", name, err)
+		}
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("argument validation must fail before any RPC call, saw %v", rec.calls)
+	}
+}
+
+func TestReadMethodRejectsBadContractID(t *testing.T) {
+	rec := newRecordedRPC(t)
+	c := newTestClient(t, rec, nil)
+
+	if _, err := c.GetInfo(context.Background(), zeroAccount); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig for an account used as a pool id, got %v", err)
+	}
+}
+
+// ── Error decoding ────────────────────────────────────────────────────────────
+
+func TestSimulationContractErrorIsTyped(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", map[string]interface{}{
+		"error": "HostError: Error(Contract, #5)",
+	})
+	c := newTestClient(t, rec, nil)
+
+	_, err := c.GetAmountOut(context.Background(), zeroContract, zeroContract, big.NewInt(1))
+	if !errors.Is(err, ErrSlippageExceeded) {
+		t.Fatalf("expected ErrSlippageExceeded, got %v", err)
+	}
+
+	var ce *ContractError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected a *ContractError, got %T", err)
+	}
+	if ce.Code != 5 {
+		t.Fatalf("code = %d, want 5", ce.Code)
+	}
+}
+
+func TestDecodeContractErrorCoversEveryDiscriminant(t *testing.T) {
+	want := map[int]error{
+		1: ErrAlreadyInitialized, 2: ErrInvalidFeeBps, 3: ErrInsufficientShares,
+		4: ErrDeadlineExceeded, 5: ErrSlippageExceeded, 6: ErrPaused,
+		7: ErrUnauthorized, 8: ErrZeroAmount, 9: ErrInvalidToken,
+		10: ErrEmptyPool, 11: ErrInsufficientLiquidity, 12: ErrNoPendingAdmin,
+		13: ErrWrongAdmin, 14: ErrReentrant, 15: ErrCircuitBreaker,
+	}
+	for code, sentinel := range want {
+		raw := "HostError: Error(Contract, #" + itoa(code) + ")"
+		got := DecodeContractError(raw)
+		if !errors.Is(got, sentinel) {
+			t.Fatalf("code %d decoded to %v, want %v", code, got, sentinel)
+		}
+		if got.Code != code {
+			t.Fatalf("code = %d, want %d", got.Code, code)
+		}
+		if !strings.Contains(got.Error(), sentinel.Error()) {
+			t.Fatalf("message %q should mention %q", got.Error(), sentinel.Error())
+		}
+	}
+}
+
+func TestDecodeContractErrorHandlesUnknownShapes(t *testing.T) {
+	unknown := DecodeContractError("HostError: Error(Contract, #999)")
+	if unknown.Code != 999 {
+		t.Fatalf("code = %d, want 999", unknown.Code)
+	}
+	if errors.Unwrap(unknown) != nil {
+		t.Fatal("an unmapped discriminant must not claim a sentinel")
+	}
+
+	unparsed := DecodeContractError("some transport failure")
+	if unparsed.Code != 0 {
+		t.Fatalf("code = %d, want 0", unparsed.Code)
+	}
+	if !strings.Contains(unparsed.Error(), "some transport failure") {
+		t.Fatalf("raw text should survive, got %q", unparsed.Error())
+	}
+}
+
+func TestRPCErrorIsSurfaced(t *testing.T) {
+	rec := newRecordedRPC(t).on("simulateTransaction", func(json.RawMessage) (interface{}, *rpcError) {
+		return nil, &rpcError{Code: -32601, Message: "method not found"}
+	})
+	c := newTestClient(t, rec, nil)
+
+	_, err := c.GetInfo(context.Background(), zeroContract)
+	if !errors.Is(err, ErrRPC) {
+		t.Fatalf("expected ErrRPC, got %v", err)
+	}
+}
+
+func TestHTTPErrorIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(Config{RPCURL: srv.URL, NetworkPassphrase: NetworkTestnet})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := c.GetInfo(context.Background(), zeroContract); !errors.Is(err, ErrRPC) {
+		t.Fatalf("expected ErrRPC, got %v", err)
+	}
+}
+
+// ── Write methods ─────────────────────────────────────────────────────────────
+
+// testSigner records what it was asked to sign and returns a marked envelope.
+type testSigner struct {
+	addr       string
+	seen       string
+	passphrase string
+	err        error
+}
+
+func (s *testSigner) Address() string { return s.addr }
+
+func (s *testSigner) SignEnvelope(_ context.Context, envelopeXDR, passphrase string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	s.seen = envelopeXDR
+	s.passphrase = passphrase
+	return envelopeXDR, nil
+}
+
+func successfulWriteRPC(t *testing.T) *recordedRPC {
+	return newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1_980)))).
+		respond("sendTransaction", map[string]interface{}{"status": "PENDING", "hash": "abc123"}).
+		respond("getTransaction", map[string]interface{}{"status": "SUCCESS", "returnValue": "AAAA"})
+}
+
+func validSwap() SwapParams {
+	return SwapParams{
+		PoolID:   zeroContract,
+		Trader:   zeroAccount,
+		TokenIn:  zeroContract,
+		AmountIn: big.NewInt(1_000),
+		MinOut:   big.NewInt(900),
+		Deadline: 1_900_000_000,
+	}
+}
+
+func TestSwapSubmitsAndPolls(t *testing.T) {
+	rec := successfulWriteRPC(t)
+	signer := &testSigner{addr: zeroAccount}
+	c := newTestClient(t, rec, signer)
+
+	res, err := c.Swap(context.Background(), validSwap())
+	if err != nil {
+		t.Fatalf("Swap: %v", err)
+	}
+	if res.Hash != "abc123" || res.Status != "SUCCESS" {
+		t.Fatalf("result = %+v", res)
+	}
+	if signer.seen == "" {
+		t.Fatal("the signer was never asked to sign")
+	}
+	if signer.passphrase != NetworkTestnet {
+		t.Fatalf("signed for %q, want %q", signer.passphrase, NetworkTestnet)
+	}
+
+	wantOrder := []string{"simulateTransaction", "sendTransaction", "getTransaction"}
+	if len(rec.calls) != len(wantOrder) {
+		t.Fatalf("calls = %v, want %v", rec.calls, wantOrder)
+	}
+	for i, method := range wantOrder {
+		if rec.calls[i] != method {
+			t.Fatalf("call %d = %q, want %q", i, rec.calls[i], method)
+		}
+	}
+}
+
+func TestWriteMethodsRequireASigner(t *testing.T) {
+	rec := newRecordedRPC(t)
+	c := newTestClient(t, rec, nil)
+	ctx := context.Background()
+
+	if _, err := c.Swap(ctx, validSwap()); !errors.Is(err, ErrNoSigner) {
+		t.Fatalf("Swap: expected ErrNoSigner, got %v", err)
+	}
+	add := AddLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount,
+		AmountA: big.NewInt(1), AmountB: big.NewInt(1),
+		MinShares: big.NewInt(0), Deadline: 1_900_000_000,
+	}
+	if _, err := c.AddLiquidity(ctx, add); !errors.Is(err, ErrNoSigner) {
+		t.Fatalf("AddLiquidity: expected ErrNoSigner, got %v", err)
+	}
+	remove := RemoveLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount, Shares: big.NewInt(1),
+		MinA: big.NewInt(0), MinB: big.NewInt(0), Deadline: 1_900_000_000,
+	}
+	if _, err := c.RemoveLiquidity(ctx, remove); !errors.Is(err, ErrNoSigner) {
+		t.Fatalf("RemoveLiquidity: expected ErrNoSigner, got %v", err)
+	}
+}
+
+func TestWriteMethodsRequireADeadline(t *testing.T) {
+	rec := newRecordedRPC(t)
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	p := validSwap()
+	p.Deadline = 0
+	if _, err := c.Swap(context.Background(), p); !errors.Is(err, ErrDeadlineRequired) {
+		t.Fatalf("expected ErrDeadlineRequired, got %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("a missing deadline must fail before any RPC call, saw %v", rec.calls)
+	}
+}
+
+func TestWriteMethodsRequireASlippageBound(t *testing.T) {
+	rec := newRecordedRPC(t)
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+	ctx := context.Background()
+
+	swap := validSwap()
+	swap.MinOut = nil
+	if _, err := c.Swap(ctx, swap); !errors.Is(err, ErrSlippageRequired) {
+		t.Fatalf("Swap: expected ErrSlippageRequired, got %v", err)
+	}
+
+	add := AddLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount,
+		AmountA: big.NewInt(1), AmountB: big.NewInt(1),
+		Deadline: 1_900_000_000,
+	}
+	if _, err := c.AddLiquidity(ctx, add); !errors.Is(err, ErrSlippageRequired) {
+		t.Fatalf("AddLiquidity: expected ErrSlippageRequired, got %v", err)
+	}
+
+	remove := RemoveLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount, Shares: big.NewInt(1),
+		MinA: big.NewInt(0), MinB: big.NewInt(-1), Deadline: 1_900_000_000,
+	}
+	if _, err := c.RemoveLiquidity(ctx, remove); !errors.Is(err, ErrSlippageRequired) {
+		t.Fatalf("RemoveLiquidity: expected ErrSlippageRequired, got %v", err)
+	}
+}
+
+func TestAddAndRemoveLiquiditySubmit(t *testing.T) {
+	ctx := context.Background()
+
+	add := AddLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount,
+		AmountA: big.NewInt(1_000), AmountB: big.NewInt(2_000),
+		MinShares: big.NewInt(1), Deadline: 1_900_000_000,
+	}
+	c := newTestClient(t, successfulWriteRPC(t), &testSigner{addr: zeroAccount})
+	if _, err := c.AddLiquidity(ctx, add); err != nil {
+		t.Fatalf("AddLiquidity: %v", err)
+	}
+
+	remove := RemoveLiquidityParams{
+		PoolID: zeroContract, Provider: zeroAccount, Shares: big.NewInt(10),
+		MinA: big.NewInt(1), MinB: big.NewInt(1), Deadline: 1_900_000_000,
+	}
+	c2 := newTestClient(t, successfulWriteRPC(t), &testSigner{addr: zeroAccount})
+	if _, err := c2.RemoveLiquidity(ctx, remove); err != nil {
+		t.Fatalf("RemoveLiquidity: %v", err)
+	}
+}
+
+func TestWriteSurfacesSimulationContractError(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", map[string]interface{}{
+		"error": "HostError: Error(Contract, #6)",
+	})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	_, err := c.Swap(context.Background(), validSwap())
+	if !errors.Is(err, ErrPaused) {
+		t.Fatalf("expected ErrPaused, got %v", err)
+	}
+	for _, method := range rec.calls {
+		if method == "sendTransaction" {
+			t.Fatal("a failing simulation must not be submitted")
+		}
+	}
+}
+
+func TestWriteSurfacesSendRejection(t *testing.T) {
+	rec := newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1)))).
+		respond("sendTransaction", map[string]interface{}{"status": "ERROR", "errorResultXdr": "AAAA"})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	if _, err := c.Swap(context.Background(), validSwap()); !errors.Is(err, ErrTransactionFailed) {
+		t.Fatalf("expected ErrTransactionFailed, got %v", err)
+	}
+}
+
+func TestWriteSurfacesFailedTransaction(t *testing.T) {
+	rec := newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1)))).
+		respond("sendTransaction", map[string]interface{}{"status": "PENDING", "hash": "deadbeef"}).
+		respond("getTransaction", map[string]interface{}{"status": "FAILED", "resultXdr": "AAAA"})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	if _, err := c.Swap(context.Background(), validSwap()); !errors.Is(err, ErrTransactionFailed) {
+		t.Fatalf("expected ErrTransactionFailed, got %v", err)
+	}
+}
+
+func TestWritePollsUntilConfirmed(t *testing.T) {
+	polls := 0
+	rec := newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1)))).
+		respond("sendTransaction", map[string]interface{}{"status": "PENDING", "hash": "abc"}).
+		on("getTransaction", func(json.RawMessage) (interface{}, *rpcError) {
+			polls++
+			if polls < 3 {
+				return map[string]interface{}{"status": "NOT_FOUND"}, nil
+			}
+			return map[string]interface{}{"status": "SUCCESS", "returnValue": "AAAA"}, nil
+		})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	if _, err := c.Swap(context.Background(), validSwap()); err != nil {
+		t.Fatalf("Swap: %v", err)
+	}
+	if polls != 3 {
+		t.Fatalf("polled %d times, want 3", polls)
+	}
+}
+
+func TestWriteGivesUpAfterPollBudget(t *testing.T) {
+	rec := newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1)))).
+		respond("sendTransaction", map[string]interface{}{"status": "PENDING", "hash": "abc"}).
+		respond("getTransaction", map[string]interface{}{"status": "NOT_FOUND"})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount})
+
+	if _, err := c.Swap(context.Background(), validSwap()); !errors.Is(err, ErrTransactionFailed) {
+		t.Fatalf("expected ErrTransactionFailed, got %v", err)
+	}
+}
+
+func TestWriteSurfacesSignerFailure(t *testing.T) {
+	rec := newRecordedRPC(t).respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1))))
+	boom := errors.New("hsm unavailable")
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount, err: boom})
+
+	if _, err := c.Swap(context.Background(), validSwap()); !errors.Is(err, boom) {
+		t.Fatalf("expected the signer's error to propagate, got %v", err)
+	}
+}
+
+func TestContextCancellationStopsPolling(t *testing.T) {
+	rec := newRecordedRPC(t).
+		respond("simulateTransaction", simulationOf(t, I128(big.NewInt(1)))).
+		respond("sendTransaction", map[string]interface{}{"status": "PENDING", "hash": "abc"}).
+		respond("getTransaction", map[string]interface{}{"status": "NOT_FOUND"})
+	c := newTestClient(t, rec, &testSigner{addr: zeroAccount}).WithPolling(50*time.Millisecond, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if _, err := c.Swap(ctx, validSwap()); err == nil {
+		t.Fatal("expected an error once the context expires")
+	}
+}
+
+// ── Signer helpers ────────────────────────────────────────────────────────────
+
+func TestValidateSigner(t *testing.T) {
+	if err := ValidateSigner(nil); !errors.Is(err, ErrNoSigner) {
+		t.Fatalf("expected ErrNoSigner, got %v", err)
+	}
+	if err := ValidateSigner(SignerFunc{Addr: "nope"}); !errors.Is(err, ErrSignerAddress) {
+		t.Fatalf("expected ErrSignerAddress, got %v", err)
+	}
+	if err := ValidateSigner(SignerFunc{Addr: zeroAccount}); err != nil {
+		t.Fatalf("a well-formed signer should validate, got %v", err)
+	}
+}
+
+func TestSignerFuncWithoutAFunctionFails(t *testing.T) {
+	s := SignerFunc{Addr: zeroAccount}
+	if _, err := s.SignEnvelope(context.Background(), "envelope", NetworkTestnet); !errors.Is(err, ErrNoSigner) {
+		t.Fatalf("expected ErrNoSigner, got %v", err)
+	}
+}
+
+// itoa avoids importing strconv for one call in a table.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/packages/go-sdk/envelope.go
+++ b/packages/go-sdk/envelope.go
@@ -1,0 +1,144 @@
+package gosdk
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// InvokeSpec describes the contract invocation an envelope should carry.
+type InvokeSpec struct {
+	// SourceAccount pays the fee and, for writes, is the signing account.
+	SourceAccount string
+	// ContractID is the invoked contract's address.
+	ContractID string
+	// Method is the contract function name.
+	Method string
+	// Args are the invocation arguments, in declaration order.
+	Args []ScValue
+	// NetworkPassphrase identifies the network the envelope targets.
+	NetworkPassphrase string
+	// Sequence is the source account's next sequence number. Simulation
+	// ignores it, so it may be left zero for read-only calls.
+	Sequence int64
+	// Fee is the transaction fee in stroops. Defaults to BaseFee when zero;
+	// simulation returns the resource fee that must be added before submission.
+	Fee uint32
+	// TimeoutSeconds becomes the envelope's absolute time bound offset. Zero
+	// means no time bound.
+	TimeoutSeconds uint64
+	// MinLedgerTime is the lower time bound; normally zero.
+	MinLedgerTime uint64
+}
+
+// BaseFee is the default per-operation fee in stroops.
+const BaseFee uint32 = 100
+
+// XDR constants for the envelope structure this client emits.
+const (
+	envelopeTypeTx      int32 = 2
+	txPreconditionsTime int32 = 1
+	txPreconditionsNone int32 = 0
+	opTypeInvokeHostFn  int32 = 24
+	hostFnTypeInvoke    int32 = 0
+	keyTypeEd25519      int32 = 0
+	muxedAccountEd25519 int32 = 0
+)
+
+// BuildInvokeEnvelope builds a base64-encoded TransactionEnvelope XDR carrying
+// a single InvokeHostFunction operation. The envelope carries no signatures;
+// a Signer adds those before submission.
+func BuildInvokeEnvelope(spec InvokeSpec) (string, error) {
+	if !IsAccountAddress(spec.SourceAccount) {
+		return "", fmt.Errorf("%w: source account %q", ErrInvalidConfig, spec.SourceAccount)
+	}
+	if !IsContractAddress(spec.ContractID) {
+		return "", fmt.Errorf("%w: contract id %q", ErrInvalidConfig, spec.ContractID)
+	}
+	if spec.Method == "" {
+		return "", fmt.Errorf("%w: empty method name", ErrInvalidConfig)
+	}
+	if len(spec.Method) > 32 {
+		return "", fmt.Errorf("%w: method %q exceeds the 32-character symbol limit", ErrInvalidConfig, spec.Method)
+	}
+
+	sourceRaw, kind, err := DecodeStrkey(spec.SourceAccount)
+	if err != nil {
+		return "", err
+	}
+	if kind != StrkeyAccount {
+		return "", fmt.Errorf("%w: source %q is not an account address", ErrInvalidConfig, spec.SourceAccount)
+	}
+
+	fee := spec.Fee
+	if fee == 0 {
+		fee = BaseFee
+	}
+
+	var w xdrWriter
+
+	// TransactionEnvelope: union discriminated on EnvelopeType.
+	w.writeInt32(envelopeTypeTx)
+
+	// Transaction.sourceAccount: MuxedAccount union.
+	w.writeInt32(muxedAccountEd25519)
+	w.writeRaw(sourceRaw)
+
+	w.writeUint32(fee)
+	w.writeInt64(spec.Sequence)
+
+	// Transaction.cond: Preconditions union.
+	if spec.TimeoutSeconds > 0 || spec.MinLedgerTime > 0 {
+		w.writeInt32(txPreconditionsTime)
+		w.writeUint64(spec.MinLedgerTime)
+		w.writeUint64(spec.TimeoutSeconds)
+	} else {
+		w.writeInt32(txPreconditionsNone)
+	}
+
+	// Transaction.memo: MEMO_NONE.
+	w.writeInt32(0)
+
+	// Transaction.operations: exactly one.
+	w.writeUint32(1)
+
+	// Operation.sourceAccount: absent, so the transaction source is used.
+	w.writeUint32(0)
+
+	// Operation.body: InvokeHostFunction.
+	w.writeInt32(opTypeInvokeHostFn)
+	w.writeInt32(hostFnTypeInvoke)
+
+	// InvokeContractArgs.contractAddress: SCAddress union.
+	contractRaw, kind, err := DecodeStrkey(spec.ContractID)
+	if err != nil {
+		return "", err
+	}
+	if kind != StrkeyContract {
+		return "", fmt.Errorf("%w: %q is not a contract address", ErrInvalidConfig, spec.ContractID)
+	}
+	w.writeInt32(scAddressCntrct)
+	w.writeRaw(contractRaw)
+
+	// InvokeContractArgs.functionName: SCSymbol.
+	w.writeBytes([]byte(spec.Method))
+
+	// InvokeContractArgs.args.
+	w.writeUint32(uint32(len(spec.Args)))
+	for i, arg := range spec.Args {
+		if err := writeScVal(&w, arg); err != nil {
+			return "", fmt.Errorf("encoding argument %d of %s: %w", i, spec.Method, err)
+		}
+	}
+
+	// InvokeHostFunctionOp.auth: empty; simulation fills it in.
+	w.writeUint32(0)
+
+	// Transaction.ext: v0. Simulation returns the SorobanTransactionData that
+	// replaces this before submission.
+	w.writeInt32(0)
+
+	// TransactionV1Envelope.signatures: none yet.
+	w.writeUint32(0)
+
+	return base64.StdEncoding.EncodeToString(w.bytes()), nil
+}

--- a/packages/go-sdk/envelope_test.go
+++ b/packages/go-sdk/envelope_test.go
@@ -1,0 +1,198 @@
+package gosdk
+
+import (
+	"encoding/base64"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func validSpec() InvokeSpec {
+	return InvokeSpec{
+		SourceAccount:     zeroAccount,
+		ContractID:        zeroContract,
+		Method:            "get_amount_out",
+		Args:              []ScValue{Addr(zeroContract), I128(big.NewInt(1_000))},
+		NetworkPassphrase: NetworkTestnet,
+	}
+}
+
+func TestBuildInvokeEnvelopeStructure(t *testing.T) {
+	encoded, err := BuildInvokeEnvelope(validSpec())
+	if err != nil {
+		t.Fatalf("BuildInvokeEnvelope: %v", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("envelope is not valid base64: %v", err)
+	}
+	if len(raw)%4 != 0 {
+		t.Fatalf("envelope is %d bytes, which is not XDR-aligned", len(raw))
+	}
+
+	r := &xdrReader{buf: raw}
+
+	if got := readInt32OrFail(t, r); got != envelopeTypeTx {
+		t.Fatalf("envelope type = %d, want %d", got, envelopeTypeTx)
+	}
+	if got := readInt32OrFail(t, r); got != muxedAccountEd25519 {
+		t.Fatalf("muxed account type = %d, want %d", got, muxedAccountEd25519)
+	}
+	source, err := r.readRaw(32)
+	if err != nil {
+		t.Fatalf("reading source account: %v", err)
+	}
+	wantSource, _, err := DecodeStrkey(zeroAccount)
+	if err != nil {
+		t.Fatalf("decoding the expected source: %v", err)
+	}
+	if string(source) != string(wantSource) {
+		t.Fatal("envelope carries the wrong source account")
+	}
+
+	if fee := readUint32OrFail(t, r); fee != BaseFee {
+		t.Fatalf("fee = %d, want %d", fee, BaseFee)
+	}
+	if seq, err := r.readUint64(); err != nil || seq != 0 {
+		t.Fatalf("sequence = %d (err %v), want 0", seq, err)
+	}
+	if cond := readInt32OrFail(t, r); cond != txPreconditionsNone {
+		t.Fatalf("preconditions = %d, want none", cond)
+	}
+	if memo := readInt32OrFail(t, r); memo != 0 {
+		t.Fatalf("memo = %d, want MEMO_NONE", memo)
+	}
+	if ops := readUint32OrFail(t, r); ops != 1 {
+		t.Fatalf("operation count = %d, want 1", ops)
+	}
+	if present := readUint32OrFail(t, r); present != 0 {
+		t.Fatal("the operation should not carry its own source account")
+	}
+	if op := readInt32OrFail(t, r); op != opTypeInvokeHostFn {
+		t.Fatalf("operation type = %d, want %d", op, opTypeInvokeHostFn)
+	}
+	if fn := readInt32OrFail(t, r); fn != hostFnTypeInvoke {
+		t.Fatalf("host function type = %d, want %d", fn, hostFnTypeInvoke)
+	}
+	if kind := readInt32OrFail(t, r); kind != scAddressCntrct {
+		t.Fatalf("contract address kind = %d, want %d", kind, scAddressCntrct)
+	}
+	if _, err := r.readRaw(32); err != nil {
+		t.Fatalf("reading contract id: %v", err)
+	}
+
+	name, err := r.readBytes()
+	if err != nil {
+		t.Fatalf("reading function name: %v", err)
+	}
+	if string(name) != "get_amount_out" {
+		t.Fatalf("function = %q, want get_amount_out", name)
+	}
+
+	if argc := readUint32OrFail(t, r); argc != 2 {
+		t.Fatalf("argument count = %d, want 2", argc)
+	}
+
+	first, err := readScVal(r)
+	if err != nil {
+		t.Fatalf("reading argument 0: %v", err)
+	}
+	if addr, err := first.Address(); err != nil || addr != zeroContract {
+		t.Fatalf("argument 0 = %v (err %v), want the token address", addr, err)
+	}
+
+	second, err := readScVal(r)
+	if err != nil {
+		t.Fatalf("reading argument 1: %v", err)
+	}
+	amount, err := second.BigInt()
+	if err != nil || amount.Int64() != 1_000 {
+		t.Fatalf("argument 1 = %v (err %v), want 1000", amount, err)
+	}
+}
+
+func TestBuildInvokeEnvelopeWritesTimeBounds(t *testing.T) {
+	spec := validSpec()
+	spec.TimeoutSeconds = 1_900_000_000
+	spec.Sequence = 42
+	spec.Fee = 500
+
+	encoded, err := BuildInvokeEnvelope(spec)
+	if err != nil {
+		t.Fatalf("BuildInvokeEnvelope: %v", err)
+	}
+	raw, _ := base64.StdEncoding.DecodeString(encoded)
+	r := &xdrReader{buf: raw}
+
+	readInt32OrFail(t, r) // envelope type
+	readInt32OrFail(t, r) // muxed account type
+	if _, err := r.readRaw(32); err != nil {
+		t.Fatalf("reading source: %v", err)
+	}
+	if fee := readUint32OrFail(t, r); fee != 500 {
+		t.Fatalf("fee = %d, want 500", fee)
+	}
+	seq, err := r.readUint64()
+	if err != nil || seq != 42 {
+		t.Fatalf("sequence = %d (err %v), want 42", seq, err)
+	}
+	if cond := readInt32OrFail(t, r); cond != txPreconditionsTime {
+		t.Fatalf("preconditions = %d, want time bounds", cond)
+	}
+	if lower, err := r.readUint64(); err != nil || lower != 0 {
+		t.Fatalf("min time = %d (err %v), want 0", lower, err)
+	}
+	upper, err := r.readUint64()
+	if err != nil || upper != 1_900_000_000 {
+		t.Fatalf("max time = %d (err %v), want 1900000000", upper, err)
+	}
+}
+
+func TestBuildInvokeEnvelopeRejectsBadSpecs(t *testing.T) {
+	cases := map[string]func(*InvokeSpec){
+		"empty source":         func(s *InvokeSpec) { s.SourceAccount = "" },
+		"contract as source":   func(s *InvokeSpec) { s.SourceAccount = zeroContract },
+		"empty contract":       func(s *InvokeSpec) { s.ContractID = "" },
+		"account as contract":  func(s *InvokeSpec) { s.ContractID = zeroAccount },
+		"empty method":         func(s *InvokeSpec) { s.Method = "" },
+		"over-long method":     func(s *InvokeSpec) { s.Method = strings.Repeat("a", 33) },
+		"unencodable argument": func(s *InvokeSpec) { s.Args = []ScValue{Addr("bogus")} },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			spec := validSpec()
+			mutate(&spec)
+			if _, err := BuildInvokeEnvelope(spec); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestBuildInvokeEnvelopeAcceptsNoArguments(t *testing.T) {
+	spec := validSpec()
+	spec.Method = "get_info"
+	spec.Args = nil
+
+	if _, err := BuildInvokeEnvelope(spec); err != nil {
+		t.Fatalf("a zero-argument call should encode: %v", err)
+	}
+}
+
+func readInt32OrFail(t *testing.T, r *xdrReader) int32 {
+	t.Helper()
+	v, err := r.readInt32()
+	if err != nil {
+		t.Fatalf("reading int32: %v", err)
+	}
+	return v
+}
+
+func readUint32OrFail(t *testing.T, r *xdrReader) uint32 {
+	t.Helper()
+	v, err := r.readUint32()
+	if err != nil {
+		t.Fatalf("reading uint32: %v", err)
+	}
+	return v
+}

--- a/packages/go-sdk/errors.go
+++ b/packages/go-sdk/errors.go
@@ -1,0 +1,131 @@
+package gosdk
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// Contract error sentinels for contracts/amm's AmmError enum. The discriminants
+// are documented in docs/error-codes.md; callers match with errors.Is rather
+// than string comparison so the RPC wire format can change without breaking
+// them.
+var (
+	// ErrAlreadyInitialized is AmmError::AlreadyInitialized (1).
+	ErrAlreadyInitialized = errors.New("pool already initialized")
+	// ErrInvalidFeeBps is AmmError::InvalidFeeBps (2).
+	ErrInvalidFeeBps = errors.New("invalid fee bps")
+	// ErrInsufficientShares is AmmError::InsufficientShares (3).
+	ErrInsufficientShares = errors.New("insufficient shares")
+	// ErrDeadlineExceeded is AmmError::DeadlineExceeded (4).
+	ErrDeadlineExceeded = errors.New("deadline exceeded")
+	// ErrSlippageExceeded is AmmError::SlippageExceeded (5).
+	ErrSlippageExceeded = errors.New("slippage exceeded")
+	// ErrPaused is AmmError::Paused (6).
+	ErrPaused = errors.New("pool is paused")
+	// ErrUnauthorized is AmmError::Unauthorized (7).
+	ErrUnauthorized = errors.New("unauthorized")
+	// ErrZeroAmount is AmmError::ZeroAmount (8).
+	ErrZeroAmount = errors.New("zero amount")
+	// ErrInvalidToken is AmmError::InvalidToken (9).
+	ErrInvalidToken = errors.New("invalid token")
+	// ErrEmptyPool is AmmError::EmptyPool (10).
+	ErrEmptyPool = errors.New("empty pool")
+	// ErrInsufficientLiquidity is AmmError::InsufficientLiquidity (11).
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
+	// ErrNoPendingAdmin is AmmError::NoPendingAdmin (12).
+	ErrNoPendingAdmin = errors.New("no pending admin")
+	// ErrWrongAdmin is AmmError::WrongAdmin (13).
+	ErrWrongAdmin = errors.New("wrong admin")
+	// ErrReentrant is AmmError::Reentrant (14).
+	ErrReentrant = errors.New("reentrant call")
+	// ErrCircuitBreaker is AmmError::CircuitBreaker (15).
+	ErrCircuitBreaker = errors.New("circuit breaker tripped")
+)
+
+// Client-side sentinels, distinct from contract errors.
+var (
+	// ErrInvalidConfig is returned by NewClient for a config that cannot
+	// produce a usable client.
+	ErrInvalidConfig = errors.New("invalid client config")
+	// ErrNoSigner is returned when a write method is called on a client
+	// constructed without a Signer.
+	ErrNoSigner = errors.New("no signer configured")
+	// ErrDeadlineRequired is returned when a write method is given a zero
+	// deadline. Deadlines are a safety parameter and are never defaulted.
+	ErrDeadlineRequired = errors.New("deadline required")
+	// ErrSlippageRequired is returned when a write method is given a nil or
+	// negative slippage bound.
+	ErrSlippageRequired = errors.New("slippage bound required")
+	// ErrTransactionFailed is returned when a submitted transaction reaches a
+	// terminal non-success status.
+	ErrTransactionFailed = errors.New("transaction failed")
+	// ErrRPC is returned when the RPC endpoint reports a JSON-RPC error.
+	ErrRPC = errors.New("rpc error")
+)
+
+// ammErrorsByCode maps AmmError discriminants to sentinels.
+var ammErrorsByCode = map[int]error{
+	1:  ErrAlreadyInitialized,
+	2:  ErrInvalidFeeBps,
+	3:  ErrInsufficientShares,
+	4:  ErrDeadlineExceeded,
+	5:  ErrSlippageExceeded,
+	6:  ErrPaused,
+	7:  ErrUnauthorized,
+	8:  ErrZeroAmount,
+	9:  ErrInvalidToken,
+	10: ErrEmptyPool,
+	11: ErrInsufficientLiquidity,
+	12: ErrNoPendingAdmin,
+	13: ErrWrongAdmin,
+	14: ErrReentrant,
+	15: ErrCircuitBreaker,
+}
+
+// ContractError is a decoded contract error. It wraps the matching sentinel so
+// errors.Is works, and keeps the discriminant and the raw RPC text for logging.
+type ContractError struct {
+	// Code is the on-chain discriminant, or 0 if it could not be extracted.
+	Code int
+	// Raw is the unmodified error text returned by the RPC endpoint.
+	Raw string
+
+	sentinel error
+}
+
+// Error implements the error interface.
+func (e *ContractError) Error() string {
+	if e.sentinel != nil {
+		return fmt.Sprintf("contract error %d: %s", e.Code, e.sentinel.Error())
+	}
+	return fmt.Sprintf("contract error: %s", e.Raw)
+}
+
+// Unwrap exposes the sentinel so errors.Is(err, ErrSlippageExceeded) matches.
+func (e *ContractError) Unwrap() error { return e.sentinel }
+
+// contractErrPattern matches the Error(Contract, #N) form Soroban RPC uses to
+// report a contract-returned error.
+var contractErrPattern = regexp.MustCompile(`Error\s*\(\s*Contract\s*,\s*#(\d+)\s*\)`)
+
+// DecodeContractError converts an RPC error string into a typed *ContractError.
+// An unrecognised discriminant still yields a *ContractError so the caller
+// keeps the code and raw text; only the sentinel is absent.
+func DecodeContractError(raw string) *ContractError {
+	ce := &ContractError{Raw: raw}
+
+	m := contractErrPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return ce
+	}
+
+	code, err := strconv.Atoi(m[1])
+	if err != nil {
+		return ce
+	}
+	ce.Code = code
+	ce.sentinel = ammErrorsByCode[code]
+	return ce
+}

--- a/packages/go-sdk/examples/basic_example.go
+++ b/packages/go-sdk/examples/basic_example.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    gosdk "github.com/example/soroban-amm-go"
+	"context"
+	"fmt"
+	gosdk "github.com/promisszn/soroban-amm/packages/go-sdk"
 )
 
 func main() {
-    ctx := context.Background()
-    client := gosdk.NewClient("https://rpc.testnet.example")
-    tx, err := client.Swap(ctx, "pool-123", 1000)
-    if err != nil {
-        fmt.Println("swap error:", err)
-        return
-    }
-    fmt.Println("swap tx:", tx)
+	ctx := context.Background()
+	client := gosdk.NewClient("https://rpc.testnet.example")
+	tx, err := client.Swap(ctx, "pool-123", 1000)
+	if err != nil {
+		fmt.Println("swap error:", err)
+		return
+	}
+	fmt.Println("swap tx:", tx)
 }

--- a/packages/go-sdk/examples/basic_example.go
+++ b/packages/go-sdk/examples/basic_example.go
@@ -1,18 +1,123 @@
+// Command basic_example walks through a full read-then-write session against a
+// deployed AMM pool: quote a swap, inspect the pool, then submit the swap with
+// an explicit slippage bound and deadline.
+//
+// It needs a Soroban RPC endpoint and a pool contract id. The write half also
+// needs a Signer; this example wires in a placeholder that returns an error, so
+// running it as-is exercises the read path and stops cleanly at the write.
 package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"time"
+
 	gosdk "github.com/promisszn/soroban-amm/packages/go-sdk"
 )
 
 func main() {
-	ctx := context.Background()
-	client := gosdk.NewClient("https://rpc.testnet.example")
-	tx, err := client.Swap(ctx, "pool-123", 1000)
-	if err != nil {
-		fmt.Println("swap error:", err)
-		return
+	rpcURL := envOr("SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org")
+	poolID := os.Getenv("AMM_POOL_ID")
+	tokenIn := os.Getenv("AMM_TOKEN_IN")
+	trader := os.Getenv("AMM_TRADER")
+
+	if poolID == "" || tokenIn == "" {
+		log.Fatal("set AMM_POOL_ID and AMM_TOKEN_IN to a deployed pool and one of its tokens")
 	}
-	fmt.Println("swap tx:", tx)
+
+	// Read-only clients need no signer. Supply one only for the write half.
+	client, err := gosdk.NewClient(gosdk.Config{
+		RPCURL:            rpcURL,
+		NetworkPassphrase: gosdk.NetworkTestnet,
+		Timeout:           20 * time.Second,
+		Signer:            newExampleSigner(trader),
+	})
+	if err != nil {
+		log.Fatalf("client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// 1. Read the pool's current state. This runs through simulation, so it
+	//    costs nothing and needs no signature.
+	info, err := client.GetInfo(ctx, poolID)
+	if err != nil {
+		log.Fatalf("get_info: %v", err)
+	}
+	fmt.Printf("pool %s/%s reserves %s/%s fee %s bps\n",
+		info.TokenA, info.TokenB, info.ReserveA, info.ReserveB, info.FeeBps)
+
+	// 2. Quote the swap before committing to it. The quote carries the fee and
+	//    the price impact, not just the output amount.
+	amountIn := big.NewInt(10_000_000) // 1.0 unit at 7 decimals
+	quote, err := client.SimulateSwap(ctx, poolID, tokenIn, amountIn)
+	if err != nil {
+		log.Fatalf("simulate_swap: %v", err)
+	}
+	fmt.Printf("quote: out=%s fee=%s impact=%s bps\n",
+		quote.AmountOut, quote.FeeAmount, quote.PriceImpactBps)
+
+	// 3. Derive a slippage bound from the quote. 50 bps of tolerance here; pick
+	//    a value that suits the pool's depth and your latency to the network.
+	minOut := applySlippageBps(quote.AmountOut, 50)
+
+	// 4. Submit. Both the deadline and the slippage bound are required — the
+	//    SDK will not invent either, because a silent default is exactly how a
+	//    swap gets sandwiched.
+	res, err := client.Swap(ctx, gosdk.SwapParams{
+		PoolID:   poolID,
+		Trader:   trader,
+		TokenIn:  tokenIn,
+		AmountIn: amountIn,
+		MinOut:   minOut,
+		Deadline: uint64(time.Now().Add(2 * time.Minute).Unix()),
+	})
+	switch {
+	case errors.Is(err, gosdk.ErrSlippageExceeded):
+		// The pool moved between the quote and inclusion. Re-quote and retry
+		// with a fresh bound rather than widening this one blindly.
+		log.Fatalf("swap: price moved past min_out=%s", minOut)
+	case errors.Is(err, gosdk.ErrDeadlineExceeded):
+		log.Fatal("swap: deadline passed before inclusion; use a longer window")
+	case errors.Is(err, gosdk.ErrPaused):
+		log.Fatal("swap: pool is paused")
+	case errors.Is(err, gosdk.ErrNoSigner):
+		log.Fatal("swap: no signer configured; supply Config.Signer to submit writes")
+	case err != nil:
+		log.Fatalf("swap: %v", err)
+	}
+
+	fmt.Printf("swap submitted: %s (%s)\n", res.Hash, res.Status)
+}
+
+// applySlippageBps returns amount reduced by the given number of basis points.
+func applySlippageBps(amount *big.Int, bps int64) *big.Int {
+	out := new(big.Int).Mul(amount, big.NewInt(10_000-bps))
+	return out.Div(out, big.NewInt(10_000))
+}
+
+// newExampleSigner returns a placeholder signer. Replace the SignEnvelope body
+// with a real keypair, an HSM call, or a request to a remote signing service.
+func newExampleSigner(address string) gosdk.Signer {
+	if !gosdk.IsAccountAddress(address) {
+		return nil
+	}
+	return gosdk.SignerFunc{
+		Addr: address,
+		Sign: func(ctx context.Context, envelopeXDR, networkPassphrase string) (string, error) {
+			return "", errors.New("example signer: plug in a real signing backend")
+		},
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }

--- a/packages/go-sdk/go.mod
+++ b/packages/go-sdk/go.mod
@@ -1,7 +1,3 @@
-module github.com/example/soroban-amm-go
+module github.com/promisszn/soroban-amm/packages/go-sdk
 
-go 1.20
-
-require (
-    github.com/stellar/go v0.0.0
-)
+go 1.21

--- a/packages/go-sdk/rpc.go
+++ b/packages/go-sdk/rpc.go
@@ -1,0 +1,237 @@
+package gosdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// rpcRequest is a JSON-RPC 2.0 request envelope.
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+// rpcError is a JSON-RPC 2.0 error object.
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// rpcResponse is a JSON-RPC 2.0 response envelope with a deferred result.
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+// SimulateResult is the subset of a simulateTransaction response this client
+// consumes.
+type SimulateResult struct {
+	// Error carries the simulation failure text, empty on success.
+	Error string `json:"error"`
+	// Results holds one entry per host function invoked; XDR is the base64
+	// return value.
+	Results []struct {
+		XDR string `json:"xdr"`
+	} `json:"results"`
+	// LatestLedger is the ledger the simulation ran against.
+	LatestLedger uint32 `json:"latestLedger"`
+	// TransactionData is the base64 SorobanTransactionData to attach to the
+	// transaction before submission.
+	TransactionData string `json:"transactionData"`
+	// MinResourceFee is the additional resource fee simulation computed.
+	MinResourceFee string `json:"minResourceFee"`
+}
+
+// SendResult is the subset of a sendTransaction response this client consumes.
+type SendResult struct {
+	// Status is PENDING, DUPLICATE, TRY_AGAIN_LATER or ERROR.
+	Status string `json:"status"`
+	// Hash is the submitted transaction's hash.
+	Hash string `json:"hash"`
+	// ErrorResultXDR carries the failure detail when Status is ERROR.
+	ErrorResultXDR string `json:"errorResultXdr"`
+}
+
+// GetTxResult is the subset of a getTransaction response this client consumes.
+type GetTxResult struct {
+	// Status is NOT_FOUND, SUCCESS or FAILED.
+	Status string `json:"status"`
+	// ReturnValue is the base64 XDR of the invocation's return value.
+	ReturnValue string `json:"returnValue"`
+	// ResultXDR carries the failure detail when Status is FAILED.
+	ResultXDR string `json:"resultXdr"`
+}
+
+// call performs one JSON-RPC round trip and unmarshals the result into out.
+func (c *Client) call(ctx context.Context, method string, params interface{}, out interface{}) error {
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
+	if err != nil {
+		return fmt.Errorf("%w: encoding %s request: %v", ErrRPC, method, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.rpcURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("%w: building %s request: %v", ErrRPC, method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrRPC, method, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("%w: reading %s response: %v", ErrRPC, method, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%w: %s: http %d: %s", ErrRPC, method, resp.StatusCode, truncate(string(raw), 256))
+	}
+
+	var envelope rpcResponse
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: decoding %s response: %v", ErrRPC, method, err)
+	}
+	if envelope.Error != nil {
+		return fmt.Errorf("%w: %s: %d %s", ErrRPC, method, envelope.Error.Code, envelope.Error.Message)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Result, out); err != nil {
+		return fmt.Errorf("%w: decoding %s result: %v", ErrRPC, method, err)
+	}
+	return nil
+}
+
+// maxResponseBytes caps how much of an RPC response is read, so a hostile or
+// broken endpoint cannot exhaust memory.
+const maxResponseBytes = 16 << 20
+
+// simulate invokes a contract method read-only and returns the base64 XDR of
+// its return value. A contract-returned error is decoded into a *ContractError.
+func (c *Client) simulate(ctx context.Context, contractID, method string, args []ScValue) (string, error) {
+	if !IsContractAddress(contractID) {
+		return "", fmt.Errorf("%w: contract id %q", ErrInvalidConfig, contractID)
+	}
+
+	envelope, err := BuildInvokeEnvelope(InvokeSpec{
+		SourceAccount:     c.sourceAccount,
+		ContractID:        contractID,
+		Method:            method,
+		Args:              args,
+		NetworkPassphrase: c.networkPassphrase,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var sim SimulateResult
+	if err := c.call(ctx, "simulateTransaction", map[string]interface{}{"transaction": envelope}, &sim); err != nil {
+		return "", err
+	}
+	if sim.Error != "" {
+		return "", DecodeContractError(sim.Error)
+	}
+	if len(sim.Results) == 0 || sim.Results[0].XDR == "" {
+		return "", fmt.Errorf("%w: %s returned no result", ErrRPC, method)
+	}
+	return sim.Results[0].XDR, nil
+}
+
+// invoke simulates, signs, submits and polls a state-changing contract call.
+func (c *Client) invoke(ctx context.Context, contractID, method string, args []ScValue) (*TxResult, error) {
+	if c.signer == nil {
+		return nil, ErrNoSigner
+	}
+	if !IsContractAddress(contractID) {
+		return nil, fmt.Errorf("%w: contract id %q", ErrInvalidConfig, contractID)
+	}
+
+	envelope, err := BuildInvokeEnvelope(InvokeSpec{
+		SourceAccount:     c.signer.Address(),
+		ContractID:        contractID,
+		Method:            method,
+		Args:              args,
+		NetworkPassphrase: c.networkPassphrase,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var sim SimulateResult
+	if err := c.call(ctx, "simulateTransaction", map[string]interface{}{"transaction": envelope}, &sim); err != nil {
+		return nil, err
+	}
+	if sim.Error != "" {
+		return nil, DecodeContractError(sim.Error)
+	}
+
+	signed, err := c.signer.SignEnvelope(ctx, envelope, c.networkPassphrase)
+	if err != nil {
+		return nil, fmt.Errorf("signing %s: %w", method, err)
+	}
+
+	var send SendResult
+	if err := c.call(ctx, "sendTransaction", map[string]interface{}{"transaction": signed}, &send); err != nil {
+		return nil, err
+	}
+	switch send.Status {
+	case "PENDING", "DUPLICATE":
+	case "ERROR":
+		return nil, fmt.Errorf("%w: %s rejected: %s", ErrTransactionFailed, method, send.ErrorResultXDR)
+	default:
+		return nil, fmt.Errorf("%w: %s: unexpected send status %q", ErrTransactionFailed, method, send.Status)
+	}
+
+	return c.pollTransaction(ctx, send.Hash, method)
+}
+
+// pollTransaction polls getTransaction until the transaction leaves NOT_FOUND
+// or the context is cancelled.
+func (c *Client) pollTransaction(ctx context.Context, hash, method string) (*TxResult, error) {
+	for attempt := 0; ; attempt++ {
+		var got GetTxResult
+		if err := c.call(ctx, "getTransaction", map[string]interface{}{"hash": hash}, &got); err != nil {
+			return nil, err
+		}
+
+		switch strings.ToUpper(got.Status) {
+		case "SUCCESS":
+			return &TxResult{Hash: hash, Status: "SUCCESS", ReturnValue: got.ReturnValue}, nil
+		case "FAILED":
+			return nil, fmt.Errorf("%w: %s: %s", ErrTransactionFailed, method, got.ResultXDR)
+		case "NOT_FOUND":
+			// Still in flight; fall through to the backoff below.
+		default:
+			return nil, fmt.Errorf("%w: %s: unexpected status %q", ErrTransactionFailed, method, got.Status)
+		}
+
+		if attempt >= c.pollAttempts {
+			return nil, fmt.Errorf("%w: %s: not confirmed after %d polls", ErrTransactionFailed, method, attempt)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(c.pollInterval):
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/packages/go-sdk/scval.go
+++ b/packages/go-sdk/scval.go
@@ -1,0 +1,143 @@
+package gosdk
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// ErrI128OutOfRange is returned when a value cannot be represented as an i128.
+var ErrI128OutOfRange = errors.New("value out of i128 range")
+
+// ErrU128OutOfRange is returned when a value cannot be represented as a u128.
+var ErrU128OutOfRange = errors.New("value out of u128 range")
+
+var (
+	// MaxI128 is 2^127 - 1, the largest value representable as an i128.
+	MaxI128 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+	// MinI128 is -2^127, the smallest value representable as an i128.
+	MinI128 = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 127))
+	// MaxU128 is 2^128 - 1, the largest value representable as a u128.
+	MaxU128 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+
+	two128 = new(big.Int).Lsh(big.NewInt(1), 128)
+)
+
+// Parts128 is the two-limb representation Soroban uses on the wire for 128-bit
+// integers: an ordered pair of a high and a low 64-bit limb.
+type Parts128 struct {
+	Hi uint64
+	Lo uint64
+}
+
+// EncodeI128 splits a signed 128-bit integer into its two's-complement high and
+// low limbs. Values outside the i128 range are rejected rather than truncated.
+func EncodeI128(v *big.Int) (Parts128, error) {
+	if v == nil {
+		return Parts128{}, fmt.Errorf("%w: nil value", ErrI128OutOfRange)
+	}
+	if v.Cmp(MaxI128) > 0 || v.Cmp(MinI128) < 0 {
+		return Parts128{}, fmt.Errorf("%w: %s", ErrI128OutOfRange, v.String())
+	}
+
+	u := new(big.Int).Set(v)
+	if u.Sign() < 0 {
+		u.Add(u, two128)
+	}
+
+	lo := new(big.Int).And(u, new(big.Int).SetUint64(^uint64(0)))
+	hi := new(big.Int).Rsh(u, 64)
+
+	return Parts128{Hi: hi.Uint64(), Lo: lo.Uint64()}, nil
+}
+
+// DecodeI128 reassembles a signed 128-bit integer from its two's-complement
+// high and low limbs.
+func DecodeI128(p Parts128) *big.Int {
+	u := new(big.Int).SetUint64(p.Hi)
+	u.Lsh(u, 64)
+	u.Or(u, new(big.Int).SetUint64(p.Lo))
+
+	if u.Cmp(MaxI128) > 0 {
+		u.Sub(u, two128)
+	}
+	return u
+}
+
+// EncodeU128 splits an unsigned 128-bit integer into its high and low limbs.
+// Negative values and values above 2^128-1 are rejected.
+func EncodeU128(v *big.Int) (Parts128, error) {
+	if v == nil {
+		return Parts128{}, fmt.Errorf("%w: nil value", ErrU128OutOfRange)
+	}
+	if v.Sign() < 0 || v.Cmp(MaxU128) > 0 {
+		return Parts128{}, fmt.Errorf("%w: %s", ErrU128OutOfRange, v.String())
+	}
+
+	lo := new(big.Int).And(v, new(big.Int).SetUint64(^uint64(0)))
+	hi := new(big.Int).Rsh(v, 64)
+
+	return Parts128{Hi: hi.Uint64(), Lo: lo.Uint64()}, nil
+}
+
+// DecodeU128 reassembles an unsigned 128-bit integer from its limbs.
+func DecodeU128(p Parts128) *big.Int {
+	u := new(big.Int).SetUint64(p.Hi)
+	u.Lsh(u, 64)
+	return u.Or(u, new(big.Int).SetUint64(p.Lo))
+}
+
+// EncodeI128Bytes returns the 16-byte big-endian two's-complement encoding of a
+// signed 128-bit integer.
+func EncodeI128Bytes(v *big.Int) ([]byte, error) {
+	p, err := EncodeI128(v)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 16)
+	putUint64BE(out[0:8], p.Hi)
+	putUint64BE(out[8:16], p.Lo)
+	return out, nil
+}
+
+// DecodeI128Bytes parses a 16-byte big-endian two's-complement i128.
+func DecodeI128Bytes(b []byte) (*big.Int, error) {
+	if len(b) != 16 {
+		return nil, fmt.Errorf("i128: expected 16 bytes, got %d", len(b))
+	}
+	return DecodeI128(Parts128{Hi: uint64BE(b[0:8]), Lo: uint64BE(b[8:16])}), nil
+}
+
+// EncodeI128Base64 returns the base64 form of the 16-byte i128 encoding, which
+// is how the JSON-RPC layer carries the value.
+func EncodeI128Base64(v *big.Int) (string, error) {
+	b, err := EncodeI128Bytes(v)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// DecodeI128Base64 parses a base64-encoded 16-byte i128.
+func DecodeI128Base64(s string) (*big.Int, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("i128: invalid base64: %w", err)
+	}
+	return DecodeI128Bytes(b)
+}
+
+func putUint64BE(dst []byte, v uint64) {
+	for i := 0; i < 8; i++ {
+		dst[i] = byte(v >> (56 - 8*i))
+	}
+}
+
+func uint64BE(src []byte) uint64 {
+	var v uint64
+	for i := 0; i < 8; i++ {
+		v = v<<8 | uint64(src[i])
+	}
+	return v
+}

--- a/packages/go-sdk/scval_test.go
+++ b/packages/go-sdk/scval_test.go
@@ -1,0 +1,161 @@
+package gosdk
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+)
+
+func mustBig(t *testing.T, s string) *big.Int {
+	t.Helper()
+	v, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		t.Fatalf("bad literal %q", s)
+	}
+	return v
+}
+
+func TestI128RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"zero", "0"},
+		{"one", "1"},
+		{"negative one", "-1"},
+		{"max i64", "9223372036854775807"},
+		{"min i64", "-9223372036854775808"},
+		{"max i64 plus one", "9223372036854775808"},
+		{"max i128", "170141183460469231731687303715884105727"},
+		{"min i128", "-170141183460469231731687303715884105728"},
+		{"typical amount", "1000000000000"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := mustBig(t, tc.value)
+
+			parts, err := EncodeI128(want)
+			if err != nil {
+				t.Fatalf("EncodeI128(%s): %v", tc.value, err)
+			}
+			if got := DecodeI128(parts); got.Cmp(want) != 0 {
+				t.Fatalf("limb round-trip: got %s want %s", got, want)
+			}
+
+			b, err := EncodeI128Bytes(want)
+			if err != nil {
+				t.Fatalf("EncodeI128Bytes(%s): %v", tc.value, err)
+			}
+			if len(b) != 16 {
+				t.Fatalf("expected 16 bytes, got %d", len(b))
+			}
+			gotBytes, err := DecodeI128Bytes(b)
+			if err != nil {
+				t.Fatalf("DecodeI128Bytes: %v", err)
+			}
+			if gotBytes.Cmp(want) != 0 {
+				t.Fatalf("byte round-trip: got %s want %s", gotBytes, want)
+			}
+
+			s, err := EncodeI128Base64(want)
+			if err != nil {
+				t.Fatalf("EncodeI128Base64: %v", err)
+			}
+			gotB64, err := DecodeI128Base64(s)
+			if err != nil {
+				t.Fatalf("DecodeI128Base64: %v", err)
+			}
+			if gotB64.Cmp(want) != 0 {
+				t.Fatalf("base64 round-trip: got %s want %s", gotB64, want)
+			}
+		})
+	}
+}
+
+func TestI128RejectsOutOfRange(t *testing.T) {
+	cases := []struct {
+		name  string
+		value *big.Int
+	}{
+		{"max i128 plus one", new(big.Int).Add(MaxI128, big.NewInt(1))},
+		{"min i128 minus one", new(big.Int).Sub(MinI128, big.NewInt(1))},
+		{"far above range", new(big.Int).Mul(MaxI128, big.NewInt(4))},
+		{"far below range", new(big.Int).Mul(MinI128, big.NewInt(4))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := EncodeI128(tc.value); !errors.Is(err, ErrI128OutOfRange) {
+				t.Fatalf("expected ErrI128OutOfRange, got %v", err)
+			}
+			if _, err := EncodeI128Bytes(tc.value); !errors.Is(err, ErrI128OutOfRange) {
+				t.Fatalf("bytes: expected ErrI128OutOfRange, got %v", err)
+			}
+		})
+	}
+}
+
+func TestI128RejectsNil(t *testing.T) {
+	if _, err := EncodeI128(nil); !errors.Is(err, ErrI128OutOfRange) {
+		t.Fatalf("expected ErrI128OutOfRange for nil, got %v", err)
+	}
+}
+
+func TestI128NegativeLimbEncoding(t *testing.T) {
+	parts, err := EncodeI128(big.NewInt(-1))
+	if err != nil {
+		t.Fatalf("EncodeI128(-1): %v", err)
+	}
+	if parts.Hi != ^uint64(0) || parts.Lo != ^uint64(0) {
+		t.Fatalf("-1 should be all ones, got hi=%d lo=%d", parts.Hi, parts.Lo)
+	}
+}
+
+func TestU128RoundTrip(t *testing.T) {
+	cases := []string{
+		"0",
+		"1",
+		"18446744073709551615",
+		"18446744073709551616",
+		"340282366920938463463374607431768211455",
+	}
+
+	for _, c := range cases {
+		want := mustBig(t, c)
+		parts, err := EncodeU128(want)
+		if err != nil {
+			t.Fatalf("EncodeU128(%s): %v", c, err)
+		}
+		if got := DecodeU128(parts); got.Cmp(want) != 0 {
+			t.Fatalf("u128 round-trip: got %s want %s", got, want)
+		}
+	}
+}
+
+func TestU128RejectsOutOfRange(t *testing.T) {
+	if _, err := EncodeU128(big.NewInt(-1)); !errors.Is(err, ErrU128OutOfRange) {
+		t.Fatalf("expected ErrU128OutOfRange for -1, got %v", err)
+	}
+	over := new(big.Int).Add(MaxU128, big.NewInt(1))
+	if _, err := EncodeU128(over); !errors.Is(err, ErrU128OutOfRange) {
+		t.Fatalf("expected ErrU128OutOfRange for 2^128, got %v", err)
+	}
+	if _, err := EncodeU128(nil); !errors.Is(err, ErrU128OutOfRange) {
+		t.Fatalf("expected ErrU128OutOfRange for nil, got %v", err)
+	}
+}
+
+func TestDecodeI128BytesRejectsWrongLength(t *testing.T) {
+	for _, n := range []int{0, 1, 15, 17, 32} {
+		if _, err := DecodeI128Bytes(make([]byte, n)); err == nil {
+			t.Fatalf("expected error for %d-byte input", n)
+		}
+	}
+}
+
+func TestDecodeI128Base64RejectsGarbage(t *testing.T) {
+	if _, err := DecodeI128Base64("!!!not base64!!!"); err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}

--- a/packages/go-sdk/scvalue.go
+++ b/packages/go-sdk/scvalue.go
@@ -1,0 +1,442 @@
+package gosdk
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// ErrScValue is returned when a value cannot be encoded to, or decoded from,
+// the Soroban ScVal representation.
+var ErrScValue = errors.New("scval")
+
+// ScVal discriminants, from the Soroban XDR definition. Only the subset the AMM
+// contracts use is implemented.
+const (
+	scvBool          int32 = 0
+	scvVoid          int32 = 1
+	scvError         int32 = 2
+	scvU32           int32 = 3
+	scvI32           int32 = 4
+	scvU64           int32 = 5
+	scvI64           int32 = 6
+	scvU128          int32 = 9
+	scvI128          int32 = 10
+	scvBytes         int32 = 14
+	scvString        int32 = 15
+	scvSymbol        int32 = 16
+	scvVec           int32 = 17
+	scvMap           int32 = 18
+	scvAddress       int32 = 19
+	scoAccount       int32 = 0
+	scoContract      int32 = 1
+	scAddressAccount int32 = 0
+	scAddressCntrct  int32 = 1
+)
+
+// ScValue is a typed Soroban contract value. Exactly one field is meaningful,
+// selected by Type.
+type ScValue struct {
+	// Type is the ScVal discriminant.
+	Type int32
+	// Bool holds the value when Type is a boolean.
+	Bool bool
+	// U32 holds the value when Type is u32.
+	U32 uint32
+	// I32 holds the value when Type is i32.
+	I32 int32
+	// U64 holds the value when Type is u64.
+	U64 uint64
+	// I64 holds the value when Type is i64.
+	I64 int64
+	// Int holds the value when Type is i128 or u128.
+	Int *big.Int
+	// Bytes holds the value when Type is bytes.
+	Bytes []byte
+	// Str holds the value when Type is string or symbol.
+	Str string
+	// Addr holds the strkey when Type is address.
+	Addr string
+	// Vec holds the elements when Type is vec.
+	Vec []ScValue
+	// Map holds the entries when Type is map, in key order.
+	Map []ScMapEntry
+}
+
+// ScMapEntry is one key/value pair of an ScVal map.
+type ScMapEntry struct {
+	// Key is the entry's key.
+	Key ScValue
+	// Val is the entry's value.
+	Val ScValue
+}
+
+// Bool returns a boolean ScValue.
+func Bool(v bool) ScValue { return ScValue{Type: scvBool, Bool: v} }
+
+// Void returns the unit ScValue.
+func Void() ScValue { return ScValue{Type: scvVoid} }
+
+// U32 returns a u32 ScValue.
+func U32(v uint32) ScValue { return ScValue{Type: scvU32, U32: v} }
+
+// I32 returns an i32 ScValue.
+func I32(v int32) ScValue { return ScValue{Type: scvI32, I32: v} }
+
+// U64 returns a u64 ScValue.
+func U64(v uint64) ScValue { return ScValue{Type: scvU64, U64: v} }
+
+// I64 returns an i64 ScValue.
+func I64(v int64) ScValue { return ScValue{Type: scvI64, I64: v} }
+
+// I128 returns an i128 ScValue. The value is range-checked at encode time.
+func I128(v *big.Int) ScValue { return ScValue{Type: scvI128, Int: v} }
+
+// U128 returns a u128 ScValue. The value is range-checked at encode time.
+func U128(v *big.Int) ScValue { return ScValue{Type: scvU128, Int: v} }
+
+// Bytes returns a bytes ScValue.
+func Bytes(v []byte) ScValue { return ScValue{Type: scvBytes, Bytes: v} }
+
+// Str returns a string ScValue.
+func Str(v string) ScValue { return ScValue{Type: scvString, Str: v} }
+
+// Symbol returns a symbol ScValue. Symbols name contract functions and struct
+// fields.
+func Symbol(v string) ScValue { return ScValue{Type: scvSymbol, Str: v} }
+
+// Vec returns a vec ScValue.
+func Vec(items ...ScValue) ScValue { return ScValue{Type: scvVec, Vec: items} }
+
+// Map returns a map ScValue.
+func Map(entries ...ScMapEntry) ScValue { return ScValue{Type: scvMap, Map: entries} }
+
+// Addr returns an address ScValue from a G... account or C... contract strkey.
+func Addr(strkey string) ScValue { return ScValue{Type: scvAddress, Addr: strkey} }
+
+// EncodeScVal serialises an ScValue to XDR.
+func EncodeScVal(v ScValue) ([]byte, error) {
+	var w xdrWriter
+	if err := writeScVal(&w, v); err != nil {
+		return nil, err
+	}
+	return w.bytes(), nil
+}
+
+// EncodeScValBase64 serialises an ScValue to base64-encoded XDR, the form the
+// JSON-RPC layer carries.
+func EncodeScValBase64(v ScValue) (string, error) {
+	b, err := EncodeScVal(v)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// DecodeScVal parses an ScValue from XDR.
+func DecodeScVal(b []byte) (ScValue, error) {
+	r := &xdrReader{buf: b}
+	v, err := readScVal(r)
+	if err != nil {
+		return ScValue{}, err
+	}
+	return v, nil
+}
+
+// DecodeScValBase64 parses an ScValue from base64-encoded XDR.
+func DecodeScValBase64(s string) (ScValue, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return ScValue{}, fmt.Errorf("%w: invalid base64: %v", ErrScValue, err)
+	}
+	return DecodeScVal(b)
+}
+
+func writeScVal(w *xdrWriter, v ScValue) error {
+	w.writeInt32(v.Type)
+
+	switch v.Type {
+	case scvBool:
+		w.writeBool(v.Bool)
+	case scvVoid:
+	case scvU32:
+		w.writeUint32(v.U32)
+	case scvI32:
+		w.writeInt32(v.I32)
+	case scvU64:
+		w.writeUint64(v.U64)
+	case scvI64:
+		w.writeInt64(v.I64)
+	case scvI128:
+		p, err := EncodeI128(v.Int)
+		if err != nil {
+			return err
+		}
+		// i128 is encoded high limb first, as { hi: int64, lo: uint64 }.
+		w.writeUint64(p.Hi)
+		w.writeUint64(p.Lo)
+	case scvU128:
+		p, err := EncodeU128(v.Int)
+		if err != nil {
+			return err
+		}
+		w.writeUint64(p.Hi)
+		w.writeUint64(p.Lo)
+	case scvBytes:
+		w.writeBytes(v.Bytes)
+	case scvString:
+		w.writeBytes([]byte(v.Str))
+	case scvSymbol:
+		if len(v.Str) > 32 {
+			return fmt.Errorf("%w: symbol %q exceeds 32 characters", ErrScValue, v.Str)
+		}
+		w.writeBytes([]byte(v.Str))
+	case scvVec:
+		// A vec is an optional array; a present vec writes 1 then the array.
+		w.writeUint32(1)
+		w.writeUint32(uint32(len(v.Vec)))
+		for _, item := range v.Vec {
+			if err := writeScVal(w, item); err != nil {
+				return err
+			}
+		}
+	case scvMap:
+		w.writeUint32(1)
+		w.writeUint32(uint32(len(v.Map)))
+		for _, e := range v.Map {
+			if err := writeScVal(w, e.Key); err != nil {
+				return err
+			}
+			if err := writeScVal(w, e.Val); err != nil {
+				return err
+			}
+		}
+	case scvAddress:
+		return writeScAddress(w, v.Addr)
+	default:
+		return fmt.Errorf("%w: unsupported type %d for encoding", ErrScValue, v.Type)
+	}
+	return nil
+}
+
+func writeScAddress(w *xdrWriter, strkey string) error {
+	raw, kind, err := DecodeStrkey(strkey)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case StrkeyAccount:
+		w.writeInt32(scAddressAccount)
+		// PublicKey is itself a union discriminated on key type.
+		w.writeInt32(scoAccount)
+		w.writeRaw(raw)
+	case StrkeyContract:
+		w.writeInt32(scAddressCntrct)
+		w.writeRaw(raw)
+	default:
+		return fmt.Errorf("%w: address %q is neither an account nor a contract", ErrScValue, strkey)
+	}
+	return nil
+}
+
+func readScVal(r *xdrReader) (ScValue, error) {
+	t, err := r.readInt32()
+	if err != nil {
+		return ScValue{}, err
+	}
+	v := ScValue{Type: t}
+
+	switch t {
+	case scvBool:
+		b, err := r.readUint32()
+		if err != nil {
+			return ScValue{}, err
+		}
+		v.Bool = b != 0
+	case scvVoid:
+	case scvU32:
+		if v.U32, err = r.readUint32(); err != nil {
+			return ScValue{}, err
+		}
+	case scvI32:
+		if v.I32, err = r.readInt32(); err != nil {
+			return ScValue{}, err
+		}
+	case scvU64:
+		if v.U64, err = r.readUint64(); err != nil {
+			return ScValue{}, err
+		}
+	case scvI64:
+		u, err := r.readUint64()
+		if err != nil {
+			return ScValue{}, err
+		}
+		v.I64 = int64(u)
+	case scvI128, scvU128:
+		hi, err := r.readUint64()
+		if err != nil {
+			return ScValue{}, err
+		}
+		lo, err := r.readUint64()
+		if err != nil {
+			return ScValue{}, err
+		}
+		if t == scvI128 {
+			v.Int = DecodeI128(Parts128{Hi: hi, Lo: lo})
+		} else {
+			v.Int = DecodeU128(Parts128{Hi: hi, Lo: lo})
+		}
+	case scvBytes:
+		if v.Bytes, err = r.readBytes(); err != nil {
+			return ScValue{}, err
+		}
+	case scvString, scvSymbol:
+		b, err := r.readBytes()
+		if err != nil {
+			return ScValue{}, err
+		}
+		v.Str = string(b)
+	case scvVec:
+		present, err := r.readUint32()
+		if err != nil {
+			return ScValue{}, err
+		}
+		if present == 0 {
+			return v, nil
+		}
+		n, err := r.readLength()
+		if err != nil {
+			return ScValue{}, err
+		}
+		v.Vec = make([]ScValue, 0, n)
+		for i := uint32(0); i < n; i++ {
+			item, err := readScVal(r)
+			if err != nil {
+				return ScValue{}, err
+			}
+			v.Vec = append(v.Vec, item)
+		}
+	case scvMap:
+		present, err := r.readUint32()
+		if err != nil {
+			return ScValue{}, err
+		}
+		if present == 0 {
+			return v, nil
+		}
+		n, err := r.readLength()
+		if err != nil {
+			return ScValue{}, err
+		}
+		v.Map = make([]ScMapEntry, 0, n)
+		for i := uint32(0); i < n; i++ {
+			k, err := readScVal(r)
+			if err != nil {
+				return ScValue{}, err
+			}
+			val, err := readScVal(r)
+			if err != nil {
+				return ScValue{}, err
+			}
+			v.Map = append(v.Map, ScMapEntry{Key: k, Val: val})
+		}
+	case scvAddress:
+		if v.Addr, err = readScAddress(r); err != nil {
+			return ScValue{}, err
+		}
+	case scvError:
+		// Error values are surfaced through DecodeContractError, not here.
+		return ScValue{}, fmt.Errorf("%w: value is a contract error", ErrScValue)
+	default:
+		return ScValue{}, fmt.Errorf("%w: unsupported type %d for decoding", ErrScValue, t)
+	}
+	return v, nil
+}
+
+func readScAddress(r *xdrReader) (string, error) {
+	kind, err := r.readInt32()
+	if err != nil {
+		return "", err
+	}
+	switch kind {
+	case scAddressAccount:
+		if _, err := r.readInt32(); err != nil { // PublicKey type
+			return "", err
+		}
+		raw, err := r.readRaw(32)
+		if err != nil {
+			return "", err
+		}
+		return EncodeStrkey(raw, StrkeyAccount)
+	case scAddressCntrct:
+		raw, err := r.readRaw(32)
+		if err != nil {
+			return "", err
+		}
+		return EncodeStrkey(raw, StrkeyContract)
+	default:
+		return "", fmt.Errorf("%w: unknown address kind %d", ErrScValue, kind)
+	}
+}
+
+// MapField returns the value stored under a symbol key in a map ScValue.
+// Contract structs are transmitted as maps keyed by their field names.
+func (v ScValue) MapField(name string) (ScValue, bool) {
+	if v.Type != scvMap {
+		return ScValue{}, false
+	}
+	for _, e := range v.Map {
+		if e.Key.Type == scvSymbol && e.Key.Str == name {
+			return e.Val, true
+		}
+	}
+	return ScValue{}, false
+}
+
+// BigInt returns the value as a *big.Int for any integer ScValue type.
+func (v ScValue) BigInt() (*big.Int, error) {
+	switch v.Type {
+	case scvI128, scvU128:
+		if v.Int == nil {
+			return nil, fmt.Errorf("%w: 128-bit value is nil", ErrScValue)
+		}
+		return new(big.Int).Set(v.Int), nil
+	case scvU32:
+		return new(big.Int).SetUint64(uint64(v.U32)), nil
+	case scvI32:
+		return big.NewInt(int64(v.I32)), nil
+	case scvU64:
+		return new(big.Int).SetUint64(v.U64), nil
+	case scvI64:
+		return big.NewInt(v.I64), nil
+	default:
+		return nil, fmt.Errorf("%w: type %d is not an integer", ErrScValue, v.Type)
+	}
+}
+
+// Address returns the strkey of an address ScValue.
+func (v ScValue) Address() (string, error) {
+	if v.Type != scvAddress {
+		return "", fmt.Errorf("%w: type %d is not an address", ErrScValue, v.Type)
+	}
+	return v.Addr, nil
+}
+
+// mapFieldBigInt reads a named struct field and converts it to a *big.Int.
+func mapFieldBigInt(v ScValue, name string) (*big.Int, error) {
+	f, ok := v.MapField(name)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing field %q", ErrScValue, name)
+	}
+	return f.BigInt()
+}
+
+// mapFieldAddress reads a named struct field and converts it to a strkey.
+func mapFieldAddress(v ScValue, name string) (string, error) {
+	f, ok := v.MapField(name)
+	if !ok {
+		return "", fmt.Errorf("%w: missing field %q", ErrScValue, name)
+	}
+	return f.Address()
+}

--- a/packages/go-sdk/scvalue_test.go
+++ b/packages/go-sdk/scvalue_test.go
@@ -1,0 +1,308 @@
+package gosdk
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+)
+
+// Independently-known strkeys. The account is the all-zero ed25519 account id,
+// whose textual form is fixed by the strkey spec, so decoding it exercises the
+// checksum against a literal this package did not generate.
+const (
+	zeroAccount  = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+	zeroContract = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"
+)
+
+func TestStrkeyDecodesKnownAccount(t *testing.T) {
+	raw, kind, err := DecodeStrkey(zeroAccount)
+	if err != nil {
+		t.Fatalf("DecodeStrkey: %v", err)
+	}
+	if kind != StrkeyAccount {
+		t.Fatalf("kind = %v, want StrkeyAccount", kind)
+	}
+	if len(raw) != 32 {
+		t.Fatalf("payload is %d bytes, want 32", len(raw))
+	}
+	for i, b := range raw {
+		if b != 0 {
+			t.Fatalf("byte %d = %d, want 0", i, b)
+		}
+	}
+}
+
+func TestStrkeyRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		addr string
+		kind StrkeyKind
+	}{
+		{zeroAccount, StrkeyAccount},
+		{zeroContract, StrkeyContract},
+	} {
+		raw, kind, err := DecodeStrkey(tc.addr)
+		if err != nil {
+			t.Fatalf("DecodeStrkey(%s): %v", tc.addr, err)
+		}
+		if kind != tc.kind {
+			t.Fatalf("kind = %v, want %v", kind, tc.kind)
+		}
+		back, err := EncodeStrkey(raw, kind)
+		if err != nil {
+			t.Fatalf("EncodeStrkey: %v", err)
+		}
+		if back != tc.addr {
+			t.Fatalf("round-trip = %q, want %q", back, tc.addr)
+		}
+	}
+}
+
+func TestStrkeyRejectsBadInput(t *testing.T) {
+	// Flip one character of a valid address; the checksum must catch it.
+	corrupt := []byte(zeroAccount)
+	corrupt[10] = 'B'
+	cases := map[string]string{
+		"empty":           "",
+		"not base32":      "G!!!",
+		"too short":       zeroAccount[:40],
+		"bad checksum":    string(corrupt),
+		"truncated by 1":  zeroAccount[:55],
+		"unknown version": "MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+	}
+	for name, addr := range cases {
+		if _, _, err := DecodeStrkey(addr); err == nil {
+			t.Fatalf("%s: expected an error for %q", name, addr)
+		}
+	}
+}
+
+func TestEncodeStrkeyRejectsWrongLength(t *testing.T) {
+	if _, err := EncodeStrkey(make([]byte, 31), StrkeyAccount); err == nil {
+		t.Fatal("expected an error for a 31-byte payload")
+	}
+	if _, err := EncodeStrkey(make([]byte, 32), StrkeyUnknown); err == nil {
+		t.Fatal("expected an error for an unknown strkey kind")
+	}
+}
+
+func TestIsAddressHelpers(t *testing.T) {
+	if !IsAccountAddress(zeroAccount) {
+		t.Fatal("zeroAccount should be an account address")
+	}
+	if IsContractAddress(zeroAccount) {
+		t.Fatal("zeroAccount is not a contract address")
+	}
+	if !IsContractAddress(zeroContract) {
+		t.Fatal("zeroContract should be a contract address")
+	}
+	if IsAccountAddress("G-not-base32-and-too-short") {
+		t.Fatal("malformed input should not pass IsAccountAddress")
+	}
+	if IsAccountAddress(zeroAccount[:55] + "1") {
+		t.Fatal("'1' is not in the base32 alphabet")
+	}
+}
+
+func TestScValRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		val  ScValue
+	}{
+		{"bool true", Bool(true)},
+		{"bool false", Bool(false)},
+		{"void", Void()},
+		{"u32", U32(4_294_967_295)},
+		{"i32 negative", I32(-2_147_483_648)},
+		{"u64", U64(18_446_744_073_709_551_615)},
+		{"i64 negative", I64(-9_223_372_036_854_775_808)},
+		{"i128 max", I128(new(big.Int).Set(MaxI128))},
+		{"i128 min", I128(new(big.Int).Set(MinI128))},
+		{"i128 negative", I128(big.NewInt(-42))},
+		{"u128 max", U128(new(big.Int).Set(MaxU128))},
+		{"bytes", Bytes([]byte{0x00, 0xff, 0x10})},
+		{"bytes empty", Bytes(nil)},
+		{"string", Str("hello world")},
+		{"symbol", Symbol("get_info")},
+		{"account address", Addr(zeroAccount)},
+		{"contract address", Addr(zeroContract)},
+		{"vec", Vec(U32(1), Str("two"), I128(big.NewInt(3)))},
+		{"vec empty", Vec()},
+		{"nested vec", Vec(Vec(U32(1), U32(2)), Vec())},
+		{"map", Map(
+			ScMapEntry{Key: Symbol("amount_out"), Val: I128(big.NewInt(999))},
+			ScMapEntry{Key: Symbol("token_a"), Val: Addr(zeroContract)},
+		)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := EncodeScValBase64(tc.val)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			got, err := DecodeScValBase64(encoded)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			assertScValEqual(t, got, tc.val)
+		})
+	}
+}
+
+func TestEncodeScValRejectsBadValues(t *testing.T) {
+	over := new(big.Int).Add(MaxI128, big.NewInt(1))
+	if _, err := EncodeScVal(I128(over)); !errors.Is(err, ErrI128OutOfRange) {
+		t.Fatalf("expected ErrI128OutOfRange, got %v", err)
+	}
+	if _, err := EncodeScVal(U128(big.NewInt(-1))); !errors.Is(err, ErrU128OutOfRange) {
+		t.Fatalf("expected ErrU128OutOfRange, got %v", err)
+	}
+	if _, err := EncodeScVal(Symbol("this_symbol_is_far_too_long_to_fit_in_32_chars")); err == nil {
+		t.Fatal("expected an error for an over-long symbol")
+	}
+	if _, err := EncodeScVal(Addr("not-an-address")); err == nil {
+		t.Fatal("expected an error for a malformed address")
+	}
+	if _, err := EncodeScVal(ScValue{Type: 99}); !errors.Is(err, ErrScValue) {
+		t.Fatalf("expected ErrScValue for an unsupported type, got %v", err)
+	}
+}
+
+func TestDecodeScValRejectsTruncatedBuffer(t *testing.T) {
+	encoded, err := EncodeScVal(I128(big.NewInt(1234)))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	for n := 1; n < len(encoded); n++ {
+		if _, err := DecodeScVal(encoded[:n]); err == nil {
+			t.Fatalf("expected an error decoding %d of %d bytes", n, len(encoded))
+		}
+	}
+	if _, err := DecodeScValBase64("!!!"); !errors.Is(err, ErrScValue) {
+		t.Fatalf("expected ErrScValue for invalid base64, got %v", err)
+	}
+}
+
+func TestScValAccessors(t *testing.T) {
+	m := Map(
+		ScMapEntry{Key: Symbol("amount"), Val: I128(big.NewInt(7))},
+		ScMapEntry{Key: Symbol("who"), Val: Addr(zeroAccount)},
+	)
+
+	amount, err := mapFieldBigInt(m, "amount")
+	if err != nil {
+		t.Fatalf("mapFieldBigInt: %v", err)
+	}
+	if amount.Int64() != 7 {
+		t.Fatalf("amount = %s, want 7", amount)
+	}
+
+	who, err := mapFieldAddress(m, "who")
+	if err != nil {
+		t.Fatalf("mapFieldAddress: %v", err)
+	}
+	if who != zeroAccount {
+		t.Fatalf("who = %q, want %q", who, zeroAccount)
+	}
+
+	if _, err := mapFieldBigInt(m, "missing"); err == nil {
+		t.Fatal("expected an error for a missing field")
+	}
+	if _, err := mapFieldAddress(m, "amount"); err == nil {
+		t.Fatal("expected an error reading an integer field as an address")
+	}
+	if _, ok := U32(1).MapField("anything"); ok {
+		t.Fatal("MapField on a non-map should report not-found")
+	}
+	if _, err := Str("x").BigInt(); err == nil {
+		t.Fatal("expected an error converting a string to an integer")
+	}
+
+	// Every integer width converts through BigInt.
+	for _, tc := range []struct {
+		val  ScValue
+		want int64
+	}{
+		{U32(5), 5},
+		{I32(-5), -5},
+		{U64(6), 6},
+		{I64(-6), -6},
+		{I128(big.NewInt(-7)), -7},
+	} {
+		got, err := tc.val.BigInt()
+		if err != nil {
+			t.Fatalf("BigInt: %v", err)
+		}
+		if got.Int64() != tc.want {
+			t.Fatalf("BigInt = %s, want %d", got, tc.want)
+		}
+	}
+}
+
+// assertScValEqual compares two ScValues structurally, so a round-trip failure
+// points at the field that differs.
+func assertScValEqual(t *testing.T, got, want ScValue) {
+	t.Helper()
+
+	if got.Type != want.Type {
+		t.Fatalf("type = %d, want %d", got.Type, want.Type)
+	}
+	switch want.Type {
+	case scvBool:
+		if got.Bool != want.Bool {
+			t.Fatalf("bool = %v, want %v", got.Bool, want.Bool)
+		}
+	case scvU32:
+		if got.U32 != want.U32 {
+			t.Fatalf("u32 = %d, want %d", got.U32, want.U32)
+		}
+	case scvI32:
+		if got.I32 != want.I32 {
+			t.Fatalf("i32 = %d, want %d", got.I32, want.I32)
+		}
+	case scvU64:
+		if got.U64 != want.U64 {
+			t.Fatalf("u64 = %d, want %d", got.U64, want.U64)
+		}
+	case scvI64:
+		if got.I64 != want.I64 {
+			t.Fatalf("i64 = %d, want %d", got.I64, want.I64)
+		}
+	case scvI128, scvU128:
+		if got.Int.Cmp(want.Int) != 0 {
+			t.Fatalf("128-bit = %s, want %s", got.Int, want.Int)
+		}
+	case scvBytes:
+		if len(got.Bytes) != len(want.Bytes) {
+			t.Fatalf("bytes length = %d, want %d", len(got.Bytes), len(want.Bytes))
+		}
+		for i := range want.Bytes {
+			if got.Bytes[i] != want.Bytes[i] {
+				t.Fatalf("byte %d = %d, want %d", i, got.Bytes[i], want.Bytes[i])
+			}
+		}
+	case scvString, scvSymbol:
+		if got.Str != want.Str {
+			t.Fatalf("string = %q, want %q", got.Str, want.Str)
+		}
+	case scvAddress:
+		if got.Addr != want.Addr {
+			t.Fatalf("address = %q, want %q", got.Addr, want.Addr)
+		}
+	case scvVec:
+		if len(got.Vec) != len(want.Vec) {
+			t.Fatalf("vec length = %d, want %d", len(got.Vec), len(want.Vec))
+		}
+		for i := range want.Vec {
+			assertScValEqual(t, got.Vec[i], want.Vec[i])
+		}
+	case scvMap:
+		if len(got.Map) != len(want.Map) {
+			t.Fatalf("map length = %d, want %d", len(got.Map), len(want.Map))
+		}
+		for i := range want.Map {
+			assertScValEqual(t, got.Map[i].Key, want.Map[i].Key)
+			assertScValEqual(t, got.Map[i].Val, want.Map[i].Val)
+		}
+	}
+}

--- a/packages/go-sdk/signer.go
+++ b/packages/go-sdk/signer.go
@@ -1,0 +1,77 @@
+package gosdk
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// Signer signs transaction envelopes. It is an interface so callers can back it
+// with a local keypair, an HSM, or a remote signing service; the client never
+// holds a raw secret key.
+type Signer interface {
+	// Address returns the signer's account address (a G... strkey).
+	Address() string
+	// SignEnvelope signs a base64-encoded transaction envelope XDR for the
+	// given network passphrase and returns the signed envelope, also base64.
+	SignEnvelope(ctx context.Context, envelopeXDR string, networkPassphrase string) (string, error)
+}
+
+// ErrSignerAddress is returned when a Signer reports an address that is not a
+// plausible Stellar account.
+var ErrSignerAddress = errors.New("signer address is not a valid account address")
+
+// SignerFunc adapts a function to the Signer interface, pairing it with a fixed
+// address.
+type SignerFunc struct {
+	// Addr is the account address the signing function signs for.
+	Addr string
+	// Sign performs the signing.
+	Sign func(ctx context.Context, envelopeXDR string, networkPassphrase string) (string, error)
+}
+
+// Address returns the configured address.
+func (s SignerFunc) Address() string { return s.Addr }
+
+// SignEnvelope calls the configured signing function.
+func (s SignerFunc) SignEnvelope(ctx context.Context, envelopeXDR string, networkPassphrase string) (string, error) {
+	if s.Sign == nil {
+		return "", ErrNoSigner
+	}
+	return s.Sign(ctx, envelopeXDR, networkPassphrase)
+}
+
+// ValidateSigner checks that a Signer reports a well-formed account address.
+func ValidateSigner(s Signer) error {
+	if s == nil {
+		return ErrNoSigner
+	}
+	if !IsAccountAddress(s.Address()) {
+		return ErrSignerAddress
+	}
+	return nil
+}
+
+// IsAccountAddress reports whether addr looks like a Stellar account strkey:
+// 56 characters beginning with G.
+func IsAccountAddress(addr string) bool {
+	return len(addr) == 56 && strings.HasPrefix(addr, "G") && isBase32Upper(addr)
+}
+
+// IsContractAddress reports whether addr looks like a Soroban contract strkey:
+// 56 characters beginning with C.
+func IsContractAddress(addr string) bool {
+	return len(addr) == 56 && strings.HasPrefix(addr, "C") && isBase32Upper(addr)
+}
+
+func isBase32Upper(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= '2' && r <= '7':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/packages/go-sdk/types.go
+++ b/packages/go-sdk/types.go
@@ -1,0 +1,170 @@
+package gosdk
+
+import (
+	"math/big"
+	"time"
+)
+
+// Config configures a Client. RPCURL and NetworkPassphrase are required.
+type Config struct {
+	// RPCURL is the Soroban JSON-RPC endpoint, e.g.
+	// https://soroban-testnet.stellar.org.
+	RPCURL string
+	// NetworkPassphrase identifies the network, e.g.
+	// "Test SDF Network ; September 2015".
+	NetworkPassphrase string
+	// Timeout bounds a single RPC round trip. Defaults to DefaultTimeout when
+	// zero. Ignored if HTTPClient is supplied with its own timeout.
+	Timeout time.Duration
+	// SourceAccount is the account used to build simulation transactions. Read
+	// methods never submit, so this account is not charged and need not be the
+	// signer. Defaults to DefaultSimulationAccount.
+	SourceAccount string
+	// Signer signs write transactions. Read methods work without one; write
+	// methods return ErrNoSigner if it is nil.
+	Signer Signer
+}
+
+// Network passphrases for the public networks.
+const (
+	// NetworkTestnet is the Stellar testnet passphrase.
+	NetworkTestnet = "Test SDF Network ; September 2015"
+	// NetworkPublic is the Stellar public network passphrase.
+	NetworkPublic = "Public Global Stellar Network ; September 2015"
+	// NetworkFuturenet is the Stellar futurenet passphrase.
+	NetworkFuturenet = "Test SDF Future Network ; October 2022"
+)
+
+// DefaultTimeout bounds a single RPC round trip when Config.Timeout is zero.
+const DefaultTimeout = 30 * time.Second
+
+// DefaultSimulationAccount is the null account used to build simulation
+// transactions when Config.SourceAccount is empty. Simulation neither consumes
+// its sequence number nor charges it, so the all-zero account id is safe here
+// and avoids depending on any funded account existing.
+//
+// Note: packages/sdk hardcodes a 55-character string for the same purpose,
+// which is one character short of a valid strkey. Do not copy it here.
+const DefaultSimulationAccount = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+
+// PoolInfo mirrors the contract's PoolInfo struct
+// (contracts/amm/src/lib.rs). Field names follow Go convention; the
+// wire-format keys are the snake_case names from the contract.
+type PoolInfo struct {
+	// TokenA is the first pool token's contract address.
+	TokenA string
+	// TokenB is the second pool token's contract address.
+	TokenB string
+	// ReserveA is the current reserve of TokenA.
+	ReserveA *big.Int
+	// ReserveB is the current reserve of TokenB.
+	ReserveB *big.Int
+	// TotalShares is the total supply of LP shares.
+	TotalShares *big.Int
+	// FeeBps is the total swap fee in basis points.
+	FeeBps *big.Int
+	// FlashLoanFeeBps is the flash loan fee in basis points.
+	FlashLoanFeeBps *big.Int
+	// Admin is the pool administrator's address.
+	Admin string
+	// FeeRecipient receives the protocol's share of fees.
+	FeeRecipient string
+	// ProtocolFeeBps is the protocol's cut, in basis points, of FeeBps.
+	ProtocolFeeBps *big.Int
+	// LpRebateBps is the fraction of the protocol fee rebated to LP reserves.
+	LpRebateBps *big.Int
+}
+
+// SwapQuote mirrors the contract's SwapSimulation struct
+// (contracts/amm/src/lib.rs).
+type SwapQuote struct {
+	// AmountOut is the tokens received for the quoted input.
+	AmountOut *big.Int
+	// FeeAmount is the fee deducted from the input.
+	FeeAmount *big.Int
+	// PriceImpactBps is the price impact in basis points.
+	PriceImpactBps *big.Int
+	// EffectivePrice is amount_out/amount_in scaled by 1_000_000.
+	EffectivePrice *big.Int
+	// SpotPrice is reserve_out/reserve_in scaled by 1_000_000.
+	SpotPrice *big.Int
+}
+
+// Reserves is the pair of pool reserves returned by GetReserves.
+type Reserves struct {
+	// ReserveA is the current reserve of the pool's first token.
+	ReserveA *big.Int
+	// ReserveB is the current reserve of the pool's second token.
+	ReserveB *big.Int
+}
+
+// SwapParams are the arguments to Client.Swap. Deadline and MinOut are safety
+// parameters and are never defaulted.
+type SwapParams struct {
+	// PoolID is the AMM pool contract address.
+	PoolID string
+	// Trader is the address whose tokens are swapped; it must match the Signer.
+	Trader string
+	// TokenIn is the contract address of the token being sold.
+	TokenIn string
+	// AmountIn is the quantity of TokenIn to sell.
+	AmountIn *big.Int
+	// MinOut is the slippage bound: the swap reverts with ErrSlippageExceeded
+	// if the output would fall below it.
+	MinOut *big.Int
+	// Deadline is a ledger timestamp (seconds); the swap reverts with
+	// ErrDeadlineExceeded once it passes.
+	Deadline uint64
+}
+
+// AddLiquidityParams are the arguments to Client.AddLiquidity.
+type AddLiquidityParams struct {
+	// PoolID is the AMM pool contract address.
+	PoolID string
+	// Provider is the liquidity provider's address; it must match the Signer.
+	Provider string
+	// AmountA is the desired deposit of the pool's first token.
+	AmountA *big.Int
+	// AmountB is the desired deposit of the pool's second token.
+	AmountB *big.Int
+	// MinShares is the slippage bound on minted LP shares.
+	MinShares *big.Int
+	// Deadline is a ledger timestamp (seconds).
+	Deadline uint64
+}
+
+// RemoveLiquidityParams are the arguments to Client.RemoveLiquidity.
+type RemoveLiquidityParams struct {
+	// PoolID is the AMM pool contract address.
+	PoolID string
+	// Provider is the liquidity provider's address; it must match the Signer.
+	Provider string
+	// Shares is the quantity of LP shares to burn.
+	Shares *big.Int
+	// MinA is the slippage bound on the first token returned.
+	MinA *big.Int
+	// MinB is the slippage bound on the second token returned.
+	MinB *big.Int
+	// Deadline is a ledger timestamp (seconds).
+	Deadline uint64
+}
+
+// LiquidityResult is the pair of token amounts returned by RemoveLiquidity.
+type LiquidityResult struct {
+	// AmountA is the quantity of the first token returned.
+	AmountA *big.Int
+	// AmountB is the quantity of the second token returned.
+	AmountB *big.Int
+}
+
+// TxResult describes a submitted transaction that reached a terminal status.
+type TxResult struct {
+	// Hash is the transaction hash.
+	Hash string
+	// Status is the terminal status reported by the RPC endpoint, normally
+	// "SUCCESS".
+	Status string
+	// ReturnValue is the base64 XDR of the invocation's return value, when the
+	// endpoint supplies one.
+	ReturnValue string
+}

--- a/packages/go-sdk/xdr.go
+++ b/packages/go-sdk/xdr.go
@@ -1,0 +1,209 @@
+package gosdk
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrXDR is returned when an XDR buffer is malformed or truncated.
+var ErrXDR = errors.New("xdr")
+
+// xdrWriter accumulates big-endian XDR, padding every opaque field to a
+// four-byte boundary as the format requires.
+type xdrWriter struct {
+	buf []byte
+}
+
+func (w *xdrWriter) writeUint32(v uint32) {
+	w.buf = append(w.buf, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+func (w *xdrWriter) writeInt32(v int32) { w.writeUint32(uint32(v)) }
+
+func (w *xdrWriter) writeUint64(v uint64) {
+	w.writeUint32(uint32(v >> 32))
+	w.writeUint32(uint32(v))
+}
+
+func (w *xdrWriter) writeInt64(v int64) { w.writeUint64(uint64(v)) }
+
+func (w *xdrWriter) writeBool(v bool) {
+	if v {
+		w.writeUint32(1)
+		return
+	}
+	w.writeUint32(0)
+}
+
+// writeBytes writes a variable-length opaque field: length then contents,
+// padded to four bytes.
+func (w *xdrWriter) writeBytes(b []byte) {
+	w.writeUint32(uint32(len(b)))
+	w.writeRaw(b)
+}
+
+// writeRaw writes fixed-length contents with padding but no length prefix.
+func (w *xdrWriter) writeRaw(b []byte) {
+	w.buf = append(w.buf, b...)
+	if pad := (4 - len(b)%4) % 4; pad > 0 {
+		w.buf = append(w.buf, make([]byte, pad)...)
+	}
+}
+
+func (w *xdrWriter) bytes() []byte { return w.buf }
+
+// xdrReader consumes big-endian XDR.
+type xdrReader struct {
+	buf []byte
+	pos int
+}
+
+func (r *xdrReader) readRaw(n int) ([]byte, error) {
+	padded := n + (4-n%4)%4
+	if r.pos+padded > len(r.buf) {
+		return nil, fmt.Errorf("%w: truncated: need %d bytes at offset %d, have %d", ErrXDR, padded, r.pos, len(r.buf)-r.pos)
+	}
+	out := r.buf[r.pos : r.pos+n]
+	r.pos += padded
+	return out, nil
+}
+
+func (r *xdrReader) readUint32() (uint32, error) {
+	if r.pos+4 > len(r.buf) {
+		return 0, fmt.Errorf("%w: truncated uint32 at offset %d", ErrXDR, r.pos)
+	}
+	v := uint32(r.buf[r.pos])<<24 | uint32(r.buf[r.pos+1])<<16 | uint32(r.buf[r.pos+2])<<8 | uint32(r.buf[r.pos+3])
+	r.pos += 4
+	return v, nil
+}
+
+func (r *xdrReader) readInt32() (int32, error) {
+	v, err := r.readUint32()
+	return int32(v), err
+}
+
+func (r *xdrReader) readUint64() (uint64, error) {
+	hi, err := r.readUint32()
+	if err != nil {
+		return 0, err
+	}
+	lo, err := r.readUint32()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(hi)<<32 | uint64(lo), nil
+}
+
+func (r *xdrReader) readBytes() ([]byte, error) {
+	n, err := r.readLength()
+	if err != nil {
+		return nil, err
+	}
+	return r.readRaw(int(n))
+}
+
+// readLength reads a length prefix and rejects one larger than the remaining
+// buffer, so a corrupt value cannot drive a huge allocation.
+func (r *xdrReader) readLength() (uint32, error) {
+	n, err := r.readUint32()
+	if err != nil {
+		return 0, err
+	}
+	if int(n) > len(r.buf)-r.pos {
+		return 0, fmt.Errorf("%w: length %d exceeds %d remaining bytes", ErrXDR, n, len(r.buf)-r.pos)
+	}
+	return n, nil
+}
+
+// StrkeyKind identifies which strkey version byte an address carries.
+type StrkeyKind int
+
+const (
+	// StrkeyUnknown is an address whose version byte is not recognised.
+	StrkeyUnknown StrkeyKind = iota
+	// StrkeyAccount is a G... ed25519 public key.
+	StrkeyAccount
+	// StrkeyContract is a C... contract id.
+	StrkeyContract
+)
+
+const (
+	versionByteAccount  byte = 6 << 3 // 0x30 -> 'G'
+	versionByteContract byte = 2 << 3 // 0x10 -> 'C'
+)
+
+var base32NoPad = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// DecodeStrkey decodes a Stellar strkey into its 32 raw bytes, verifying the
+// trailing CRC16-XModem checksum.
+func DecodeStrkey(s string) ([]byte, StrkeyKind, error) {
+	if s == "" {
+		return nil, StrkeyUnknown, fmt.Errorf("%w: empty address", ErrXDR)
+	}
+	raw, err := base32NoPad.DecodeString(strings.ToUpper(s))
+	if err != nil {
+		return nil, StrkeyUnknown, fmt.Errorf("%w: address %q is not base32: %v", ErrXDR, s, err)
+	}
+	if len(raw) != 35 {
+		return nil, StrkeyUnknown, fmt.Errorf("%w: address %q decodes to %d bytes, want 35", ErrXDR, s, len(raw))
+	}
+
+	payload, want := raw[:33], raw[33:]
+	if got := crc16XModem(payload); got[0] != want[0] || got[1] != want[1] {
+		return nil, StrkeyUnknown, fmt.Errorf("%w: address %q has a bad checksum", ErrXDR, s)
+	}
+
+	var kind StrkeyKind
+	switch payload[0] {
+	case versionByteAccount:
+		kind = StrkeyAccount
+	case versionByteContract:
+		kind = StrkeyContract
+	default:
+		return nil, StrkeyUnknown, fmt.Errorf("%w: address %q has unknown version byte 0x%02x", ErrXDR, s, payload[0])
+	}
+	return payload[1:], kind, nil
+}
+
+// EncodeStrkey encodes 32 raw bytes as a strkey of the given kind.
+func EncodeStrkey(raw []byte, kind StrkeyKind) (string, error) {
+	if len(raw) != 32 {
+		return "", fmt.Errorf("%w: strkey payload is %d bytes, want 32", ErrXDR, len(raw))
+	}
+
+	var version byte
+	switch kind {
+	case StrkeyAccount:
+		version = versionByteAccount
+	case StrkeyContract:
+		version = versionByteContract
+	default:
+		return "", fmt.Errorf("%w: cannot encode unknown strkey kind", ErrXDR)
+	}
+
+	payload := make([]byte, 0, 35)
+	payload = append(payload, version)
+	payload = append(payload, raw...)
+	sum := crc16XModem(payload)
+	payload = append(payload, sum[0], sum[1])
+
+	return base32NoPad.EncodeToString(payload), nil
+}
+
+// crc16XModem computes the CRC16-XModem checksum strkeys carry, little-endian.
+func crc16XModem(data []byte) [2]byte {
+	var crc uint16
+	for _, b := range data {
+		crc ^= uint16(b) << 8
+		for i := 0; i < 8; i++ {
+			if crc&0x8000 != 0 {
+				crc = crc<<1 ^ 0x1021
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return [2]byte{byte(crc), byte(crc >> 8)}
+}


### PR DESCRIPTION
Work in progress — opening early so the four linked issues are visible against one branch.

Landed so far: a typed 128-bit ScVal encoding layer for the Go SDK (`packages/go-sdk/scval.go`) with range-checked i128/u128 conversion and table-driven round-trip tests at both extremes, plus a go.mod fix that makes the package build at all.

Still to land on this branch:
- webhook-streamer: HMAC-SHA256 request signing, authenticated management API, durable subscription store, cursor persistence
- go-sdk: read/write client, Signer interface, typed contract errors, CI job
- amm-sdk: feature-gated factory/CL/governance/staking clients, unified `SdkError`, cross-contract quote helpers
- docs: audit of every code sample in the three integration guides, plus CI verification

Closes #731
Closes #727
Closes #722
Closes #721