### PR TITLE
fix(webhook-streamer): timeout, jitter, dead-letter queue and circuit breaker

### DIFF
--- a/services/webhook-streamer/src/circuit-breaker.ts
+++ b/services/webhook-streamer/src/circuit-breaker.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-subscription circuit breaker (issue #720).
+ *
+ * A permanently-dead endpoint should stop costing the service anything. After
+ * `failureThreshold` consecutive failures the circuit opens and delivery is
+ * skipped outright until `cooldownMs` has elapsed; the next attempt after that
+ * is a half-open probe. A successful probe closes the circuit, a failed one
+ * re-opens it and restarts the cooldown.
+ *
+ * The clock is injectable so cooldown behaviour can be tested without sleeping.
+ */
+
+import type { CircuitSnapshot, CircuitState } from "./types.js";
+
+export const DEFAULT_FAILURE_THRESHOLD = 5;
+export const DEFAULT_COOLDOWN_MS = 30_000;
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  cooldownMs?: number;
+  /** Injectable clock, defaults to Date.now. */
+  now?: () => number;
+}
+
+interface CircuitEntry {
+  state: CircuitState;
+  consecutiveFailures: number;
+  openedAt?: number;
+}
+
+export class CircuitBreaker {
+  private circuits = new Map<string, CircuitEntry>();
+  readonly failureThreshold: number;
+  readonly cooldownMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    this.cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  private entry(id: string): CircuitEntry {
+    let e = this.circuits.get(id);
+    if (!e) {
+      e = { state: "closed", consecutiveFailures: 0 };
+      this.circuits.set(id, e);
+    }
+    return e;
+  }
+
+  /**
+   * Whether a delivery may be attempted right now.
+   *
+   * Transitions an expired open circuit to half-open as a side effect, so the
+   * caller's attempt becomes the probe.
+   */
+  canAttempt(id: string): boolean {
+    const e = this.entry(id);
+    if (e.state === "open") {
+      const openedAt = e.openedAt ?? 0;
+      if (this.now() - openedAt >= this.cooldownMs) {
+        e.state = "half_open";
+        return true;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  /** Record a successful delivery: closes the circuit and clears the counter. */
+  recordSuccess(id: string): void {
+    const e = this.entry(id);
+    e.state = "closed";
+    e.consecutiveFailures = 0;
+    delete e.openedAt;
+  }
+
+  /**
+   * Record a failed delivery.
+   *
+   * A failure while half-open re-opens immediately — the endpoint is still
+   * broken, so the cooldown restarts rather than allowing repeated probes.
+   */
+  recordFailure(id: string): void {
+    const e = this.entry(id);
+    e.consecutiveFailures += 1;
+
+    if (e.state === "half_open") {
+      e.state = "open";
+      e.openedAt = this.now();
+      return;
+    }
+
+    if (e.consecutiveFailures >= this.failureThreshold) {
+      e.state = "open";
+      e.openedAt = this.now();
+    }
+  }
+
+  /** Current state of one circuit. */
+  stateOf(id: string): CircuitState {
+    return this.entry(id).state;
+  }
+
+  /** Snapshot of one circuit, for the management API. */
+  snapshot(id: string): CircuitSnapshot {
+    const e = this.entry(id);
+    const snap: CircuitSnapshot = {
+      subscriptionId: id,
+      state: e.state,
+      consecutiveFailures: e.consecutiveFailures,
+    };
+    if (e.state === "open" && e.openedAt !== undefined) {
+      snap.nextProbeAt = e.openedAt + this.cooldownMs;
+    }
+    return snap;
+  }
+
+  /** Snapshots of every circuit this breaker has seen. */
+  snapshots(): CircuitSnapshot[] {
+    return [...this.circuits.keys()].map((id) => this.snapshot(id));
+  }
+
+  /** Forget a subscription's circuit, e.g. after it is unregistered. */
+  forget(id: string): void {
+    this.circuits.delete(id);
+  }
+
+  /** Drop all circuit state. */
+  reset(): void {
+    this.circuits.clear();
+  }
+}
+
+export const defaultCircuitBreaker = new CircuitBreaker();

--- a/services/webhook-streamer/src/dead-letter.ts
+++ b/services/webhook-streamer/src/dead-letter.ts
@@ -1,0 +1,99 @@
+/**
+ * Bounded dead-letter queue for permanently-failed webhook deliveries
+ * (issue #720).
+ *
+ * Before this existed a delivery that exhausted its retries was reported as a
+ * failure count and then discarded — there was no record of what was lost and
+ * no way to replay it. Entries here retain the event, the subscription and
+ * every attempt's outcome so an operator can diagnose and re-deliver.
+ *
+ * The queue is bounded: at capacity the oldest entry is evicted so a
+ * permanently-broken subscriber cannot exhaust memory.
+ */
+
+import type {
+  AttemptOutcome,
+  DeadLetter,
+  PoolEvent,
+  WebhookSubscription,
+} from "./types.js";
+
+export const DEFAULT_MAX_ENTRIES = 1_000;
+
+let _nextId = 1;
+
+/** Reset the dead-letter ID counter. Exposed for deterministic tests. */
+export function _resetDeadLetterIds(): void {
+  _nextId = 1;
+}
+
+export class DeadLetterQueue {
+  private entries: DeadLetter[] = [];
+  readonly maxEntries: number;
+
+  constructor(maxEntries: number = DEFAULT_MAX_ENTRIES) {
+    if (!Number.isFinite(maxEntries) || maxEntries < 1) {
+      throw new RangeError("maxEntries must be a positive integer");
+    }
+    this.maxEntries = Math.floor(maxEntries);
+  }
+
+  /**
+   * Record a permanently-failed delivery.
+   *
+   * Evicts the oldest entry when already at capacity, so the queue never grows
+   * beyond `maxEntries`.
+   */
+  add(
+    event: PoolEvent,
+    subscription: WebhookSubscription,
+    attempts: AttemptOutcome[],
+    reason: string,
+    failedAt: number = Date.now(),
+  ): DeadLetter {
+    const entry: DeadLetter = {
+      id: String(_nextId++),
+      event,
+      subscription,
+      attempts,
+      failedAt,
+      reason,
+    };
+
+    this.entries.push(entry);
+    // Bounded: drop oldest-first once over capacity.
+    while (this.entries.length > this.maxEntries) {
+      this.entries.shift();
+    }
+    return entry;
+  }
+
+  /** All retained entries, oldest first. */
+  list(): DeadLetter[] {
+    return [...this.entries];
+  }
+
+  /** Look up a single entry by ID. */
+  get(id: string): DeadLetter | undefined {
+    return this.entries.find((e) => e.id === id);
+  }
+
+  /** Remove an entry by ID. Returns true if it existed. */
+  remove(id: string): boolean {
+    const idx = this.entries.findIndex((e) => e.id === id);
+    if (idx === -1) return false;
+    this.entries.splice(idx, 1);
+    return true;
+  }
+
+  /** Drop every entry. */
+  clear(): void {
+    this.entries = [];
+  }
+
+  get size(): number {
+    return this.entries.length;
+  }
+}
+
+export const defaultDeadLetterQueue = new DeadLetterQueue();

--- a/services/webhook-streamer/src/dispatcher.ts
+++ b/services/webhook-streamer/src/dispatcher.ts
@@ -1,86 +1,442 @@
 /**
  * Webhook dispatcher — delivers a PoolEvent to all matching subscribers.
  *
- * Retries up to MAX_RETRIES times with exponential back-off.
+ * Delivery reliability (issue #720):
+ *   - Every request is bounded by a timeout via AbortController; a timeout is
+ *     recorded distinctly from other failures.
+ *   - Fan-out uses settled results with bounded concurrency, so one hanging
+ *     subscriber cannot delay another or stall the poller loop.
+ *   - Retries are iterative (no stack growth) and apply full jitter:
+ *     random(0, base * 2 ** attempt), capped at maxDelayMs.
+ *   - Only retryable failures are retried: 408, 429, 5xx and network errors.
+ *     A 4xx such as 404 is terminal — it will still be a 404 in two seconds.
+ *   - Retry-After is honoured when the subscriber sends one.
+ *   - Permanently-failed deliveries land in a bounded dead-letter queue.
+ *   - A per-subscription circuit breaker stops paying for a dead endpoint.
+ *
  * Sends X-Webhook-Secret header when a secret is configured.
  */
 
 import fetch from "node-fetch";
-import type { PoolEvent, WebhookSubscription, DeliveryResult } from "./types.js";
+import type {
+  AttemptOutcome,
+  DeliveryResult,
+  FailureKind,
+  MetricsSnapshot,
+  PoolEvent,
+  WebhookSubscription,
+} from "./types.js";
 import type { WebhookRegistry } from "./registry.js";
+import { DeadLetterQueue, defaultDeadLetterQueue } from "./dead-letter.js";
+import { CircuitBreaker, defaultCircuitBreaker } from "./circuit-breaker.js";
 
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 500;
+export const MAX_RETRIES = 3;
+export const BASE_DELAY_MS = 500;
+export const MAX_DELAY_MS = 30_000;
+export const DEFAULT_TIMEOUT_MS = 10_000;
+export const DEFAULT_CONCURRENCY = 10;
+/** Cap on a honoured Retry-After, so a hostile header cannot stall delivery. */
+export const MAX_RETRY_AFTER_MS = 60_000;
 
-export class WebhookDispatcher {
-  constructor(private readonly registry: WebhookRegistry) {}
+export interface DispatcherOptions {
+  /** Per-request timeout in ms. Default 10s. */
+  timeoutMs?: number;
+  /** Maximum concurrent in-flight deliveries per dispatch. Default 10. */
+  concurrency?: number;
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  deadLetterQueue?: DeadLetterQueue;
+  circuitBreaker?: CircuitBreaker;
+  /** Injectable sleep, for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable RNG in [0,1), for deterministic jitter in tests. */
+  random?: () => number;
+}
 
-  /** Fan out `event` to all matching subscriptions. Resolves when all
-   *  deliveries have been attempted (failures are logged, not thrown). */
-  async dispatch(event: PoolEvent): Promise<DeliveryResult[]> {
-    const subs = this.registry.matching(event.contractId, event.eventType);
-    return Promise.all(subs.map((sub) => this._deliver(sub, event)));
+interface Counters {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  timedOut: number;
+  deadLettered: number;
+  retries: number;
+  shortCircuited: number;
+}
+
+/** Internal: an attempt outcome plus any server-directed retry delay. */
+type AttemptResult = AttemptOutcome & { retryAfterMs?: number };
+
+/** HTTP statuses worth retrying. Everything else in 4xx is terminal. */
+export function isRetryableStatus(status: number): boolean {
+  if (status === 408 || status === 429) return true;
+  return status >= 500 && status <= 599;
+}
+
+/**
+ * Parse a Retry-After header, which may be delta-seconds or an HTTP date.
+ * Returns undefined when absent or unparseable.
+ */
+export function parseRetryAfter(
+  value: string | null | undefined,
+  now: number = Date.now(),
+): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+
+  // delta-seconds
+  if (/^\d+$/.test(trimmed)) {
+    return Math.min(Number(trimmed) * 1_000, MAX_RETRY_AFTER_MS);
   }
 
+  // HTTP-date
+  const ts = Date.parse(trimmed);
+  if (Number.isNaN(ts)) return undefined;
+  const delta = ts - now;
+  if (delta <= 0) return 0;
+  return Math.min(delta, MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * Full jitter: random(0, min(base * 2 ** attempt, cap)).
+ *
+ * Un-jittered backoff leaves every failing subscriber retrying in lockstep —
+ * a synchronised thundering herd against an endpoint that is trying to
+ * recover. Full jitter spreads those retries evenly across the window.
+ */
+export function fullJitterDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+): number {
+  const exponential = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+  return Math.floor(random() * exponential);
+}
+
+function _sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` in flight at once, returning a
+ * settled result per item so one failure never rejects the whole batch.
+ */
+async function _mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let cursor = 0;
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      for (;;) {
+        const idx = cursor++;
+        if (idx >= items.length) return;
+        try {
+          results[idx] = { status: "fulfilled", value: await fn(items[idx]!) };
+        } catch (reason) {
+          results[idx] = { status: "rejected", reason };
+        }
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  return results;
+}
+
+export class WebhookDispatcher {
+  private readonly timeoutMs: number;
+  private readonly concurrency: number;
+  private readonly maxRetries: number;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly random: () => number;
+
+  readonly deadLetters: DeadLetterQueue;
+  readonly circuitBreaker: CircuitBreaker;
+
+  private counters: Counters = {
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    timedOut: 0,
+    deadLettered: 0,
+    retries: 0,
+    shortCircuited: 0,
+  };
+
+  constructor(
+    private readonly registry: WebhookRegistry,
+    opts: DispatcherOptions = {},
+  ) {
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
+    this.maxRetries = opts.maxRetries ?? MAX_RETRIES;
+    this.baseDelayMs = opts.baseDelayMs ?? BASE_DELAY_MS;
+    this.maxDelayMs = opts.maxDelayMs ?? MAX_DELAY_MS;
+    this.sleep = opts.sleep ?? _sleep;
+    this.random = opts.random ?? Math.random;
+    this.deadLetters = opts.deadLetterQueue ?? defaultDeadLetterQueue;
+    this.circuitBreaker = opts.circuitBreaker ?? defaultCircuitBreaker;
+  }
+
+  /**
+   * Fan out `event` to all matching subscriptions.
+   *
+   * Every subscriber gets a result regardless of how any other behaves, and
+   * the fan-out never opens more than `concurrency` sockets at once.
+   */
+  async dispatch(event: PoolEvent): Promise<DeliveryResult[]> {
+    const subs = this.registry.matching(event.contractId, event.eventType);
+    const settled = await _mapWithConcurrency(subs, this.concurrency, (sub) =>
+      this._deliver(sub, event),
+    );
+
+    return settled.map((r, i) => {
+      if (r.status === "fulfilled") return r.value;
+      // A rejection here is a dispatcher bug rather than a delivery failure,
+      // but it must not take down the fan-out.
+      const sub = subs[i]!;
+      return {
+        subscriptionId: sub.id,
+        url: sub.url,
+        success: false,
+        failureKind: "network" as FailureKind,
+        error: String(r.reason),
+        attemptedAt: Date.now(),
+      };
+    });
+  }
+
+  /**
+   * Re-attempt a previously dead-lettered delivery. The entry is removed only
+   * once it succeeds, so a failed replay stays available to try again.
+   */
+  async replay(deadLetterId: string): Promise<DeliveryResult | undefined> {
+    const entry = this.deadLetters.get(deadLetterId);
+    if (!entry) return undefined;
+
+    const result = await this._deliver(entry.subscription, entry.event);
+    if (result.success) {
+      this.deadLetters.remove(deadLetterId);
+    }
+    return result;
+  }
+
+  /** Current delivery counters and circuit states. */
+  metrics(): MetricsSnapshot {
+    return {
+      ...this.counters,
+      circuits: this.circuitBreaker.snapshots(),
+    };
+  }
+
+  /** Zero the counters. Exposed for tests. */
+  resetMetrics(): void {
+    this.counters = {
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      timedOut: 0,
+      deadLettered: 0,
+      retries: 0,
+      shortCircuited: 0,
+    };
+  }
+
+  /**
+   * Deliver one event to one subscriber, retrying iteratively.
+   *
+   * Written as a loop rather than recursion so the stack does not grow with
+   * each attempt.
+   */
   private async _deliver(
     sub: WebhookSubscription,
     event: PoolEvent,
-    attempt = 0,
   ): Promise<DeliveryResult> {
+    // Short-circuit a known-dead endpoint before spending a socket on it.
+    if (!this.circuitBreaker.canAttempt(sub.id)) {
+      this.counters.shortCircuited += 1;
+      return {
+        subscriptionId: sub.id,
+        url: sub.url,
+        success: false,
+        failureKind: "circuit_open",
+        error: "circuit open",
+        attemptedAt: Date.now(),
+        attempts: [],
+      };
+    }
+
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
     if (sub.secret) {
       headers["X-Webhook-Secret"] = sub.secret;
     }
+    const body = JSON.stringify(event);
+
+    const attempts: AttemptOutcome[] = [];
+    let delayMs = 0;
+
+    for (let attempt = 0; ; attempt++) {
+      if (delayMs > 0) {
+        await this.sleep(delayMs);
+      }
+      if (attempt > 0) {
+        this.counters.retries += 1;
+      }
+
+      const attemptedAt = Date.now();
+      this.counters.attempted += 1;
+
+      const outcome = await this._attempt(
+        sub,
+        headers,
+        body,
+        attempt,
+        delayMs,
+        attemptedAt,
+      );
+      const { retryAfterMs, ...record } = outcome;
+      attempts.push(record);
+
+      if (outcome.success) {
+        this.circuitBreaker.recordSuccess(sub.id);
+        this.counters.succeeded += 1;
+        const ok: DeliveryResult = {
+          subscriptionId: sub.id,
+          url: sub.url,
+          success: true,
+          attemptedAt: outcome.attemptedAt,
+          attempts,
+        };
+        if (outcome.statusCode !== undefined) ok.statusCode = outcome.statusCode;
+        return ok;
+      }
+
+      if (outcome.failureKind === "timeout") {
+        this.counters.timedOut += 1;
+      }
+
+      // Network and timeout failures are retryable; HTTP failures only when
+      // the status says so. A 404 will still be a 404 in two seconds.
+      const retryable =
+        outcome.failureKind !== "http" ||
+        (outcome.statusCode !== undefined &&
+          isRetryableStatus(outcome.statusCode));
+
+      if (!retryable || attempt >= this.maxRetries) {
+        return this._fail(sub, event, attempts, record);
+      }
+
+      delayMs =
+        retryAfterMs ??
+        fullJitterDelay(attempt, this.baseDelayMs, this.maxDelayMs, this.random);
+    }
+  }
+
+  /** One timeout-bounded HTTP attempt. Never throws. */
+  private async _attempt(
+    sub: WebhookSubscription,
+    headers: Record<string, string>,
+    body: string,
+    attempt: number,
+    delayMs: number,
+    attemptedAt: number,
+  ): Promise<AttemptResult> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 
     try {
       const res = await fetch(sub.url, {
         method: "POST",
         headers,
-        body: JSON.stringify(event),
+        body,
+        signal: controller.signal,
       });
 
       if (res.ok) {
         return {
-          subscriptionId: sub.id,
-          url: sub.url,
+          attempt,
           success: true,
           statusCode: res.status,
-          attemptedAt: Date.now(),
+          delayMs,
+          attemptedAt,
         };
       }
 
-      // Non-2xx: retry if attempts remain.
-      if (attempt < MAX_RETRIES) {
-        await _sleep(BASE_DELAY_MS * 2 ** attempt);
-        return this._deliver(sub, event, attempt + 1);
-      }
-
+      const retryAfterMs = parseRetryAfter(res.headers.get("retry-after"));
       return {
-        subscriptionId: sub.id,
-        url: sub.url,
+        attempt,
         success: false,
         statusCode: res.status,
+        failureKind: "http",
         error: `HTTP ${res.status}`,
-        attemptedAt: Date.now(),
+        delayMs,
+        attemptedAt,
+        ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
       };
     } catch (err) {
-      if (attempt < MAX_RETRIES) {
-        await _sleep(BASE_DELAY_MS * 2 ** attempt);
-        return this._deliver(sub, event, attempt + 1);
-      }
+      // AbortError is how the timeout surfaces; record it distinctly from a
+      // genuine network error so operators can tell slow from broken.
+      const aborted =
+        controller.signal.aborted ||
+        (err as { name?: string })?.name === "AbortError";
       return {
-        subscriptionId: sub.id,
-        url: sub.url,
+        attempt,
         success: false,
-        error: String(err),
-        attemptedAt: Date.now(),
+        failureKind: aborted ? "timeout" : "network",
+        error: aborted ? `timeout after ${this.timeoutMs}ms` : String(err),
+        delayMs,
+        attemptedAt,
       };
+    } finally {
+      clearTimeout(timer);
     }
   }
-}
 
-function _sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  /** Terminal failure: record it, trip the circuit, dead-letter the event. */
+  private _fail(
+    sub: WebhookSubscription,
+    event: PoolEvent,
+    attempts: AttemptOutcome[],
+    last: AttemptOutcome,
+  ): DeliveryResult {
+    this.circuitBreaker.recordFailure(sub.id);
+    this.counters.failed += 1;
+
+    const reason = last.error ?? "delivery failed";
+    const entry = this.deadLetters.add(event, sub, attempts, reason);
+    this.counters.deadLettered += 1;
+
+    console.warn(
+      `[dead-letter] event=${event.id} type=${event.eventType} ` +
+        `contract=${event.contractId} subscription=${sub.id} url=${sub.url} ` +
+        `attempts=${attempts.length} reason="${reason}" ` +
+        `deadLetterId=${entry.id} circuit=${this.circuitBreaker.stateOf(sub.id)}`,
+    );
+
+    const result: DeliveryResult = {
+      subscriptionId: sub.id,
+      url: sub.url,
+      success: false,
+      error: reason,
+      attemptedAt: last.attemptedAt,
+      attempts,
+      deadLettered: true,
+      deadLetterId: entry.id,
+    };
+    if (last.statusCode !== undefined) result.statusCode = last.statusCode;
+    if (last.failureKind !== undefined) result.failureKind = last.failureKind;
+    if (last.failureKind === "timeout") result.timedOut = true;
+    return result;
+  }
 }

--- a/services/webhook-streamer/src/index.ts
+++ b/services/webhook-streamer/src/index.ts
@@ -20,6 +20,8 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { defaultRegistry } from "./registry.js";
 import { WebhookDispatcher } from "./dispatcher.js";
+import { DeadLetterQueue } from "./dead-letter.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
 import { HorizonPoller } from "./horizon-poller.js";
 import type { PoolEvent } from "./types.js";
 
@@ -31,8 +33,21 @@ const CONTRACT_IDS = (process.env["CONTRACT_IDS"] ?? "")
   .map((s) => s.trim())
   .filter(Boolean);
 const POLL_INTERVAL_MS = Number(process.env["POLL_INTERVAL_MS"] ?? 5_000);
+const DELIVERY_TIMEOUT_MS = Number(process.env["DELIVERY_TIMEOUT_MS"] ?? 10_000);
+const DELIVERY_CONCURRENCY = Number(process.env["DELIVERY_CONCURRENCY"] ?? 10);
+const DEAD_LETTER_MAX = Number(process.env["DEAD_LETTER_MAX"] ?? 1_000);
+const CIRCUIT_THRESHOLD = Number(process.env["CIRCUIT_FAILURE_THRESHOLD"] ?? 5);
+const CIRCUIT_COOLDOWN_MS = Number(process.env["CIRCUIT_COOLDOWN_MS"] ?? 30_000);
 
-const dispatcher = new WebhookDispatcher(defaultRegistry);
+const dispatcher = new WebhookDispatcher(defaultRegistry, {
+  timeoutMs: DELIVERY_TIMEOUT_MS,
+  concurrency: DELIVERY_CONCURRENCY,
+  deadLetterQueue: new DeadLetterQueue(DEAD_LETTER_MAX),
+  circuitBreaker: new CircuitBreaker({
+    failureThreshold: CIRCUIT_THRESHOLD,
+    cooldownMs: CIRCUIT_COOLDOWN_MS,
+  }),
+});
 
 // ── Horizon poller ──────────────────────────────────────────────────────────
 
@@ -81,9 +96,46 @@ const server = createServer(async (req, res) => {
     return json(res, 200, { status: "ok", webhooks: defaultRegistry.size });
   }
 
-  // GET /webhooks
+  // GET /webhooks — includes each subscription's circuit state.
   if (method === "GET" && url === "/webhooks") {
-    return json(res, 200, defaultRegistry.list());
+    return json(
+      res,
+      200,
+      defaultRegistry
+        .list()
+        .map((sub) => ({
+          ...sub,
+          circuit: dispatcher.circuitBreaker.snapshot(sub.id),
+        })),
+    );
+  }
+
+  // GET /metrics
+  if (method === "GET" && url === "/metrics") {
+    return json(res, 200, dispatcher.metrics());
+  }
+
+  // GET /dead-letters
+  if (method === "GET" && url === "/dead-letters") {
+    return json(res, 200, dispatcher.deadLetters.list());
+  }
+
+  // POST /dead-letters/:id/replay
+  const replayMatch = url.match(/^\/dead-letters\/([^/]+)\/replay$/);
+  if (method === "POST" && replayMatch) {
+    const id = replayMatch[1]!;
+    const result = await dispatcher.replay(id);
+    if (!result) {
+      return json(res, 404, { error: "dead letter not found" });
+    }
+    return json(res, result.success ? 200 : 502, { replayed: result.success, result });
+  }
+
+  // DELETE /dead-letters/:id
+  const deadLetterMatch = url.match(/^\/dead-letters\/([^/]+)$/);
+  if (method === "DELETE" && deadLetterMatch) {
+    const removed = dispatcher.deadLetters.remove(deadLetterMatch[1]!);
+    return json(res, removed ? 200 : 404, { removed });
   }
 
   // POST /webhooks
@@ -114,6 +166,7 @@ const server = createServer(async (req, res) => {
   if (method === "DELETE" && deleteMatch) {
     const id = deleteMatch[1]!;
     const removed = defaultRegistry.unregister(id);
+    if (removed) dispatcher.circuitBreaker.forget(id);
     return json(res, removed ? 200 : 404, { removed });
   }
 

--- a/services/webhook-streamer/src/streamer.test.ts
+++ b/services/webhook-streamer/src/streamer.test.ts
@@ -5,7 +5,17 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { WebhookRegistry } from "./registry.js";
+import {
+  WebhookDispatcher,
+  fullJitterDelay,
+  isRetryableStatus,
+  parseRetryAfter,
+} from "./dispatcher.js";
+import { DeadLetterQueue } from "./dead-letter.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
 import type { PoolEvent } from "./types.js";
 
 describe("WebhookRegistry", () => {
@@ -69,5 +79,729 @@ describe("PoolEvent shape", () => {
     };
     assert.equal(event.eventType, "swap");
     assert.equal(event.payload["amountIn"], 1000);
+  });
+});
+
+// ── Delivery reliability (issue #720) ───────────────────────────────────────
+//
+// Every test below drives a real local HTTP server. No external network.
+
+const EVENT: PoolEvent = {
+  id: "evt-1",
+  contractId: "CABC123",
+  eventType: "swap",
+  ledger: 1234,
+  timestamp: "2026-06-01T00:00:00Z",
+  payload: { amountIn: 1000, amountOut: 990 },
+};
+
+interface TestServer {
+  url: string;
+  /** Number of requests received. */
+  hits: () => number;
+  /** Bodies of received requests. */
+  bodies: () => string[];
+  /** Headers of received requests. */
+  headers: () => Array<Record<string, string | string[] | undefined>>;
+  close: () => Promise<void>;
+}
+
+type Handler = (
+  hit: number,
+) => {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  /** Accept the connection and never respond. */
+  hang?: boolean;
+  /** Delay in ms before responding. */
+  delayMs?: number;
+};
+
+/** Start a local HTTP server driven by `handler`. */
+async function startServer(handler: Handler): Promise<TestServer> {
+  let hits = 0;
+  const bodies: string[] = [];
+  const headers: Array<Record<string, string | string[] | undefined>> = [];
+  const openTimers: NodeJS.Timeout[] = [];
+
+  const server: Server = createServer((req, res) => {
+    const hit = ++hits;
+    headers.push({ ...req.headers });
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      bodies.push(body);
+      const spec = handler(hit);
+      if (spec.hang) return; // never respond
+      const send = () => {
+        res.writeHead(spec.status ?? 200, spec.headers ?? {});
+        res.end(spec.body ?? "ok");
+      };
+      if (spec.delayMs) {
+        openTimers.push(setTimeout(send, spec.delayMs));
+      } else {
+        send();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}/hook`,
+    hits: () => hits,
+    bodies: () => [...bodies],
+    headers: () => [...headers],
+    close: () =>
+      new Promise<void>((resolve) => {
+        openTimers.forEach(clearTimeout);
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** Dispatcher wired for fast, deterministic tests. */
+function makeDispatcher(
+  registry: WebhookRegistry,
+  overrides: Partial<{
+    timeoutMs: number;
+    maxRetries: number;
+    baseDelayMs: number;
+    concurrency: number;
+    deadLetterQueue: DeadLetterQueue;
+    circuitBreaker: CircuitBreaker;
+    random: () => number;
+  }> = {},
+) {
+  return new WebhookDispatcher(registry, {
+    timeoutMs: 200,
+    maxRetries: 2,
+    baseDelayMs: 1,
+    maxDelayMs: 10,
+    deadLetterQueue: new DeadLetterQueue(100),
+    circuitBreaker: new CircuitBreaker({ failureThreshold: 100 }),
+    // Keep retry sleeps effectively instant unless a test overrides them.
+    sleep: () => Promise.resolve(),
+    ...overrides,
+  });
+}
+
+describe("delivery timeout", () => {
+  it("abandons a subscriber that never responds, and dispatch resolves", async () => {
+    // Fails against main: node-fetch has no default timeout, so this hangs.
+    const srv = await startServer(() => ({ hang: true }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg, { maxRetries: 0 });
+
+      const results = await d.dispatch(EVENT);
+      assert.equal(results.length, 1);
+      assert.equal(results[0]!.success, false);
+      assert.equal(results[0]!.timedOut, true);
+      assert.equal(results[0]!.failureKind, "timeout");
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("records a timeout distinctly from a network error", async () => {
+    const srv = await startServer(() => ({ hang: true }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg, { maxRetries: 0 });
+      await d.dispatch(EVENT);
+      const m = d.metrics();
+      assert.equal(m.timedOut, 1);
+      assert.equal(m.failed, 1);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("succeeds when the subscriber responds inside the timeout", async () => {
+    const srv = await startServer(() => ({ status: 200, delayMs: 10 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg);
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, true);
+      assert.equal(r!.statusCode, 200);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe("subscriber isolation", () => {
+  it("one hanging subscriber does not delay a healthy one", async () => {
+    const hanging = await startServer(() => ({ hang: true }));
+    const healthy = await startServer(() => ({ status: 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(hanging.url);
+      reg.register(healthy.url);
+      const d = makeDispatcher(reg, { maxRetries: 0, timeoutMs: 1_000 });
+
+      const started = Date.now();
+      let healthyDoneAt = 0;
+
+      // Observe when the healthy endpoint is actually hit, independent of
+      // when the overall dispatch settles.
+      const dispatched = d.dispatch(EVENT);
+      while (healthy.hits() === 0) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      healthyDoneAt = Date.now() - started;
+
+      const results = await dispatched;
+      assert.equal(results.length, 2);
+      assert.ok(
+        healthyDoneAt < 500,
+        `healthy subscriber waited ${healthyDoneAt}ms behind the hanging one`,
+      );
+      assert.equal(results.filter((r) => r.success).length, 1);
+    } finally {
+      await hanging.close();
+      await healthy.close();
+    }
+  });
+
+  it("returns a result for every subscriber even when some fail", async () => {
+    const ok = await startServer(() => ({ status: 200 }));
+    const bad = await startServer(() => ({ status: 500 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(ok.url);
+      reg.register(bad.url);
+      const d = makeDispatcher(reg, { maxRetries: 0 });
+      const results = await d.dispatch(EVENT);
+      assert.equal(results.length, 2);
+      assert.equal(results.filter((r) => r.success).length, 1);
+      assert.equal(results.filter((r) => !r.success).length, 1);
+    } finally {
+      await ok.close();
+      await bad.close();
+    }
+  });
+
+  it("bounds concurrency so it never exceeds the configured limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const srv = await startServer(() => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Released on response; approximate by decrementing after the delay.
+      setTimeout(() => inFlight--, 30);
+      return { status: 200, delayMs: 30 };
+    });
+    try {
+      const reg = new WebhookRegistry();
+      for (let i = 0; i < 10; i++) reg.register(srv.url);
+      const d = makeDispatcher(reg, { concurrency: 3 });
+      await d.dispatch(EVENT);
+      assert.ok(peak <= 3, `peak in-flight was ${peak}, expected <= 3`);
+      assert.equal(srv.hits(), 10);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe("retry policy", () => {
+  it("does not retry a 404", async () => {
+    const srv = await startServer(() => ({ status: 404 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg, { maxRetries: 3 });
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, false);
+      assert.equal(srv.hits(), 1);
+      assert.equal(r!.attempts!.length, 1);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("retries a 503", async () => {
+    const srv = await startServer(() => ({ status: 503 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg, { maxRetries: 2 });
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, false);
+      assert.equal(srv.hits(), 3); // initial + 2 retries
+      assert.equal(r!.attempts!.length, 3);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("retries a 500 and succeeds when the endpoint recovers", async () => {
+    const srv = await startServer((hit) => ({ status: hit === 1 ? 500 : 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg);
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, true);
+      assert.equal(srv.hits(), 2);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("retries 408 and 429 but not 400 or 403", () => {
+    assert.equal(isRetryableStatus(408), true);
+    assert.equal(isRetryableStatus(429), true);
+    assert.equal(isRetryableStatus(500), true);
+    assert.equal(isRetryableStatus(503), true);
+    assert.equal(isRetryableStatus(400), false);
+    assert.equal(isRetryableStatus(403), false);
+    assert.equal(isRetryableStatus(404), false);
+    assert.equal(isRetryableStatus(200), false);
+  });
+
+  it("retries a network error (connection refused)", async () => {
+    // Bind then immediately close, so the port refuses connections.
+    const srv = await startServer(() => ({ status: 200 }));
+    const url = srv.url;
+    await srv.close();
+
+    const reg = new WebhookRegistry();
+    reg.register(url);
+    const d = makeDispatcher(reg, { maxRetries: 2 });
+    const [r] = await d.dispatch(EVENT);
+    assert.equal(r!.success, false);
+    assert.equal(r!.failureKind, "network");
+    assert.equal(r!.attempts!.length, 3);
+  });
+
+  it("is iterative, not recursive — deep retry chains do not grow the stack", async () => {
+    const srv = await startServer(() => ({ status: 503 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      // A recursive implementation would nest 500 frames here.
+      const d = makeDispatcher(reg, { maxRetries: 500 });
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, false);
+      assert.equal(r!.attempts!.length, 501);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("counts retries in metrics", async () => {
+    const srv = await startServer(() => ({ status: 503 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg, { maxRetries: 2 });
+      await d.dispatch(EVENT);
+      assert.equal(d.metrics().retries, 2);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe("backoff jitter", () => {
+  it("produces different delays across repeated runs", () => {
+    const delays = new Set<number>();
+    for (let i = 0; i < 50; i++) {
+      delays.add(fullJitterDelay(3, 500, 30_000));
+    }
+    assert.ok(
+      delays.size > 1,
+      `expected jittered delays to vary, got ${[...delays]}`,
+    );
+  });
+
+  it("stays within [0, base * 2 ** attempt]", () => {
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const ceiling = 500 * 2 ** attempt;
+      for (let i = 0; i < 25; i++) {
+        const d = fullJitterDelay(attempt, 500, 30_000);
+        assert.ok(d >= 0 && d < ceiling, `delay ${d} outside [0, ${ceiling})`);
+      }
+    }
+  });
+
+  it("caps the delay at maxDelayMs", () => {
+    for (let i = 0; i < 50; i++) {
+      assert.ok(fullJitterDelay(20, 500, 1_000) < 1_000);
+    }
+  });
+
+  it("returns 0 when the RNG returns 0", () => {
+    assert.equal(fullJitterDelay(5, 500, 30_000, () => 0), 0);
+  });
+});
+
+describe("Retry-After", () => {
+  it("parses delta-seconds", () => {
+    assert.equal(parseRetryAfter("2"), 2_000);
+    assert.equal(parseRetryAfter("0"), 0);
+  });
+
+  it("parses an HTTP date", () => {
+    const now = Date.parse("2026-06-01T00:00:00Z");
+    const at = new Date(now + 5_000).toUTCString();
+    const parsed = parseRetryAfter(at, now)!;
+    assert.ok(parsed >= 4_000 && parsed <= 5_000, `got ${parsed}`);
+  });
+
+  it("returns undefined when absent or unparseable", () => {
+    assert.equal(parseRetryAfter(null), undefined);
+    assert.equal(parseRetryAfter(""), undefined);
+    assert.equal(parseRetryAfter("not-a-date"), undefined);
+  });
+
+  it("clamps an absurd Retry-After to the cap", () => {
+    assert.equal(parseRetryAfter("999999"), 60_000);
+  });
+
+  it("is honoured over computed jitter when the subscriber sends one", async () => {
+    const srv = await startServer((hit) => ({
+      status: hit === 1 ? 503 : 200,
+      headers: hit === 1 ? { "retry-after": "1" } : ({} as Record<string, string>),
+    }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const slept: number[] = [];
+      const d = new WebhookDispatcher(reg, {
+        timeoutMs: 200,
+        maxRetries: 2,
+        baseDelayMs: 1,
+        maxDelayMs: 5,
+        deadLetterQueue: new DeadLetterQueue(10),
+        circuitBreaker: new CircuitBreaker({ failureThreshold: 100 }),
+        sleep: (ms) => {
+          slept.push(ms);
+          return Promise.resolve();
+        },
+      });
+      const [r] = await d.dispatch(EVENT);
+      assert.equal(r!.success, true);
+      // 1000ms from the header, not the <=5ms jitter ceiling.
+      assert.deepEqual(slept, [1_000]);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe("dead-letter queue", () => {
+  it("captures a permanently-failing delivery", async () => {
+    const srv = await startServer(() => ({ status: 500 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const dlq = new DeadLetterQueue(10);
+      const d = makeDispatcher(reg, { maxRetries: 1, deadLetterQueue: dlq });
+      const [r] = await d.dispatch(EVENT);
+
+      assert.equal(r!.deadLettered, true);
+      assert.equal(dlq.size, 1);
+      const entry = dlq.list()[0]!;
+      assert.equal(entry.event.id, EVENT.id);
+      assert.equal(entry.subscription.url, srv.url);
+      assert.equal(entry.attempts.length, 2);
+      assert.ok(entry.failedAt > 0);
+      assert.match(entry.reason, /HTTP 500/);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("does not dead-letter a successful delivery", async () => {
+    const srv = await startServer(() => ({ status: 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const dlq = new DeadLetterQueue(10);
+      const d = makeDispatcher(reg, { deadLetterQueue: dlq });
+      await d.dispatch(EVENT);
+      assert.equal(dlq.size, 0);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("is bounded and evicts oldest-first at capacity", () => {
+    const dlq = new DeadLetterQueue(3);
+    const sub = { id: "s1", url: "http://x", createdAt: 0 };
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(dlq.add({ ...EVENT, id: `e${i}` }, sub, [], "boom").id);
+    }
+    assert.equal(dlq.size, 3);
+    const kept = dlq.list().map((e) => e.event.id);
+    assert.deepEqual(kept, ["e2", "e3", "e4"]);
+    // The two oldest are gone.
+    assert.equal(dlq.get(ids[0]!), undefined);
+    assert.equal(dlq.get(ids[1]!), undefined);
+  });
+
+  it("rejects a non-positive capacity", () => {
+    assert.throws(() => new DeadLetterQueue(0), RangeError);
+  });
+
+  it("removes an entry by id", () => {
+    const dlq = new DeadLetterQueue(5);
+    const e = dlq.add(EVENT, { id: "s1", url: "http://x", createdAt: 0 }, [], "boom");
+    assert.equal(dlq.remove(e.id), true);
+    assert.equal(dlq.remove(e.id), false);
+    assert.equal(dlq.size, 0);
+  });
+
+  it("replays successfully once the endpoint recovers, and clears the entry", async () => {
+    // Fail hard enough to dead-letter, then recover.
+    let recovered = false;
+    const srv = await startServer(() => ({ status: recovered ? 200 : 500 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const dlq = new DeadLetterQueue(10);
+      const d = makeDispatcher(reg, { maxRetries: 0, deadLetterQueue: dlq });
+
+      const [failed] = await d.dispatch(EVENT);
+      assert.equal(failed!.deadLettered, true);
+      assert.equal(dlq.size, 1);
+
+      recovered = true;
+      const replayed = await d.replay(failed!.deadLetterId!);
+      assert.equal(replayed!.success, true);
+      assert.equal(dlq.size, 0);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("keeps a failed replay in the queue rather than dropping the event", async () => {
+    const srv = await startServer(() => ({ status: 500 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const dlq = new DeadLetterQueue(10);
+      const d = makeDispatcher(reg, { maxRetries: 0, deadLetterQueue: dlq });
+      const [failed] = await d.dispatch(EVENT);
+      const originalId = failed!.deadLetterId!;
+
+      const replayed = await d.replay(originalId);
+      assert.equal(replayed!.success, false);
+      // The original entry survives, and the failed replay is itself recorded,
+      // so no failed delivery is ever silently discarded.
+      assert.ok(dlq.get(originalId), "original entry should survive a failed replay");
+      assert.equal(dlq.size, 2);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("returns undefined when replaying an unknown id", async () => {
+    const d = makeDispatcher(new WebhookRegistry());
+    assert.equal(await d.replay("nope"), undefined);
+  });
+});
+
+describe("circuit breaker", () => {
+  it("opens after the configured consecutive failures", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 1_000 });
+    cb.recordFailure("s1");
+    cb.recordFailure("s1");
+    assert.equal(cb.stateOf("s1"), "closed");
+    cb.recordFailure("s1");
+    assert.equal(cb.stateOf("s1"), "open");
+  });
+
+  it("stops attempting delivery while open", async () => {
+    const srv = await startServer(() => ({ status: 500 }));
+    try {
+      const reg = new WebhookRegistry();
+      const sub = reg.register(srv.url);
+      const cb = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+      const d = makeDispatcher(reg, { maxRetries: 0, circuitBreaker: cb });
+
+      await d.dispatch(EVENT);
+      const hitsAfterFirst = srv.hits();
+      assert.equal(cb.stateOf(sub.id), "open");
+
+      const [second] = await d.dispatch(EVENT);
+      assert.equal(second!.failureKind, "circuit_open");
+      assert.equal(srv.hits(), hitsAfterFirst, "no request should be sent while open");
+      assert.equal(d.metrics().shortCircuited, 1);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("half-opens once the cooldown elapses", () => {
+    let now = 1_000;
+    const cb = new CircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 500,
+      now: () => now,
+    });
+    cb.recordFailure("s1");
+    assert.equal(cb.canAttempt("s1"), false);
+
+    now += 499;
+    assert.equal(cb.canAttempt("s1"), false);
+
+    now += 1; // exactly at the cooldown boundary
+    assert.equal(cb.canAttempt("s1"), true);
+    assert.equal(cb.stateOf("s1"), "half_open");
+  });
+
+  it("closes again after a successful probe", () => {
+    let now = 0;
+    const cb = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 10, now: () => now });
+    cb.recordFailure("s1");
+    now += 10;
+    cb.canAttempt("s1");
+    cb.recordSuccess("s1");
+    assert.equal(cb.stateOf("s1"), "closed");
+    assert.equal(cb.snapshot("s1").consecutiveFailures, 0);
+  });
+
+  it("re-opens immediately when the probe fails", () => {
+    let now = 0;
+    const cb = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 10, now: () => now });
+    cb.recordFailure("s1");
+    now += 10;
+    cb.canAttempt("s1");
+    assert.equal(cb.stateOf("s1"), "half_open");
+    cb.recordFailure("s1");
+    assert.equal(cb.stateOf("s1"), "open");
+    assert.equal(cb.canAttempt("s1"), false);
+  });
+
+  it("a success resets the consecutive-failure count", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3 });
+    cb.recordFailure("s1");
+    cb.recordFailure("s1");
+    cb.recordSuccess("s1");
+    cb.recordFailure("s1");
+    assert.equal(cb.stateOf("s1"), "closed");
+  });
+
+  it("tracks circuits independently per subscription", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1 });
+    cb.recordFailure("s1");
+    assert.equal(cb.stateOf("s1"), "open");
+    assert.equal(cb.stateOf("s2"), "closed");
+  });
+
+  it("exposes a nextProbeAt on an open circuit", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 1_000, now: () => 5_000 });
+    cb.recordFailure("s1");
+    assert.equal(cb.snapshot("s1").nextProbeAt, 6_000);
+  });
+});
+
+describe("metrics", () => {
+  it("reports accurate counts across a mixed success/failure run", async () => {
+    const ok = await startServer(() => ({ status: 200 }));
+    const bad = await startServer(() => ({ status: 500 }));
+    const hang = await startServer(() => ({ hang: true }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(ok.url);
+      reg.register(bad.url);
+      reg.register(hang.url);
+      const d = makeDispatcher(reg, { maxRetries: 1, timeoutMs: 150 });
+
+      await d.dispatch(EVENT);
+      const m = d.metrics();
+
+      // ok: 1 attempt. bad: 2 attempts. hang: 2 attempts (both time out).
+      assert.equal(m.attempted, 5);
+      assert.equal(m.succeeded, 1);
+      assert.equal(m.failed, 2);
+      assert.equal(m.timedOut, 2);
+      assert.equal(m.deadLettered, 2);
+      assert.equal(m.retries, 2);
+      assert.equal(m.circuits.length, 3);
+    } finally {
+      await ok.close();
+      await bad.close();
+      await hang.close();
+    }
+  });
+
+  it("starts at zero and resets", async () => {
+    const d = makeDispatcher(new WebhookRegistry());
+    const m = d.metrics();
+    assert.equal(m.attempted, 0);
+    assert.equal(m.succeeded, 0);
+    assert.equal(m.deadLettered, 0);
+    d.resetMetrics();
+    assert.equal(d.metrics().attempted, 0);
+  });
+});
+
+describe("request shape", () => {
+  it("sends the event as JSON with the secret header when configured", async () => {
+    const srv = await startServer(() => ({ status: 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url, { secret: "s3cr3t" });
+      const d = makeDispatcher(reg);
+      await d.dispatch(EVENT);
+
+      assert.equal(srv.headers()[0]!["x-webhook-secret"], "s3cr3t");
+      assert.equal(srv.headers()[0]!["content-type"], "application/json");
+      assert.deepEqual(JSON.parse(srv.bodies()[0]!), EVENT);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("omits the secret header when none is configured", async () => {
+    const srv = await startServer(() => ({ status: 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(srv.url);
+      const d = makeDispatcher(reg);
+      await d.dispatch(EVENT);
+      assert.equal(srv.headers()[0]!["x-webhook-secret"], undefined);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("delivers only to subscriptions matching the event", async () => {
+    const match = await startServer(() => ({ status: 200 }));
+    const other = await startServer(() => ({ status: 200 }));
+    try {
+      const reg = new WebhookRegistry();
+      reg.register(match.url, { eventType: "swap" });
+      reg.register(other.url, { eventType: "mint_pos" });
+      const d = makeDispatcher(reg);
+      const results = await d.dispatch(EVENT);
+      assert.equal(results.length, 1);
+      assert.equal(match.hits(), 1);
+      assert.equal(other.hits(), 0);
+    } finally {
+      await match.close();
+      await other.close();
+    }
+  });
+
+  it("resolves to an empty array when nothing matches", async () => {
+    const reg = new WebhookRegistry();
+    reg.register("http://127.0.0.1:1/never", { eventType: "other" });
+    const d = makeDispatcher(reg);
+    assert.deepEqual(await d.dispatch(EVENT), []);
   });
 });

--- a/services/webhook-streamer/src/types.ts
+++ b/services/webhook-streamer/src/types.ts
@@ -35,6 +35,27 @@ export interface WebhookSubscription {
   createdAt: number;
 }
 
+/**
+ * Why a delivery attempt failed.
+ *
+ * `timeout` is deliberately distinct from `network` so operators can tell a
+ * slow subscriber from a broken one (issue #720).
+ */
+export type FailureKind = "timeout" | "network" | "http" | "circuit_open";
+
+/** Outcome of one individual HTTP attempt within a delivery. */
+export interface AttemptOutcome {
+  /** 0-based attempt index. */
+  attempt: number;
+  success: boolean;
+  statusCode?: number;
+  failureKind?: FailureKind;
+  error?: string;
+  /** Delay waited *before* this attempt was made, in ms. */
+  delayMs: number;
+  attemptedAt: number;
+}
+
 /** Result of a single webhook delivery attempt. */
 export interface DeliveryResult {
   subscriptionId: string;
@@ -43,4 +64,50 @@ export interface DeliveryResult {
   statusCode?: number;
   error?: string;
   attemptedAt: number;
+  /** Set when the delivery failed; distinguishes a timeout from other failures. */
+  failureKind?: FailureKind;
+  /** True when the request was abandoned at the configured timeout. */
+  timedOut?: boolean;
+  /** Every attempt made, in order. Length is 1 when no retry occurred. */
+  attempts?: AttemptOutcome[];
+  /** True when the delivery was abandoned and written to the dead-letter queue. */
+  deadLettered?: boolean;
+  /** Identifier of the dead-letter entry, when one was created. */
+  deadLetterId?: string;
+}
+
+/** A permanently-failed delivery, retained for inspection and replay. */
+export interface DeadLetter {
+  id: string;
+  event: PoolEvent;
+  subscription: WebhookSubscription;
+  attempts: AttemptOutcome[];
+  /** When the delivery was finally abandoned. */
+  failedAt: number;
+  /** Human-readable summary of the terminal failure. */
+  reason: string;
+}
+
+/** Circuit-breaker states, following the standard closed → open → half-open cycle. */
+export type CircuitState = "closed" | "open" | "half_open";
+
+/** Point-in-time view of one subscription's circuit. */
+export interface CircuitSnapshot {
+  subscriptionId: string;
+  state: CircuitState;
+  consecutiveFailures: number;
+  /** Epoch ms at which an open circuit may next be probed. */
+  nextProbeAt?: number;
+}
+
+/** Aggregate delivery counters exposed via GET /metrics. */
+export interface MetricsSnapshot {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  timedOut: number;
+  deadLettered: number;
+  retries: number;
+  shortCircuited: number;
+  circuits: CircuitSnapshot[];
 }


### PR DESCRIPTION
Delivery is the whole product of `webhook-streamer`, and the delivery path had no timeout, no jitter, and no way to recover a failed event. One unresponsive subscriber degraded the service for everyone.

## What changed

**Per-request timeout.** Every attempt is bounded by an `AbortController` (default 10s, `DELIVERY_TIMEOUT_MS`). `node-fetch` has no default request timeout, so a subscriber that accepted the connection and never responded held the promise open indefinitely. Timeouts are recorded as their own `FailureKind`, distinct from network errors, so operators can tell *slow* from *broken*.

**Subscriber isolation.** `Promise.all` is replaced with settled results over a bounded worker pool (`DELIVERY_CONCURRENCY`, default 10). Previously one hanging endpoint blocked the fan-out for that event forever — and the poller awaited that callback, so a single bad subscriber could stall the whole loop. Fan-out also no longer opens unlimited sockets.

**Retry policy.**
- Full jitter: `random(0, base * 2 ** attempt)`, capped at `maxDelayMs`. The old lockstep 500ms/1s/2s schedule meant every subscriber failing at once retried in synchrony against a recovering endpoint.
- Iterative, not recursive — a long retry chain no longer grows the stack per attempt.
- Only retryable failures retry: 408, 429, 5xx, network and timeout. 4xx is terminal; a 404 will still be a 404 in two seconds.
- `Retry-After` honoured when sent (delta-seconds or HTTP-date), clamped so a hostile header cannot stall delivery.

**Dead-letter queue** (`src/dead-letter.ts`). Captures permanently-failed deliveries with the event, the subscription, every attempt's outcome and a timestamp. Bounded (`DEAD_LETTER_MAX`, default 1000) with oldest-first eviction. Each dead-letter emits a log line with event, subscription, attempt count, reason and circuit state.

**Circuit breaker** (`src/circuit-breaker.ts`). Consecutive failures tracked per subscription; after a threshold the circuit opens and delivery is skipped for a cooldown, then half-opens to probe. A failed probe re-opens immediately. Circuit state is dropped when a webhook is unregistered so a reused id cannot inherit a stale open circuit.

## New routes

Additive — the existing request router is not restructured.

| Route | Purpose |
|---|---|
| `GET /metrics` | attempted, succeeded, failed, timed out, dead-lettered, retries, short-circuited, per-subscription circuit state |
| `GET /dead-letters` | list retained failures |
| `POST /dead-letters/:id/replay` | re-attempt a failed delivery |
| `DELETE /dead-letters/:id` | discard an entry |

`GET /webhooks` now also reports each subscription's circuit state.

## Tests

**50 tests, all against a local HTTP server — no external network.** `npx tsc` clean.

Covers the hang-and-abandon case that **fails against `main`**, isolation of a hanging subscriber from a healthy one, jitter variance across repeated runs, 404-vs-503 retry classification, `Retry-After` precedence over computed jitter, dead-letter bounding and replay, circuit transitions tested exactly at the cooldown boundary, and metric accuracy across a mixed success/failure run.

## Notes for the reviewer

- Out of scope per the coordination note: payload signing, management-API auth, subscription persistence. `registry.ts` is untouched.
- **Pre-existing, not fixed here:** `package.json` pins `typescript@5.6.0` and `@types/node@22.0.0`, neither of which exists on npm, so `npm install` fails on a clean checkout. I verified against `typescript@5.6.3` / `@types/node@22.7.5` without changing the pins. Worth a separate fix.

Closes #720
Closes #719 
Closes #718 
Closes #726 