### PR TITLE
fix: repair contract tooling, docs, and advanced client

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,6 +1,6 @@
 # Security Audit — Soroban AMM Pool Contract
 
-**Scope:** `contracts/amm/src/lib.rs` — constant-product AMM pool  
+**Scope:** `contracts/amm/src/lib.rs` (constant-product pool) and `contracts/concentrated_liquidity/src/lib.rs` (concentrated-liquidity pool)
 **Audit type:** Internal property-based audit with manual review  
 **Methodology:** Static analysis, manual code review, and property-based testing via proptest
 
@@ -10,14 +10,19 @@
 
 | Component | File | Focus |
 |-----------|------|-------|
-| AMM pool | `contracts/amm/src/lib.rs` | Liquidity accounting, fee calculations, swap invariants |
+| Constant-product AMM | `contracts/amm/src/lib.rs` | Liquidity accounting, fee calculations, swap invariants |
+| Concentrated-liquidity AMM | `contracts/concentrated_liquidity/src/lib.rs` | Tick bounds, positions, liquidity accounting, swaps |
 | LP token | `contracts/token/src/lib.rs` | Mint/burn authorization |
 | Factory | `contracts/factory/src/lib.rs` | Deployment and initialization |
 | Fuzz suite | `contracts/amm-fuzz/src/lib.rs` | Property-based invariant verification |
 
-> Note: This AMM uses the constant-product formula (x\*y=k). There is no
-> concentrated liquidity or tick-based pricing in this codebase. Audit findings
-> are scoped to the constant-product model accordingly.
+> Scope note: This report contains the findings from the original constant-product
+> review and identifies the concentrated-liquidity contract as a separate review
+> surface. The concentrated-liquidity implementation uses tick-based ranges and
+> position liquidity; the x*y=k findings below must not be generalized to that
+> contract. A complete concentrated-liquidity security review should separately
+> cover tick transitions, price bounds, position ownership, fee accounting, and
+> liquidity-crossing arithmetic.
 
 ---
 
@@ -142,7 +147,9 @@ can use to detect initial price discovery.
 ## 3. Property-Based Testing Summary
 
 The fuzz suite in `contracts/amm-fuzz/src/lib.rs` verified the following
-properties over **10 000 random cases each**:
+constant-product properties over **10 000 random cases each**. These results
+apply to `contracts/amm/src/lib.rs` only and are not evidence that the
+concentrated-liquidity contract has the same invariant.
 
 | Property | Result |
 |----------|--------|
@@ -171,7 +178,11 @@ All regression cases pinned in `regression` module also pass.
 
 ## 5. Conclusion
 
-The constant-product AMM pool is functionally sound. The x\*y=k invariant holds
-across all fee tiers verified by the fuzz suite. Three open issues (H-01, M-01,
-L-03) are recommended for remediation before a mainnet deployment handling
-significant value. No critical vulnerabilities were identified.
+The constant-product AMM review found the x*y=k invariant holding across the
+fee tiers exercised by the fuzz suite, subject to the open findings listed above.
+The concentrated-liquidity contract is an additional production component with
+tick-based pricing and position ranges; it requires its own complete audit
+before deployment handling significant value. This document must therefore be
+read as a scoped review, not a claim that the entire workspace is functionally
+sound. No critical vulnerabilities were identified within the reviewed
+constant-product scope.

--- a/docs/event-schema-versioning.md
+++ b/docs/event-schema-versioning.md
@@ -3,7 +3,7 @@
 Every event emitted by the AMM, CL, governance, factory (and any future
 contract that adopts the pattern) carries a `schema_version: u32`
 field. Off-chain consumers (GraphQL indexer, health dashboard, any
-WebSocket subscriber) read this field BEFORe decoding the rest of
+WebSocket subscriber) read this field before decoding the rest of
 the payload so an unexpected version can be quarantined rather than
 silently misinterpreted.
 
@@ -96,14 +96,11 @@ prefix -- easy to validate during the upgrade window.
 
 ## Affected contracts
 
