### PR TITLE
Add CI coverage for JS/TS/Python packages, harden dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,36 +4,70 @@ updates:
     directory: "/"
     schedule: { interval: weekly }
     groups: { patch-updates: { update-types: [patch] } }
+    ignore:
+      # Major bumps have broken the build (events API redesign, deprecated
+      # Env methods) - needs a deliberate migration, not an automatic PR.
+      - dependency-name: "soroban-sdk"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: "/packages/sdk"
     schedule: { interval: weekly }
     groups: { patch-updates: { update-types: [patch] } }
+    ignore:
+      # TypeScript 7 requires an explicit tsconfig `rootDir`, which this
+      # package doesn't set yet - bumping breaks `tsc`.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # v17 introduces ScValType changes that break src/governance.ts.
+      - dependency-name: "@stellar/stellar-sdk"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: "/packages/ui-components"
     schedule: { interval: weekly }
-    groups: { patch-updates: { update-types: [patch] } }
+    groups:
+      patch-updates: { update-types: [patch] }
+      react:
+        patterns: ["react", "react-dom", "@types/react", "@types/react-dom"]
+    ignore:
+      # TypeScript 7's stricter cast checking breaks GovernanceForum.tsx.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: "/packages/ts-advanced-client"
     schedule: { interval: weekly }
     groups: { patch-updates: { update-types: [patch] } }
+    ignore:
+      # Same TypeScript 7 rootDir issue as packages/sdk.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: "/services/graphql-api"
     schedule: { interval: weekly }
+    groups:
+      patch-updates: { update-types: [patch] }
+      graphql:
+        patterns: ["graphql", "@apollo/server"]
   - package-ecosystem: npm
     directory: "/services/webhook-streamer"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }
   - package-ecosystem: npm
     directory: "/services/health-dashboard"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }
   - package-ecosystem: npm
     directory: "/examples/client"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }
   - package-ecosystem: gomod
     directory: "/packages/go-sdk"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }
   - package-ecosystem: pip
     directory: "/examples/python"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }
   - package-ecosystem: github-actions
     directory: "/"
     schedule: { interval: weekly }
+    groups: { patch-updates: { update-types: [patch] } }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,63 @@ jobs:
         run: go vet ./...
       - name: Test
         run: go test ./... -count=1
+
+  npm-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dir: packages/sdk
+            test_cmd: npm test -- --passWithNoTests
+          - dir: packages/ui-components
+            test_cmd: npm test -- --passWithNoTests
+          - dir: packages/ts-advanced-client
+            test_cmd: npm test
+          - dir: services/graphql-api
+            # No runnable test suite yet (the "test" script points at a
+            # dist file that isn't emitted) - build coverage only for now.
+            test_cmd: echo "no test suite configured yet"
+          - dir: services/webhook-streamer
+            test_cmd: npm test
+          - dir: services/health-dashboard
+            test_cmd: npm test
+          - dir: examples/client
+            test_cmd: npm test
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: ${{ matrix.test_cmd }}
+
+  python-examples:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: examples/python
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -q

--- a/packages/ui-components/src/GovernanceForum.tsx
+++ b/packages/ui-components/src/GovernanceForum.tsx
@@ -720,11 +720,11 @@ function ProposalWizard({ onSubmit, onToast }: {
                 <button onClick={() => removeAction(i)} aria-label={`Remove action ${i + 1}`}
                   style={{ ...S.btn, background: "transparent", border: `1px solid ${T.border}`, color: T.muted, padding: ".2rem .5rem", fontSize: ".8rem" }}>✕</button>
               </div>
-              {[["Contract ID", "contractId", "C..."], ["Function", "functionName", "set_fee_rate"], ["Arguments (JSON)", "args", '{"bps": 150}']].map(([l, k, ph]) => (
+              {([["Contract ID", "contractId", "C..."], ["Function", "functionName", "set_fee_rate"], ["Arguments (JSON)", "args", '{"bps": 150}']] as const).map(([l, k, ph]) => (
                 <div key={k} style={{ marginBottom: ".5rem" }}>
                   <label htmlFor={`action-${i}-${k}`} style={{ display: "block", fontSize: ".82rem", marginBottom: ".25rem", color: T.muted }}>{l}</label>
                   <input id={`action-${i}-${k}`} type="text" placeholder={ph}
-                    value={(a as Record<string, string>)[k]}
+                    value={a[k]}
                     onChange={e => set("actions", form.actions.map((x, xi) => xi === i ? { ...x, [k]: e.target.value } : x))}
                     style={inputStyle} />
                 </div>


### PR DESCRIPTION
## Summary
- Adds an `npm-packages` matrix job and a `python-examples` job to `ci.yml`, covering the seven packages (`packages/sdk`, `packages/ui-components`, `packages/ts-advanced-client`, `services/graphql-api`, `services/webhook-streamer`, `services/health-dashboard`, `examples/client`, `examples/python`) that previously had zero CI — every check on their dependabot PRs was passing without ever building the code.
- Updates `dependabot.yml`: ignores TypeScript majors on the three packages where TS7 currently breaks the build, ignores major `soroban-sdk`/`@stellar/stellar-sdk` bumps until someone does that migration deliberately, groups `react`/`react-dom`/`@types/react*` so they can't land independently of each other again, groups `graphql` with its peer-locked `@apollo/server`, and adds `patch-updates` grouping to the ecosystems missing it.
- Fixes a pre-existing `packages/ui-components` build failure that turning on its CI job surfaced: `GovernanceForum.tsx:727` cast `a as Record<string, string>` on an `OnChainAction`, which TypeScript rejects. Narrowed the key with `as const` instead of the unsafe cast.

## Test plan
- [x] Ran every new CI leg locally against current `main` before committing: all 7 npm packages (build + test) and the python job pass.
- [x] Validated both YAML files parse correctly.
- [ ] Confirm the new `npm-packages` / `python-examples` checks show up and pass on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)