### PR TITLE
incentive_campaigns: replace unbounded reads with pagination and add creator/claim indices

### DIFF
--- a/contracts/incentive_campaigns/src/lib.rs
+++ b/contracts/incentive_campaigns/src/lib.rs
@@ -73,6 +73,12 @@ pub enum DataKey {
     /// Audit: next distribution record id
     NextDistributionId,
     DistributionRecord(u64),
+    /// Per creator: ids of every campaign that address created, in creation order.
+    CampaignsByCreator(Address),
+    /// Per campaign: ids of every distribution record it produced, in claim order.
+    DistributionsByCampaign(u64),
+    /// Per provider: ids of every distribution record they received, in claim order.
+    DistributionsByProvider(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +92,11 @@ const BUMP_TO: u32 = 3_110_400; // ~180 days (5 s / ledger)
 /// Chosen large enough that even a rate of 1 token/s with a total supply of
 /// 10^14 tokens still produces a non-zero per-share increment per second.
 const PRECISION: i128 = 1_000_000_000_000; // 1e12
+
+/// Upper bound on the number of entries any paginated read may return. Keeps a
+/// single read within the per-transaction resource limit however many campaigns
+/// or distribution records exist.
+pub const MAX_PAGE: u32 = 50;
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -330,6 +341,16 @@ impl IncentiveCampaigns {
         env.storage().persistent().set(&index_key, &id);
         extend_persistent_ttl(&env, &index_key);
 
+        let creator_key = DataKey::CampaignsByCreator(caller.clone());
+        let mut by_creator: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&creator_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        by_creator.push_back(id);
+        env.storage().persistent().set(&creator_key, &by_creator);
+        extend_persistent_ttl(&env, &creator_key);
+
         let contract = env.current_contract_address();
         TokenClient::new(&env, &reward_token).transfer(&caller, &contract, &funding_amount);
 
@@ -548,6 +569,32 @@ impl IncentiveCampaigns {
             .instance()
             .set(&DataKey::NextDistributionId, &(dist_id + 1));
 
+        // Index the record both ways so it can be found without already knowing
+        // its id. Both lists are append-only, so they stay in claim order.
+        let by_campaign_key = DataKey::DistributionsByCampaign(campaign_id);
+        let mut by_campaign: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&by_campaign_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        by_campaign.push_back(dist_id);
+        env.storage()
+            .persistent()
+            .set(&by_campaign_key, &by_campaign);
+        extend_persistent_ttl(&env, &by_campaign_key);
+
+        let by_provider_key = DataKey::DistributionsByProvider(provider.clone());
+        let mut by_provider: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&by_provider_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        by_provider.push_back(dist_id);
+        env.storage()
+            .persistent()
+            .set(&by_provider_key, &by_provider);
+        extend_persistent_ttl(&env, &by_provider_key);
+
         env.events().publish(
             (Symbol::new(&env, "reward_distributed"),),
             (campaign_id, provider, pending, dist_id),
@@ -571,6 +618,12 @@ impl IncentiveCampaigns {
         campaign
     }
 
+    /// Every campaign id ever created, oldest first.
+    ///
+    /// **Unbounded**: this loads the whole id list and will eventually exceed
+    /// the transaction resource limit. Prefer
+    /// [`IncentiveCampaigns::list_campaigns_paginated`]; kept on the ABI for
+    /// existing consumers.
     pub fn list_campaigns(env: Env) -> Vec<u64> {
         extend_instance_ttl(&env);
         let next_id: u64 = env
@@ -624,6 +677,12 @@ impl IncentiveCampaigns {
         record
     }
 
+    /// Every currently active campaign.
+    ///
+    /// **Unbounded**: this loads the whole id list *and* deserialises every
+    /// campaign behind it. Prefer
+    /// [`IncentiveCampaigns::get_active_campaigns_paginated`]; kept on the ABI
+    /// for existing consumers.
     pub fn get_active_campaigns(env: Env) -> Vec<Campaign> {
         extend_instance_ttl(&env);
         let ids = Self::list_campaigns(env.clone());
@@ -676,8 +735,251 @@ impl IncentiveCampaigns {
     }
 
     // -------------------------------------------------------------------------
+    // Paginated read paths (#684)
+    // -------------------------------------------------------------------------
+
+    /// Number of campaigns ever created.
+    pub fn get_campaign_count(env: Env) -> u32 {
+        extend_instance_ttl(&env);
+        Self::campaign_count(&env) as u32
+    }
+
+    /// Page through campaign ids in creation order.
+    ///
+    /// `limit` is clamped to [`MAX_PAGE`]; `limit == 0` or an `offset` at or
+    /// beyond the campaign count yields an empty `Vec` rather than panicking.
+    /// Paging through the whole range reproduces
+    /// [`IncentiveCampaigns::list_campaigns`] exactly.
+    pub fn list_campaigns_paginated(env: Env, offset: u32, limit: u32) -> Vec<u64> {
+        extend_instance_ttl(&env);
+        let count = Self::campaign_count(&env);
+        let mut page = Vec::new(&env);
+        let Some((start, end)) = Self::page_bounds(offset, limit, count) else {
+            return page;
+        };
+        for i in start..end {
+            if let Some(id) = Self::campaign_id_at(&env, i) {
+                page.push_back(id);
+            }
+        }
+        page
+    }
+
+    /// Page through full campaign structs in creation order.
+    ///
+    /// Same bounds as [`IncentiveCampaigns::list_campaigns_paginated`], but
+    /// saves the caller a `get_campaign` round trip per id.
+    pub fn get_campaigns_paginated(env: Env, offset: u32, limit: u32) -> Vec<Campaign> {
+        extend_instance_ttl(&env);
+        let count = Self::campaign_count(&env);
+        let mut page: Vec<Campaign> = Vec::new(&env);
+        let Some((start, end)) = Self::page_bounds(offset, limit, count) else {
+            return page;
+        };
+        for i in start..end {
+            if let Some(id) = Self::campaign_id_at(&env, i) {
+                if let Some(c) = Self::load_campaign(&env, id) {
+                    page.push_back(c);
+                }
+            }
+        }
+        page
+    }
+
+    /// Page through the currently active campaigns.
+    ///
+    /// `offset` and `limit` count *matching* campaigns, not scanned ones, so a
+    /// page of `limit` active campaigns comes back even when inactive ones are
+    /// interleaved. `limit` is clamped to [`MAX_PAGE`], which bounds the size of
+    /// the result; the scan itself still walks the id list until it has filled
+    /// the page, so callers paging deeply should prefer
+    /// [`IncentiveCampaigns::get_campaigns_paginated`] plus their own filter.
+    pub fn get_active_campaigns_paginated(env: Env, offset: u32, limit: u32) -> Vec<Campaign> {
+        extend_instance_ttl(&env);
+        let mut page: Vec<Campaign> = Vec::new(&env);
+        let capped = limit.min(MAX_PAGE);
+        if capped == 0 {
+            return page;
+        }
+
+        let now = env.ledger().timestamp();
+        let count = Self::campaign_count(&env);
+        let mut matched: u32 = 0;
+        for i in 0..count {
+            let Some(id) = Self::campaign_id_at(&env, i) else {
+                continue;
+            };
+            let Some(c) = Self::load_campaign(&env, id) else {
+                continue;
+            };
+            if !Self::campaign_is_active(&c, now) {
+                continue;
+            }
+            if matched >= offset {
+                page.push_back(c);
+                if page.len() >= capped {
+                    break;
+                }
+            }
+            matched += 1;
+        }
+        page
+    }
+
+    /// Page through the campaign ids created by `creator`, in creation order.
+    ///
+    /// Returns an empty `Vec` for an address that has never created a campaign.
+    pub fn get_campaigns_by_creator(
+        env: Env,
+        creator: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<u64> {
+        extend_instance_ttl(&env);
+        let key = DataKey::CampaignsByCreator(creator);
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        Self::page_u64(&env, &ids, offset, limit)
+    }
+
+    /// Whether `campaign_id` is active right now, without pulling the struct.
+    ///
+    /// A campaign that does not exist is reported as inactive rather than
+    /// panicking, so a caller can probe an id safely.
+    pub fn is_campaign_active(env: Env, campaign_id: u64) -> bool {
+        extend_instance_ttl(&env);
+        match Self::load_campaign(&env, campaign_id) {
+            Some(c) => Self::campaign_is_active(&c, env.ledger().timestamp()),
+            None => false,
+        }
+    }
+
+    /// Number of distribution records a campaign has produced.
+    pub fn get_distribution_count(env: Env, campaign_id: u64) -> u32 {
+        extend_instance_ttl(&env);
+        Self::distribution_ids_by_campaign(&env, campaign_id).len()
+    }
+
+    /// Page through a campaign's distribution records, oldest claim first.
+    pub fn list_distribution_records(
+        env: Env,
+        campaign_id: u64,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<DistributionRecord> {
+        extend_instance_ttl(&env);
+        let ids = Self::distribution_ids_by_campaign(&env, campaign_id);
+        Self::page_records(&env, &ids, offset, limit)
+    }
+
+    /// Page through everything `provider` has ever claimed, in chronological
+    /// order across all campaigns.
+    ///
+    /// Returns an empty `Vec` for a provider that has never claimed.
+    pub fn get_claim_history(
+        env: Env,
+        provider: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<DistributionRecord> {
+        extend_instance_ttl(&env);
+        let key = DataKey::DistributionsByProvider(provider);
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        Self::page_records(&env, &ids, offset, limit)
+    }
+
+    // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------
+
+    /// Resolve `(offset, limit)` against `count`, clamping `limit` to
+    /// [`MAX_PAGE`]. `None` means "nothing to return": an empty limit, or an
+    /// offset at or past the end.
+    fn page_bounds(offset: u32, limit: u32, count: u64) -> Option<(u64, u64)> {
+        let capped = limit.min(MAX_PAGE) as u64;
+        if capped == 0 {
+            return None;
+        }
+        let start = offset as u64;
+        if start >= count {
+            return None;
+        }
+        Some((start, (start + capped).min(count)))
+    }
+
+    fn campaign_count(env: &Env) -> u64 {
+        let next_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextCampaignId)
+            .unwrap_or(1);
+        next_id.saturating_sub(1)
+    }
+
+    fn campaign_id_at(env: &Env, index: u64) -> Option<u64> {
+        let key = DataKey::CampaignIdByIndex(index);
+        let id = env.storage().persistent().get::<DataKey, u64>(&key)?;
+        extend_persistent_ttl(env, &key);
+        Some(id)
+    }
+
+    fn load_campaign(env: &Env, campaign_id: u64) -> Option<Campaign> {
+        let key = DataKey::Campaign(campaign_id);
+        let campaign = env.storage().persistent().get::<DataKey, Campaign>(&key)?;
+        extend_persistent_ttl(env, &key);
+        Some(campaign)
+    }
+
+    fn campaign_is_active(campaign: &Campaign, now: u64) -> bool {
+        campaign.active && now >= campaign.start_time && now <= campaign.end_time
+    }
+
+    fn distribution_ids_by_campaign(env: &Env, campaign_id: u64) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DistributionsByCampaign(campaign_id))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Slice an id list with the shared pagination rules.
+    fn page_u64(env: &Env, ids: &Vec<u64>, offset: u32, limit: u32) -> Vec<u64> {
+        let mut page = Vec::new(env);
+        let Some((start, end)) = Self::page_bounds(offset, limit, ids.len() as u64) else {
+            return page;
+        };
+        for i in start..end {
+            page.push_back(ids.get(i as u32).unwrap());
+        }
+        page
+    }
+
+    /// Slice a record-id list and resolve each id to its stored record.
+    fn page_records(env: &Env, ids: &Vec<u64>, offset: u32, limit: u32) -> Vec<DistributionRecord> {
+        let mut page: Vec<DistributionRecord> = Vec::new(env);
+        let Some((start, end)) = Self::page_bounds(offset, limit, ids.len() as u64) else {
+            return page;
+        };
+        for i in start..end {
+            let record_id = ids.get(i as u32).unwrap();
+            let key = DataKey::DistributionRecord(record_id);
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, DistributionRecord>(&key)
+            {
+                extend_persistent_ttl(env, &key);
+                page.push_back(record);
+            }
+        }
+        page
+    }
 
     fn require_governance(env: &Env, caller: &Address) {
         let gov: Address = env.storage().instance().get(&DataKey::Governance).unwrap();
@@ -1333,5 +1635,318 @@ mod tests {
                 "get_campaign must refresh Campaign TTL, got {campaign_ttl}"
             );
         });
+    }
+
+    // -------------------------------------------------------------------------
+    // #684: pagination, creator index, distribution-record indices
+    // -------------------------------------------------------------------------
+
+    /// Create `n` campaigns owned by `gov`, all running over the same window,
+    /// and return their ids in creation order.
+    fn seed_campaigns(
+        client: &IncentiveCampaignsClient,
+        gov: &Address,
+        pool: &Address,
+        lp: &Address,
+        reward: &Address,
+        n: u32,
+    ) -> soroban_sdk::Vec<u64> {
+        let mut ids = soroban_sdk::Vec::new(&client.env);
+        for _ in 0..n {
+            ids.push_back(
+                client.create_campaign(gov, pool, lp, reward, &1_000, &11_000, &1, &10_000),
+            );
+        }
+        ids
+    }
+
+    #[test]
+    fn test_campaign_count_tracks_creations() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        assert_eq!(client.get_campaign_count(), 0);
+
+        seed_campaigns(&client, &gov, &amm, &lp, &reward, 3);
+        assert_eq!(client.get_campaign_count(), 3);
+    }
+
+    #[test]
+    fn test_paging_in_threes_reproduces_list_campaigns() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        seed_campaigns(&client, &gov, &amm, &lp, &reward, 7);
+
+        let all = client.list_campaigns();
+        let mut paged: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+        let mut offset = 0u32;
+        loop {
+            let page = client.list_campaigns_paginated(&offset, &3);
+            if page.is_empty() {
+                break;
+            }
+            for id in page.iter() {
+                paged.push_back(id);
+            }
+            offset += 3;
+        }
+        assert_eq!(paged, all);
+    }
+
+    #[test]
+    fn test_list_campaigns_paginated_boundaries() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        seed_campaigns(&client, &gov, &amm, &lp, &reward, 4);
+
+        // limit == 0 returns an empty page.
+        assert_eq!(client.list_campaigns_paginated(&0, &0).len(), 0);
+        // offset == count and offset > count return empty, not a panic.
+        assert_eq!(client.list_campaigns_paginated(&4, &10).len(), 0);
+        assert_eq!(client.list_campaigns_paginated(&99, &10).len(), 0);
+        // A partial trailing page is truncated to what remains.
+        assert_eq!(client.list_campaigns_paginated(&3, &10).len(), 1);
+        // limit > MAX_PAGE is clamped, not rejected.
+        assert_eq!(
+            client
+                .list_campaigns_paginated(&0, &(MAX_PAGE + 1_000))
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn test_get_campaigns_paginated_returns_structs_in_order() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let ids = seed_campaigns(&client, &gov, &amm, &lp, &reward, 5);
+
+        let page = client.get_campaigns_paginated(&1, &2);
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().id, ids.get(1).unwrap());
+        assert_eq!(page.get(1).unwrap().id, ids.get(2).unwrap());
+        assert_eq!(page.get(0).unwrap().pool, amm);
+    }
+
+    #[test]
+    fn test_active_pagination_skips_interleaved_inactive_campaigns() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+
+        // Interleave expired campaigns (window already closed at t = 1_000)
+        // with live ones so filtering has to skip over them.
+        let mut active_ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+        for _ in 0..5 {
+            client.create_campaign(&gov, &amm, &lp, &reward, &10, &100, &1, &1_000);
+            active_ids.push_back(
+                client.create_campaign(&gov, &amm, &lp, &reward, &1_000, &11_000, &1, &10_000),
+            );
+        }
+
+        let page = client.get_active_campaigns_paginated(&0, &5);
+        assert_eq!(page.len(), 5);
+        for i in 0..5u32 {
+            assert_eq!(page.get(i).unwrap().id, active_ids.get(i).unwrap());
+        }
+
+        // The unbounded view agrees on the same set.
+        assert_eq!(client.get_active_campaigns().len(), 5);
+
+        // Offsets count matching campaigns, not scanned ones.
+        let tail = client.get_active_campaigns_paginated(&3, &10);
+        assert_eq!(tail.len(), 2);
+        assert_eq!(tail.get(0).unwrap().id, active_ids.get(3).unwrap());
+
+        // Boundaries behave like every other paginated read.
+        assert_eq!(client.get_active_campaigns_paginated(&0, &0).len(), 0);
+        assert_eq!(client.get_active_campaigns_paginated(&5, &5).len(), 0);
+        assert_eq!(
+            client
+                .get_active_campaigns_paginated(&0, &(MAX_PAGE + 1_000))
+                .len(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_is_campaign_active_reflects_the_window() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+
+        let live = client.create_campaign(&gov, &amm, &lp, &reward, &1_000, &11_000, &1, &10_000);
+        let expired = client.create_campaign(&gov, &amm, &lp, &reward, &10, &100, &1, &1_000);
+
+        assert!(client.is_campaign_active(&live));
+        assert!(!client.is_campaign_active(&expired));
+        // An id that was never created is inactive, not a panic.
+        assert!(!client.is_campaign_active(&9_999));
+
+        env.ledger().with_mut(|l| l.timestamp = 20_000);
+        assert!(!client.is_campaign_active(&live));
+    }
+
+    #[test]
+    fn test_campaigns_by_creator_is_scoped_to_that_creator() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let ids = seed_campaigns(&client, &gov, &amm, &lp, &reward, 3);
+
+        let mine = client.get_campaigns_by_creator(&gov, &0, &10);
+        assert_eq!(mine, ids);
+
+        // Hand governance to a second address and let it create one campaign.
+        let other = Address::generate(&env);
+        StellarAssetClient::new(&env, &reward).mint(&other, &10_000_000);
+        client.propose_governance(&gov, &other);
+        client.accept_governance(&other);
+        let other_id =
+            client.create_campaign(&other, &amm, &lp, &reward, &1_000, &11_000, &1, &10_000);
+
+        assert_eq!(client.get_campaigns_by_creator(&gov, &0, &10), ids);
+        assert_eq!(
+            client.get_campaigns_by_creator(&other, &0, &10),
+            soroban_sdk::vec![&env, other_id]
+        );
+    }
+
+    #[test]
+    fn test_campaigns_by_creator_pagination_and_empty_creator() {
+        let (env, incentives, amm, lp, reward, _provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let ids = seed_campaigns(&client, &gov, &amm, &lp, &reward, 4);
+
+        let page = client.get_campaigns_by_creator(&gov, &2, &1);
+        assert_eq!(page, soroban_sdk::vec![&env, ids.get(2).unwrap()]);
+        assert_eq!(client.get_campaigns_by_creator(&gov, &0, &0).len(), 0);
+        assert_eq!(client.get_campaigns_by_creator(&gov, &4, &10).len(), 0);
+        assert_eq!(
+            client
+                .get_campaigns_by_creator(&gov, &0, &(MAX_PAGE + 1_000))
+                .len(),
+            4
+        );
+
+        // A creator that has never created a campaign gets an empty Vec.
+        let stranger = Address::generate(&env);
+        assert_eq!(client.get_campaigns_by_creator(&stranger, &0, &10).len(), 0);
+    }
+
+    /// Claim twice so the provider builds up a two-record history, and return
+    /// the campaign id.
+    fn claim_twice(
+        env: &Env,
+        client: &IncentiveCampaignsClient,
+        gov: &Address,
+        amm: &Address,
+        lp: &Address,
+        reward: &Address,
+        provider: &Address,
+    ) -> u64 {
+        let id = client.create_campaign(gov, amm, lp, reward, &1_000, &11_000, &100, &1_000_000);
+        // First call only initialises the provider snapshot.
+        client.claim_rewards(provider, &id);
+        env.ledger().with_mut(|l| l.timestamp = 3_000);
+        client.claim_rewards(provider, &id);
+        env.ledger().with_mut(|l| l.timestamp = 5_000);
+        client.claim_rewards(provider, &id);
+        id
+    }
+
+    #[test]
+    fn test_distribution_records_are_indexed_per_campaign() {
+        let (env, incentives, amm, lp, reward, provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let id = claim_twice(&env, &client, &gov, &amm, &lp, &reward, &provider);
+
+        assert_eq!(client.get_distribution_count(&id), 2);
+        let records = client.list_distribution_records(&id, &0, &10);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records.get(0).unwrap().campaign_id, id);
+        assert_eq!(records.get(0).unwrap().provider, provider);
+        // Chronological order.
+        assert!(records.get(0).unwrap().timestamp < records.get(1).unwrap().timestamp);
+        // Each record round-trips through the by-id getter.
+        let first_id = records.get(0).unwrap().id;
+        assert_eq!(
+            client.get_distribution_record(&first_id),
+            records.get(0).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_distribution_record_pagination_boundaries() {
+        let (env, incentives, amm, lp, reward, provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let id = claim_twice(&env, &client, &gov, &amm, &lp, &reward, &provider);
+
+        assert_eq!(client.list_distribution_records(&id, &0, &0).len(), 0);
+        assert_eq!(client.list_distribution_records(&id, &1, &10).len(), 1);
+        assert_eq!(client.list_distribution_records(&id, &2, &10).len(), 0);
+        assert_eq!(
+            client
+                .list_distribution_records(&id, &0, &(MAX_PAGE + 1_000))
+                .len(),
+            2
+        );
+        // A campaign nobody has claimed from has no records.
+        let empty = client.create_campaign(&gov, &amm, &lp, &reward, &1_000, &11_000, &1, &10_000);
+        assert_eq!(client.get_distribution_count(&empty), 0);
+        assert_eq!(client.list_distribution_records(&empty, &0, &10).len(), 0);
+    }
+
+    #[test]
+    fn test_claim_history_is_chronological_across_campaigns() {
+        let (env, incentives, amm, lp, reward, provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        let first = claim_twice(&env, &client, &gov, &amm, &lp, &reward, &provider);
+
+        // A second campaign the same provider also claims from.
+        let second =
+            client.create_campaign(&gov, &amm, &lp, &reward, &5_000, &11_000, &100, &600_000);
+        client.claim_rewards(&provider, &second);
+        env.ledger().with_mut(|l| l.timestamp = 7_000);
+        client.claim_rewards(&provider, &second);
+
+        let history = client.get_claim_history(&provider, &0, &10);
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap().campaign_id, first);
+        assert_eq!(history.get(2).unwrap().campaign_id, second);
+        for i in 0..history.len() - 1 {
+            assert!(history.get(i).unwrap().timestamp <= history.get(i + 1).unwrap().timestamp);
+            assert!(history.get(i).unwrap().id < history.get(i + 1).unwrap().id);
+        }
+    }
+
+    #[test]
+    fn test_claim_history_pagination_and_provider_with_no_claims() {
+        let (env, incentives, amm, lp, reward, provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+        claim_twice(&env, &client, &gov, &amm, &lp, &reward, &provider);
+
+        assert_eq!(client.get_claim_history(&provider, &0, &1).len(), 1);
+        assert_eq!(client.get_claim_history(&provider, &0, &0).len(), 0);
+        assert_eq!(client.get_claim_history(&provider, &2, &10).len(), 0);
+        assert_eq!(
+            client
+                .get_claim_history(&provider, &0, &(MAX_PAGE + 1_000))
+                .len(),
+            2
+        );
+
+        let stranger = Address::generate(&env);
+        assert_eq!(client.get_claim_history(&stranger, &0, &10).len(), 0);
+    }
+
+    #[test]
+    fn test_paginated_reads_on_an_empty_contract() {
+        let (env, incentives, _amm, _lp, _reward, provider, gov) = setup();
+        let client = IncentiveCampaignsClient::new(&env, &incentives);
+
+        assert_eq!(client.get_campaign_count(), 0);
+        assert_eq!(client.list_campaigns_paginated(&0, &10).len(), 0);
+        assert_eq!(client.get_campaigns_paginated(&0, &10).len(), 0);
+        assert_eq!(client.get_active_campaigns_paginated(&0, &10).len(), 0);
+        assert_eq!(client.get_campaigns_by_creator(&gov, &0, &10).len(), 0);
+        assert_eq!(client.get_claim_history(&provider, &0, &10).len(), 0);
+        assert_eq!(client.get_distribution_count(&1), 0);
     }
 }


### PR DESCRIPTION
closes #684

## Problem

Every read path in `incentive_campaigns` loaded all campaigns at once. `list_campaigns` walked the entire id list and `get_active_campaigns` additionally deserialised every `Campaign` behind it, so both will eventually exceed the transaction resource limit and leave no off-chain consumer able to enumerate campaigns at all, including the UI that shows LPs what they can claim. There was also no campaign count, no way to find the campaigns a given creator owns, and no way to reach a `DistributionRecord` without already knowing an id the contract never returns to the caller.

## What this changes

`contracts/incentive_campaigns/src/lib.rs` only. This is read-path and indexing work: reward-accrual math, `claim_rewards` payout semantics and `recover_leftover_funds` are untouched.

### Counts and pagination

- `get_campaign_count(env) -> u32`
- `list_campaigns_paginated(env, offset, limit) -> Vec<u64>`
- `get_campaigns_paginated(env, offset, limit) -> Vec<Campaign>`
- `get_active_campaigns_paginated(env, offset, limit) -> Vec<Campaign>`

All of them share one `page_bounds` helper: `limit` is clamped to a new `MAX_PAGE = 50`, `limit == 0` returns an empty `Vec`, and an out-of-range `offset` returns an empty `Vec` rather than panicking.

`get_active_campaigns_paginated` counts *matching* campaigns rather than scanned ones, so a full page of active campaigns comes back even when inactive ones are interleaved. Its doc comment is explicit that `limit` bounds the result while the scan still walks the id list until the page is filled, and points deep-paging callers at `get_campaigns_paginated` plus their own filter.

### Creator index

`DataKey::CampaignsByCreator(Address)` is maintained by `create_campaign` and exposed through `get_campaigns_by_creator(env, creator, offset, limit)`. An address that has never created a campaign gets an empty `Vec`.

### Distribution records

`claim_rewards` now writes the new record id into two append-only indices, `DataKey::DistributionsByCampaign(u64)` and `DataKey::DistributionsByProvider(Address)`, which surface as:

- `get_distribution_count(env, campaign_id) -> u32`
- `list_distribution_records(env, campaign_id, offset, limit) -> Vec<DistributionRecord>`
- `get_claim_history(env, provider, offset, limit) -> Vec<DistributionRecord>`

Because both lists are append-only, records come back in chronological order.

### Cheap status view

`is_campaign_active(env, campaign_id) -> bool` answers the common question without pulling the whole struct over the wire, and reports a campaign id that does not exist as inactive rather than panicking, so a caller can probe an id safely.

### ABI

`list_campaigns` and `get_active_campaigns` stay exactly as they are, now carrying doc comments that mark them unbounded and point at the paginated variants. The pre-existing `get_campaigns` and `get_active_campaigns_paged` are also left alone.

## Tests

The crate goes from 9 tests to 22. The 13 new ones cover:

- `get_campaign_count` tracking creations
- paging through `list_campaigns_paginated` in pages of 3 reproducing `list_campaigns` exactly, in the same order
- every pagination boundary on every new function: `limit == 0`, `offset == count`, `offset > count`, partial trailing page, `limit > MAX_PAGE` clamped
- `get_campaigns_paginated` returning the right structs at the right offsets
- `get_active_campaigns_paginated(0, 5)` returning 5 active campaigns with expired ones interleaved between them, offsets counting matches, and agreement with the unbounded view
- `is_campaign_active` across the window boundary and for an id that was never created
- `get_campaigns_by_creator` scoped correctly after a governance handover to a second creator, and empty for a creator with zero campaigns
- distribution records indexed per campaign, in chronological order, round-tripping through `get_distribution_record`
- `get_claim_history` chronological across two campaigns, and empty for a provider with zero claims
- every paginated read on a contract with nothing in it

## Verification

- `cargo test -p incentive-campaigns` — 22 passed
- `cargo clippy --workspace --all-targets --exclude amm-fuzz -- -D warnings` — clean
- `cargo fmt --all`