-This PR migrates every existing emit site in:
-
-- `contracts/amm/src/lib.rs` (14 sites)
-- `contracts/concentrated_liquidity/src/lib.rs` (5 sites)
-- `contracts/governance/src/lib.rs` (5 sites)
-- `contracts/factory/src/lib.rs` (6 sites)
-
-Total: *30 sites migrated**.
+The catalogue below is the current source-level event inventory for the contracts
+that emit versioned events. Keep it synchronized with every
+`emit_versioned_event!` call when adding or changing events; do not rely on a
+hard-coded site count because tests and helper examples may also contain macro
+calls.
 
 `contracts/staking/src/lib.rs` was inspected but has no event emissions
 yet -- once it starts emitting it should adopt the macro from day one.
@@ -122,3 +119,87 @@ The factory now emits two additional events:
   `(schema_version: u32, verified: bool)`.
 
 Consumers should ignore unknown topics; existing versioning rules apply.
+
+## Event catalogue
+
+Every row below has the on-wire data shape `(schema_version, payload)`.
+The topic is the event name, optionally followed by the address shown in the
+`topics` column. Field types use the Rust/Soroban names from the emitting
+contract.
+
+### Constant-product AMM — `contracts/amm/src/lib.rs`
+
+| Event | Topics | Payload |
+|---|---|---|
+| `swap` | `trader` | `(token_in: Address, amount_in: i128, token_out: Address, amount_out: i128)` on standard paths; the fee-on-transfer path uses `(token_in, actual_received, token_out, amount_out, referrer: Option<Address>)` |
+| `flash_loan` | `receiver` | `(amount_a: i128, amount_b: i128, fee_a: i128, fee_b: i128)` |
+| `fot_detected` | `token_in` | `(amount_in: i128, actual_received: i128)` |
+| `add_liquidity` | `provider` | `(amount_a: i128, amount_b: i128, shares: i128)` |
+| `rm_liq` | — | `(provider: Address, shares: i128, amount_a: i128, amount_b: i128)` |
+| `rm_liq_1s` | — | `(provider: Address, shares: i128, token_out: Address, amount_out: i128)` |
+| `admin_nominated` | — | `(current_admin: Address, new_admin: Address)` |
+| `admin_changed` | — | `(new_admin: Address)` |
+
+| `cb_config` | — | `(threshold_bps: i128, cooldown_secs: u64)` |
+| `circuit_break` | — | `(baseline_price: i128, current_price: i128, deviation_bps: i128, threshold_bps: i128)` |
+| `emergency_withdraw` | `admin` | `(to: Address, reserve_a: i128, reserve_b: i128)` |
+| `flash_fee_upd` | `admin` | `(new_fee_bps: i128)` |
+| `lp_rebate_set` | `admin` | `(lp_rebate_bps: i128)` |
+| `multisig_set` | `admin` | `(quorum: u32)` |
+| `ms_proposed` | `signer` | `(recipient: Address, approvals: u32)` |
+| `ms_ew` | `signer` | `(to: Address, reserve_a: i128, reserve_b: i128)` |
+
+The two swap payload variants and all configuration payloads above are emitted
+by the current source. Consumers should use the event topic and the global
+schema version together when selecting a decoder.
+
+### Concentrated-liquidity AMM — `contracts/concentrated_liquidity/src/lib.rs`
+
+| Event | Topics | Payload |
+|---|---|---|
+| `mint_pos` | `provider` | `(lower_tick: i32, upper_tick: i32, liquidity: i128, amount_a: i128, amount_b: i128)` |
+| `mod_pos` | `provider` | `(lower_tick: i32, upper_tick: i32, liquidity_delta: i128, amount_a: i128, amount_b: i128)` |
+| `mint_1t` | `provider` | `(lower_tick: i32, upper_tick: i32, liquidity: i128, amount_used: i128, dust: i128)` |
+| `rng_ord` | `provider` | `(lower_tick: i32, upper_tick: i32, liquidity: i128, is_above: bool)` |
+| `burn_pos` | `recipient` | `(lower_tick: i32, upper_tick: i32, liquidity: i128, amount_a: i128, amount_b: i128)` |
+| `coll_fees` | `recipient` | `(lower_tick: i32, upper_tick: i32, total_a: i128, total_b: i128)` |
+| `nft_link` | `provider` | `(token_id: i128, lower_tick: i32, upper_tick: i32)` |
+| `swap` | `sender` | `(zero_for_one: bool, amount_in: i128, amount_out: i128, sqrt_price_x96: i128, current_tick: i32, liquidity: i128)` |
+| `price_upd` | `token_in`, `token_out` | `(amount_in: i128, amount_out: i128, sqrt_price_x96: i128, current_tick: i32)` |
+
+### Factory — `contracts/factory/src/lib.rs`
+
+| Event | Payload |
+|---|---|
+| `pool_created` | `(token_a: Address, token_b: Address, pool: Address, fee_bps: u32, lp_token: Address, ...)` |
+| `cl_pool_created` | `(token_a: Address, token_b: Address, fee_bps: u32, pool: Address)` |
+| `wasm_updated` | `(amm_wasm_hash: BytesN<32>, token_wasm_hash: BytesN<32>)` |
+| `creation_paused` / `creation_unpaused` | `(admin: Address)` |
+| `mode_changed` | `(enabled: bool)` |
+| `creation_fee_set` | `(fee_token: Address, fee_amount: i128)` |
+| `treasury_set` | `(treasury: Address, global_protocol_fee_bps: u32, updated: u32)` |
+| `global_fee_set` | `(protocol_fee_bps: u32, offset: u32, updated: u32)` |
+| `fees_swept` | `(treasury: Address, token: Address, offset: u32, pools_swept: u32, total_collected: i128)` |
+| `creation_fee_paid` | `(caller: Address, fee_amount: i128)` |
+| `pool_meta` | `(label: String, category: PoolCategory, created_at: u64, created_by: Address, verified: bool)` |
+| `pool_ver` | `(verified: bool)` |
+
+### Governance — `contracts/governance/src/lib.rs`
+
+| Event | Payload |
+|---|---|
+| `admin_nominated` | `(current_admin: Address, new_admin: Address)` |
+| `admin_changed` | `(new_admin: Address)` |
+| `proposed` | `(id: u64, proposer: Address, kind: ProposalKind, vote_end: u64, snapshot_ledger: u32)` |
+| `voted` | `(proposal_id: u64, voter: Address, choice: VoteChoice, voting_power: i128)` |
+| `executed` | `(proposal_id: u64, kind: ProposalKind)` |
+| `vote_unlocked` | `(proposal_id: u64, locked: i128)` |
+| `vetoed` | `(proposal_id: u64, multisig: Address, now: u64, discussion_end: u64)` |
+
+### Consumer rules
+
+A consumer must inspect the leading `schema_version` before decoding any row in
+this catalogue. It may decode a version it explicitly supports, quarantine a
+newer version, and ignore an unknown topic. A payload shape change requires a
+single global version bump even if the change affects only one event; adding a
+new topic does not require a bump by itself.

--- a/packages/ts-advanced-client/README.md
+++ b/packages/ts-advanced-client/README.md
@@ -6,12 +6,24 @@ price feeds and plugins.
 Usage example:
 
 ```ts
-import { AdvancedClient, signerMiddleware, priceFeedMiddleware } from '@example/ts-advanced-client'
+import {
+  AdvancedClient,
+  priceFeedMiddleware,
+  signerMiddleware,
+} from '@example/ts-advanced-client'
 
-const client = new AdvancedClient()
+type Transaction = { kind: string; amount: number; signed?: boolean }
+type Result = { hash: string }
+
+const client = new AdvancedClient<Transaction, Result>({
+  async sendTransaction(tx) {
+    // Adapt this call to the Soroban SDK/RPC client used by your application.
+    return sorobanRpc.sendTransaction(tx)
+  },
+})
 client.middleware()
   .use(priceFeedMiddleware(async () => 123.45))
-  .use(signerMiddleware({ sign: async (tx)=> ({...tx, signed:true}) }))
+  .use(signerMiddleware({ sign: async (tx) => ({ ...tx, signed: true }) }))
 
-await client.sendTransaction({ kind: 'swap', amount: 1000 })
+const result = await client.sendTransaction({ kind: 'swap', amount: 1000 })
 ```

--- a/packages/ts-advanced-client/package.json
+++ b/packages/ts-advanced-client/package.json
@@ -5,6 +5,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test test/*.test.js",
     "clean": "rm -rf lib"
   },
   "devDependencies": {

--- a/packages/ts-advanced-client/src/index.ts
+++ b/packages/ts-advanced-client/src/index.ts
@@ -1,62 +1,79 @@
-export type MiddlewareContext = {
-  tx: any
-  metadata?: Record<string, unknown>
+export type Transaction = object
+
+export type MiddlewareContext<TTransaction extends Transaction = Transaction> = {
+  tx: TTransaction
+  metadata: Record<string, unknown>
 }
 
-export type Middleware = (ctx: MiddlewareContext, next: () => Promise<void>) => Promise<void>
+export type Middleware<TTransaction extends Transaction = Transaction> = (
+  ctx: MiddlewareContext<TTransaction>,
+  next: () => Promise<void>,
+) => Promise<void>
 
-export class MiddlewareStack {
-  private middlewares: Middleware[] = []
+export interface TransactionSubmitter<
+  TTransaction extends Transaction = Transaction,
+  TResult = unknown,
+> {
+  sendTransaction(tx: TTransaction): Promise<TResult>
+}
 
-  use(m: Middleware) {
-    this.middlewares.push(m)
+export class MiddlewareStack<TTransaction extends Transaction = Transaction> {
+  private readonly middlewares: Array<Middleware<TTransaction>> = []
+
+  use(middleware: Middleware<TTransaction>): this {
+    this.middlewares.push(middleware)
     return this
   }
 
-  async run(ctx: MiddlewareContext) {
-    let idx = -1
-    const dispatch = async (i: number): Promise<void> => {
-      if (i <= idx) throw new Error('next() called multiple times')
-      idx = i
-      const fn = this.middlewares[i]
-      if (fn) {
-        await fn(ctx, () => dispatch(i + 1))
-      }
+  async run(ctx: MiddlewareContext<TTransaction>): Promise<void> {
+    let index = -1
+    const dispatch = async (current: number): Promise<void> => {
+      if (current <= index) throw new Error('next() called multiple times')
+      index = current
+      const middleware = this.middlewares[current]
+      if (middleware) await middleware(ctx, () => dispatch(current + 1))
     }
     await dispatch(0)
   }
 }
 
-export class AdvancedClient {
-  private stack = new MiddlewareStack()
+export class AdvancedClient<
+  TTransaction extends Transaction = Transaction,
+  TResult = unknown,
+> {
+  private readonly stack = new MiddlewareStack<TTransaction>()
 
-  middleware(): MiddlewareStack {
+  constructor(private readonly submitter: TransactionSubmitter<TTransaction, TResult>) {}
+
+  middleware(): MiddlewareStack<TTransaction> {
     return this.stack
   }
 
-  async sendTransaction(tx: any) {
-    const ctx: MiddlewareContext = { tx, metadata: {} }
-    // run middlewares in order
+  async sendTransaction(tx: TTransaction): Promise<TResult> {
+    const ctx: MiddlewareContext<TTransaction> = { tx, metadata: {} }
     await this.stack.run(ctx)
-    // after middleware stack, tx should be signed/validated
-    // TODO: submit to network
-    return { status: 'ok', tx }
+    return this.submitter.sendTransaction(ctx.tx)
   }
 }
 
-// Example plugin: signer middleware
-export function signerMiddleware(signer: { sign: (tx: any) => Promise<any> }): Middleware {
+export interface Signer<TTransaction extends Transaction = Transaction> {
+  sign(tx: TTransaction): Promise<TTransaction>
+}
+
+export function signerMiddleware<TTransaction extends Transaction>(
+  signer: Signer<TTransaction>,
+): Middleware<TTransaction> {
   return async (ctx, next) => {
     ctx.tx = await signer.sign(ctx.tx)
     await next()
   }
 }
 
-// Example plugin: price feed middleware
-export function priceFeedMiddleware(getPrice: () => Promise<number>): Middleware {
+export function priceFeedMiddleware<TTransaction extends Transaction = Transaction>(
+  getPrice: () => Promise<number>,
+): Middleware<TTransaction> {
   return async (ctx, next) => {
-    const price = await getPrice()
-    ctx.metadata = { ...(ctx.metadata || {}), price }
+    ctx.metadata.price = await getPrice()
     await next()
   }
 }

--- a/packages/ts-advanced-client/test/advanced-client.test.js
+++ b/packages/ts-advanced-client/test/advanced-client.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const {
+  AdvancedClient,
+  MiddlewareStack,
+  priceFeedMiddleware,
+  signerMiddleware,
+} = require('../lib/index.js')
+
+test('runs middleware in order and submits the processed transaction', async () => {
+  const calls = []
+  const submitter = {
+    async sendTransaction(tx) {
+      calls.push(['submit', tx])
+      return { hash: 'abc123', tx }
+    },
+  }
+  const client = new AdvancedClient(submitter)
+  client
+    .middleware()
+    .use(priceFeedMiddleware(async () => 123.45))
+    .use(signerMiddleware({ sign: async (tx) => ({ ...tx, signed: true }) }))
+    .use(async (ctx, next) => {
+      calls.push(['middleware', ctx.metadata.price])
+      await next()
+    })
+
+  const result = await client.sendTransaction({ kind: 'swap', amount: 1000 })
+
+  assert.deepEqual(calls, [
+    ['middleware', 123.45],
+    ['submit', { kind: 'swap', amount: 1000, signed: true }],
+  ])
+  assert.deepEqual(result, {
+    hash: 'abc123',
+    tx: { kind: 'swap', amount: 1000, signed: true },
+  })
+})
+
+test('does not submit when middleware fails', async () => {
+  let submitted = false
+  const client = new AdvancedClient({
+    async sendTransaction() {
+      submitted = true
+      return { ok: true }
+    },
+  })
+  client.middleware().use(async () => {
+    throw new Error('validation failed')
+  })
+
+  await assert.rejects(() => client.sendTransaction({ kind: 'swap' }), /validation failed/)
+  assert.equal(submitted, false)
+})
+
+test('rejects calling next more than once', async () => {
+  const stack = new MiddlewareStack()
+  stack.use(async (_ctx, next) => {
+    await next()
+    await assert.rejects(() => next(), /next\(\) called multiple times/)
+  })
+
+  await stack.run({ tx: { kind: 'swap' }, metadata: {} })
+})

--- a/scripts/optimize_contracts.sh
+++ b/scripts/optimize_contracts.sh
@@ -1,38 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build and optimize all contracts producing wasm artifacts.
-# Requires: cargo, wasm-opt (binaryen) optional but recommended.
+# Build and optimize all contracts producing WASM artifacts.
+# Requires: cargo and the wasm32v1-none Rust target. The Stellar CLI is used
+# when available; wasm-opt is supported as a fallback.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CONTRACTS_DIR="$ROOT_DIR/contracts"
-TARGET=wasm32-unknown-unknown
+TARGET="wasm32v1-none"
+WASM_DIR="$ROOT_DIR/target/$TARGET/release"
+OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/optimized-artifacts}"
 
-echo "[optimize] Starting contract optimization"
+cd "$ROOT_DIR"
+printf '[optimize] Building workspace for %s\n' "$TARGET"
+cargo build --workspace --release --target "$TARGET"
 
-for d in "$CONTRACTS_DIR"/*/; do
-  if [ -f "$d/Cargo.toml" ]; then
-    name=$(basename "$d")
-    echo "\n[optimize] Building contract: $name"
-    pushd "$d" >/dev/null
-    cargo build --release --target "$TARGET" || true
-    # locate wasm
-    wasm_path="$(find target -path "*/release/*.wasm" -print -quit 2>/dev/null || true)"
-    if [ -n "$wasm_path" ]; then
-      echo "[optimize] found wasm: $wasm_path"
-      if command -v wasm-opt >/dev/null 2>&1; then
-        out="$(dirname "$wasm_path")/$(basename "$wasm_path" .wasm).opt.wasm"
-        echo "[optimize] running wasm-opt -O3 --strip-dwarf"
-        wasm-opt -O3 --strip-dwarf -o "$out" "$wasm_path" || true
-        echo "[optimize] optimized wasm written to $out"
-      else
-        echo "[optimize] wasm-opt not found; skipping binary-level optimization"
-      fi
-    else
-      echo "[optimize] no wasm found for $name (skipping wasm-opt)"
-    fi
-    popd >/dev/null
+shopt -s nullglob
+artifacts=("$WASM_DIR"/*.wasm)
+if [[ ${#artifacts[@]} -eq 0 ]]; then
+  echo "[optimize] no WASM artifacts found in $WASM_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+for wasm in "${artifacts[@]}"; do
+  name=$(basename "$wasm")
+  output="$OUTPUT_DIR/$name"
+  printf '[optimize] %s -> %s\n' "${wasm#$ROOT_DIR/}" "${output#$ROOT_DIR/}"
+
+  if command -v stellar >/dev/null 2>&1; then
+    stellar contract optimize --wasm "$wasm" --output "$output"
+  elif command -v wasm-opt >/dev/null 2>&1; then
+    wasm-opt -O3 --strip-dwarf -o "$output" "$wasm"
+  else
+    echo '[optimize] neither stellar CLI nor wasm-opt is installed' >&2
+    exit 1
   fi
 done
 
-echo "[optimize] Done. Run scripts/size_report.sh to view sizes."
+printf '[optimize] Optimized artifacts are in %s\n' "${OUTPUT_DIR#$ROOT_DIR/}"

--- a/scripts/size_report.sh
+++ b/scripts/size_report.sh
@@ -2,14 +2,43 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WASM_DIR="${WASM_DIR:-$ROOT_DIR/target/wasm32v1-none/release}"
+MAX_BYTES="${WASM_MAX_BYTES:-204800}"
+FAIL_ON_LIMIT=false
 
-echo "Contract WASM size report"
-echo "-------------------------"
+if [[ "${1:-}" == "--fail-on-limit" ]]; then
+  FAIL_ON_LIMIT=true
+elif [[ $# -gt 0 ]]; then
+  echo "Usage: $0 [--fail-on-limit]" >&2
+  exit 2
+fi
 
-find "$ROOT_DIR"/contracts -type f -name '*.wasm' | while read -r f; do
-  size=$(stat -c%s "$f" 2>/dev/null || true)
-  human=$(numfmt --to=iec-i --suffix=B --format="%.1f" "$size" 2>/dev/null || echo "${size}B")
-  echo "$(realpath --relative-to="$ROOT_DIR" "$f"): $human ($size bytes)"
+shopt -s nullglob
+artifacts=("$WASM_DIR"/*.wasm)
+
+printf 'Contract WASM size report\n'
+printf '%s\n' '-------------------------'
+
+if [[ ${#artifacts[@]} -eq 0 ]]; then
+  echo "No WASM artifacts found in $WASM_DIR" >&2
+  exit 1
+fi
+
+status=0
+for wasm in "${artifacts[@]}"; do
+  size=$(wc -c < "$wasm")
+  human=$(numfmt --to=iec-i --suffix=B --format='%.1f' "$size" 2>/dev/null || printf '%sB' "$size")
+  relative=$(realpath --relative-to="$ROOT_DIR" "$wasm")
+  if (( size > MAX_BYTES )); then
+    printf '%s: %s (%s bytes) EXCEEDS LIMIT (%s bytes)\n' "$relative" "$human" "$size" "$MAX_BYTES"
+    status=1
+  else
+    printf '%s: %s (%s bytes)\n' "$relative" "$human" "$size"
+  fi
 done
 
-echo "-------------------------"
+printf '%s\n' '-------------------------'
+if $FAIL_ON_LIMIT && (( status != 0 )); then
+  exit "$status"
+fi
+exit 0


### PR DESCRIPTION
Summary
This pull request combines the four requested fixes:

Repairs scripts/size_report.sh to inspect target/wasm32v1-none/release, report every generated WASM artifact, honor the documented 200 KiB limit, and support the release workflow’s --fail-on-limit flag.
Repairs scripts/optimize_contracts.sh to build the workspace for the documented wasm32v1-none target and optimize all generated contract artifacts using the Stellar CLI or wasm-opt fallback.
Completes docs/event-schema-versioning.md with a source-aligned catalogue for AMM, concentrated-liquidity, factory, and governance events, plus consumer compatibility rules.
Re-scopes AUDIT.md so the report distinguishes the constant-product review from the current concentrated-liquidity, tick-based contract and no longer claims that concentrated liquidity is absent.
Replaces any in packages/ts-advanced-client, injects a typed transaction submitter, makes sendTransaction submit the middleware-processed transaction, and adds regression tests.
Validation
TypeScript build and Node test suite pass: 3 tests passed.
Shell scripts pass bash -n syntax validation.
Size-report success and fail-on-limit smoke tests pass.
Optimization smoke test passes with fake build/optimizer tools.
git diff --check passes.
The wasm32v1-none target could not be built in this environment because rustup is unavailable; CI should run the repository’s native workspace build.
Closes https://github.com/promisszn/soroban-amm/issues/702
Closes https://github.com/promisszn/soroban-amm/issues/704
Closes https://github.com/promisszn/soroban-amm/issues/705
Closes https://github.com/promisszn/soroban-amm/issues/709