### PR TITLE
test(v2_to_v3_migration): add real-contract unit-test suite for the V2→V3 migration (#686)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,6 +1754,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 name = "v2-to-v3-migration"
 version = "0.1.0"
 dependencies = [
+ "amm",
  "soroban-amm-sdk",
  "soroban-sdk",
  "token",

--- a/contracts/v2_to_v3_migration/Cargo.toml
+++ b/contracts/v2_to_v3_migration/Cargo.toml
@@ -14,5 +14,6 @@ soroban-sdk = { workspace = true }
 soroban-amm-sdk = { path = "../amm-sdk" }
 
 [dev-dependencies]
+amm = { path = "../amm", features = ["testutils"] }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 token = { path = "../token", features = ["testutils"] }

--- a/contracts/v2_to_v3_migration/src/lib.rs
+++ b/contracts/v2_to_v3_migration/src/lib.rs
@@ -418,7 +418,11 @@ impl MigrationContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use amm::{AmmPool, AmmPoolClient};
+    use soroban_sdk::testutils::{Address as _, Ledger as _, MockAuth, MockAuthInvoke};
+    use soroban_sdk::token::{StellarAssetClient, TokenClient};
+    use soroban_sdk::{IntoVal, String};
+    use token::{LpToken, LpTokenClient};
 
     /// Minimal V3 pool stub: `get_current_tick` is needed to exercise
     /// `compute_range` via the public `preview_range` entry point, and
@@ -580,5 +584,954 @@ mod tests {
         let result = client.try_preview_range(&200, &100, &0);
 
         assert_eq!(result, Err(Ok(MigrationError::InvalidRange)));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Issue #686: full migration unit-test suite against real contracts.
+    //
+    // The tests below register the REAL `amm` V2 pool plus real SEP-41 token
+    // contracts (`StellarAssetClient`) in the test Env, so the funds-moving
+    // cross-contract calls — `remove_liquidity`, `transfer`, `approve`,
+    // `transfer_from`, and LpToken `mint`/`burn` — all run against deployed
+    // contracts rather than hand-rolled stubs.
+    //
+    // The V3 side is the one documented interface gap: the migration contract
+    // talks to a synthetic `V3PoolInterface` (`add_liquidity_range`,
+    // `get_current_tick`), which the real `ConcentratedLiquidity` contract does
+    // NOT expose (calling those symbols against it panics). Mirroring the
+    // repo's integration tests (`integration-tests/tests/v2_to_v3_migration.rs`),
+    // a tiny registered harness contract satisfies exactly that interface, pulls
+    // tokens through the SEP-41 approval the migration grants, records real
+    // positions with concrete balances and ticks, and can be driven to fail so
+    // that the migration's atomicity is observable.
+    /// The harness is declared in its own module so the `#[contractimpl]`
+    /// macro-generated helper names (e.g. `__get_current_tick`) do not collide
+    /// with those of the `MockV2Pool`/`MockV3Pool` stubs above, which expose
+    /// the same method names and therefore live in the same namespace.
+    mod test_v3_pool {
+        use super::*;
+
+        #[contract]
+        pub(crate) struct TestV3Pool;
+
+        #[contracttype]
+        #[derive(Clone, Debug, PartialEq)]
+        pub(crate) struct V3Position {
+            pub(crate) provider: Address,
+            pub(crate) tick_lower: i32,
+            pub(crate) tick_upper: i32,
+            pub(crate) deposited_a: i128,
+            pub(crate) deposited_b: i128,
+        }
+
+        #[contracttype]
+        enum V3DataKey {
+            TokensA,
+            TokensB,
+            CurrentTick,
+            NextPositionId,
+            Position(i128),
+        }
+
+        #[contractimpl]
+        impl TestV3Pool {
+            pub fn setup(env: Env, token_a: Address, token_b: Address, initial_tick: i32) {
+                env.storage().instance().set(&V3DataKey::TokensA, &token_a);
+                env.storage().instance().set(&V3DataKey::TokensB, &token_b);
+                env.storage()
+                    .instance()
+                    .set(&V3DataKey::CurrentTick, &initial_tick);
+                env.storage()
+                    .instance()
+                    .set(&V3DataKey::NextPositionId, &1_i128);
+            }
+
+            pub fn set_current_tick(env: Env, tick: i32) {
+                env.storage().instance().set(&V3DataKey::CurrentTick, &tick);
+            }
+
+            pub fn get_current_tick(env: Env) -> i32 {
+                env.storage()
+                    .instance()
+                    .get(&V3DataKey::CurrentTick)
+                    .unwrap_or(0)
+            }
+
+            pub fn get_tokens(env: Env) -> (Address, Address) {
+                let token_a: Address = env.storage().instance().get(&V3DataKey::TokensA).unwrap();
+                let token_b: Address = env.storage().instance().get(&V3DataKey::TokensB).unwrap();
+                (token_a, token_b)
+            }
+
+            pub fn position(env: Env, position_id: i128) -> V3Position {
+                env.storage()
+                    .instance()
+                    .get(&V3DataKey::Position(position_id))
+                    .unwrap()
+            }
+
+            /// Number of positions minted so far (0 before the first deposit).
+            pub fn position_count(env: Env) -> i128 {
+                let next: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&V3DataKey::NextPositionId)
+                    .unwrap_or(1);
+                next - 1
+            }
+
+            /// Mirrors `V3PoolInterface::add_liquidity_range`: pulls `amount_a`
+            /// and `amount_b` out of `provider`'s SEP-41 allowance to this pool
+            /// (exactly as the real design intends), enforces `min_shares` on
+            /// the resulting position size, and mints a position NFT.
+            #[allow(clippy::too_many_arguments)]
+            pub fn add_liquidity_range(
+                env: Env,
+                provider: Address,
+                amount_a: i128,
+                amount_b: i128,
+                tick_lower: i32,
+                tick_upper: i32,
+                min_shares: i128,
+                _deadline: u64,
+                _fee_discount: bool,
+            ) -> Result<i128, soroban_sdk::Error> {
+                if tick_lower >= tick_upper {
+                    return Err(soroban_sdk::Error::from_contract_error(1));
+                }
+                provider.require_auth();
+
+                let token_a: Address = env.storage().instance().get(&V3DataKey::TokensA).unwrap();
+                let token_b: Address = env.storage().instance().get(&V3DataKey::TokensB).unwrap();
+                let self_addr = env.current_contract_address();
+
+                if amount_a > 0 {
+                    TokenClient::new(&env, &token_a)
+                        .transfer_from(&self_addr, &provider, &self_addr, &amount_a);
+                }
+                if amount_b > 0 {
+                    TokenClient::new(&env, &token_b)
+                        .transfer_from(&self_addr, &provider, &self_addr, &amount_b);
+                }
+
+                let liquidity = amount_a + amount_b;
+                if liquidity < min_shares {
+                    return Err(soroban_sdk::Error::from_contract_error(2));
+                }
+
+                let next: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&V3DataKey::NextPositionId)
+                    .unwrap_or(1);
+                env.storage().instance().set(
+                    &V3DataKey::Position(next),
+                    &V3Position {
+                        provider: provider.clone(),
+                        tick_lower,
+                        tick_upper,
+                        deposited_a: amount_a,
+                        deposited_b: amount_b,
+                    },
+                );
+                env.storage()
+                    .instance()
+                    .set(&V3DataKey::NextPositionId, &(next + 1));
+
+                Ok(next)
+            }
+        }
+    }
+
+    pub(crate) use test_v3_pool::{TestV3Pool, TestV3PoolClient};
+
+    // ── Shared fixture ─────────────────────────────────────────────────────────
+
+    const DEADLINE: u64 = u64::MAX;
+
+    struct Fixture<'a> {
+        admin: Address,
+        lp: Address,
+        lp_shares: i128,
+        ta: TokenClient<'a>,
+        tb: TokenClient<'a>,
+        ta_sac: StellarAssetClient<'a>,
+        tb_sac: StellarAssetClient<'a>,
+        v2_pool: Address,
+        v2_lp: LpTokenClient<'a>,
+        v3_pool: Address,
+        v3: TestV3PoolClient<'a>,
+        migration: MigrationContractClient<'a>,
+        migration_addr: Address,
+    }
+
+    fn create_sac<'a>(env: &'a Env, admin: &Address) -> (TokenClient<'a>, StellarAssetClient<'a>) {
+        let c = env.register_stellar_asset_contract_v2(admin.clone());
+        (
+            TokenClient::new(env, &c.address()),
+            StellarAssetClient::new(env, &c.address()),
+        )
+    }
+
+    /// Bootstrap a full fixture around the REAL V2 AMM:
+    ///   - `admin` seeds the pool with 6_000_000/6_000_000 (the first deposit
+    ///     locks MINIMUM_LIQUIDITY = 1_000; admin receives 5_999_000 LP);
+    ///   - `lp` mints exactly `lp_deposit_a`/`lp_deposit_b` and deposits
+    ///     them, ending with reserves 7_000_000/7_000_000 (+lp_deposit_b)
+    ///     and total shares 7_000_000 (+lp_deposit_b);
+    ///   - the registered `TestV3Pool` harness is wired to the pair in the
+    ///     `reversed` order when requested;
+    ///   - the migration contract is initialized against both pools.
+    fn build_fixture(
+        env: &Env,
+        lp_deposit_a: i128,
+        lp_deposit_b: i128,
+        reversed: bool,
+        initial_tick: i32,
+    ) -> Fixture<'_> {
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+
+        let admin = Address::generate(env);
+        let lp = Address::generate(env);
+        let fee_recipient = Address::generate(env);
+
+        let (ta, ta_sac) = create_sac(env, &admin);
+        let (tb, tb_sac) = create_sac(env, &admin);
+
+        // ── Real V2 AMM pool + real LpToken ──
+        let v2_addr = env.register_contract(None, AmmPool);
+        let v2_lp_addr = env.register_contract(None, LpToken);
+        LpTokenClient::new(env, &v2_lp_addr).initialize(
+            &v2_addr,
+            &String::from_str(env, "V2 LP"),
+            &String::from_str(env, "V2LP"),
+            &7u32,
+        );
+        let v2 = AmmPoolClient::new(env, &v2_addr);
+        v2.initialize(
+            &admin,
+            &ta.address,
+            &tb.address,
+            &v2_lp_addr,
+            &30_i128,
+            &fee_recipient,
+            &0_i128,
+        );
+
+        ta_sac.mint(&admin, &10_000_000_i128);
+        tb_sac.mint(&admin, &10_000_000_i128);
+        v2.add_liquidity(&admin, &6_000_000_i128, &6_000_000_i128, &0_i128, &DEADLINE);
+        assert_eq!(
+            LpTokenClient::new(env, &v2_lp_addr).balance(&admin),
+            5_999_000_i128,
+            "6M initial shares minus the 1_000 locked MINIMUM_LIQUIDITY"
+        );
+
+        ta_sac.mint(&lp, &lp_deposit_a);
+        tb_sac.mint(&lp, &lp_deposit_b);
+        let lp_shares = v2.add_liquidity(&lp, &lp_deposit_a, &lp_deposit_b, &0_i128, &DEADLINE);
+
+        // ── V3 harness ──
+        let v3_addr = env.register_contract(None, TestV3Pool);
+        let v3 = TestV3PoolClient::new(env, &v3_addr);
+        if reversed {
+            v3.setup(&tb.address, &ta.address, &initial_tick);
+        } else {
+            v3.setup(&ta.address, &tb.address, &initial_tick);
+        }
+
+        // ── Migration contract ──
+        let migration_addr = env.register_contract(None, MigrationContract);
+        let migration = MigrationContractClient::new(env, &migration_addr);
+        migration.initialize(&admin, &v2_addr, &v3_addr);
+
+        Fixture {
+            admin,
+            lp,
+            lp_shares,
+            ta,
+            tb,
+            ta_sac,
+            tb_sac,
+            v2_pool: v2_addr,
+            v2_lp: LpTokenClient::new(env, &v2_lp_addr),
+            v3_pool: v3_addr,
+            v3,
+            migration,
+            migration_addr,
+        }
+    }
+
+    /// Default symmetric fixture:
+    /// reserves 7_000_000/7_000_000, total shares 7_000_000, `lp` holds
+    /// 1_000_000 shares (a full exit withdraws exactly 1_000_000/1_000_000).
+    fn fixture(env: &Env) -> Fixture<'_> {
+        build_fixture(env, 1_000_000, 1_000_000, false, 0)
+    }
+
+    // ── initialize ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_initialize_twice_returns_already_initialized() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let second = f.migration.try_initialize(&f.admin, &f.v2_pool, &f.v3_pool);
+
+        assert!(
+            matches!(second, Err(Ok(MigrationError::AlreadyInitialized))),
+            "re-initializing must be rejected"
+        );
+
+        // The pool addresses survive re-initialization attempts: preview_range
+        // reads the stored V3 address and round-trips real pool state.
+        assert_eq!(f.migration.preview_range(&100, &200, &0), (100, 200));
+    }
+
+    #[test]
+    fn test_initialize_rejects_mismatched_v3_token_pair() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let (tc, _tc_sac) = create_sac(&env, &f.admin);
+        let bad_v3 = env.register_contract(None, TestV3Pool);
+        TestV3PoolClient::new(&env, &bad_v3).setup(&f.ta.address, &tc.address, &0);
+
+        let fresh = env.register_contract(None, MigrationContract);
+        let result = MigrationContractClient::new(&env, &fresh)
+            .try_initialize(&f.admin, &f.v2_pool, &bad_v3);
+
+        assert!(
+            matches!(result, Err(Ok(MigrationError::TokenMismatch))),
+            "a V3 pool trading a different pair must be rejected at initialize"
+        );
+    }
+
+    #[test]
+    fn test_migrate_before_initialize_returns_not_initialized() {
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let contract_addr = env.register_contract(None, MigrationContract);
+        let client = MigrationContractClient::new(&env, &contract_addr);
+
+        let result = client.try_migrate(
+            &provider, &1_i128, &0_i128, &0_i128, &100_i32, &200_i32, &0_i32, &0_i128, &DEADLINE,
+        );
+        assert!(
+            matches!(result, Err(Ok(MigrationError::NotInitialized))),
+            "migrate before initialize must fail"
+        );
+
+        let preview = client.try_preview_range(&100, &200, &0);
+        assert!(
+            matches!(preview, Err(Ok(MigrationError::NotInitialized))),
+            "preview_range before initialize must fail"
+        );
+    }
+
+    // ── preview_range against the registered V3 harness ─────────────────────────
+
+    #[test]
+    fn test_preview_range_explicit_ticks_used_verbatim() {
+        let env = Env::default();
+        let f = fixture(&env);
+        let client = MigrationContractClient::new(&env, &f.migration_addr);
+
+        // Explicit bounds are kept exactly as-is regardless of the pool tick.
+        assert_eq!(f.migration.preview_range(&100, &200, &9_999), (100, 200));
+
+        // Inverted explicit bounds are rejected.
+        let result = client.try_preview_range(&200, &100, &0);
+        assert!(matches!(result, Err(Ok(MigrationError::InvalidRange))));
+    }
+
+    #[test]
+    fn test_preview_range_sentinels_auto_bracket_current_tick() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        f.v3.set_current_tick(&1_000_i32);
+
+        assert_eq!(
+            f.migration.preview_range(&i32::MIN, &i32::MAX, &500),
+            (500, 1_500)
+        );
+
+        // Single-sided sentinels only replace that bound, keeping the other.
+        assert_eq!(
+            f.migration.preview_range(&i32::MIN, &1_500, &500),
+            (500, 1_500)
+        );
+        assert_eq!(
+            f.migration.preview_range(&500, &i32::MAX, &500),
+            (500, 1_500)
+        );
+    }
+
+    #[test]
+    fn test_preview_range_pool_without_liquidity_still_returns_valid_range() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        // No position deposited yet; the harness reports its stored current
+        // tick (0) and the migration still yields a well-formed, non-empty
+        // bracket rather than panicking or returning an inverted range.
+        assert_eq!(
+            f.migration.preview_range(&i32::MIN, &i32::MAX, &100),
+            (-100, 100)
+        );
+    }
+
+    #[test]
+    fn test_preview_range_wider_width_auto_range_strictly_contains_narrower() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        f.v3.set_current_tick(&0_i32);
+
+        let narrow = f.migration.preview_range(&i32::MIN, &i32::MAX, &100);
+        let wide = f.migration.preview_range(&i32::MIN, &i32::MAX, &1_000);
+
+        assert_eq!(narrow, (-100, 100));
+        assert_eq!(wide, (-1_000, 1_000));
+        assert!(
+            narrow.0 > wide.0 && narrow.1 < wide.1,
+            "the wider range must strictly contain the narrower one"
+        );
+    }
+
+    // ── migrate happy paths ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_full_migration_burns_all_lp_shares_and_mints_position() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        assert_eq!(f.v2_lp.balance(&f.lp), 1_000_000_i128);
+
+        let result = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        // All V2 LP shares were burned by the real AMM contract.
+        assert_eq!(f.v2_lp.balance(&f.lp), 0_i128);
+        assert_eq!(f.v3.position_count(), 1_i128);
+
+        // The registered V3 pool minted a real, queryable position at the
+        // range auto-computed around the harness's current tick (default 0).
+        let pos = f.v3.position(&result.position_id);
+        assert_eq!(pos.provider, f.migration_addr);
+        assert_eq!(pos.tick_lower, -500);
+        assert_eq!(pos.tick_upper, 500);
+        assert_eq!(pos.deposited_a, 1_000_000_i128);
+        assert_eq!(pos.deposited_b, 1_000_000_i128);
+    }
+
+    #[test]
+    fn test_full_migration_deposits_exact_withdrawal_amounts_with_no_dust() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        // shares * reserve_x / total_shares = 1M * 7M / 7M = exactly 1M each.
+        let result = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        assert_eq!(result.deposited_a, 1_000_000_i128);
+        assert_eq!(result.deposited_b, 1_000_000_i128);
+        assert_eq!(result.refund_a, 0_i128);
+        assert_eq!(result.refund_b, 0_i128);
+
+        // Both tokens physically landed in the V3 pool.
+        assert_eq!(f.ta.balance(&f.v3_pool), 1_000_000_i128);
+        assert_eq!(f.tb.balance(&f.v3_pool), 1_000_000_i128);
+    }
+
+    #[test]
+    fn test_migration_conserves_every_token_and_does_not_touch_admin_position() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let result = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        // The migrating LP ends up with nothing in their pocket...
+        assert_eq!(f.ta.balance(&f.lp), 0_i128);
+        assert_eq!(f.tb.balance(&f.lp), 0_i128);
+
+        // ...the shared migration contract retains nothing...
+        assert_eq!(f.ta.balance(&f.migration_addr), 0_i128);
+        assert_eq!(f.tb.balance(&f.migration_addr), 0_i128);
+
+        // ...and 100% of the withdrawn tokens sit in the V3 pool.
+        assert_eq!(
+            f.ta.balance(&f.v3_pool),
+            result.deposited_a + result.refund_a
+        );
+        assert_eq!(
+            f.tb.balance(&f.v3_pool),
+            result.deposited_b + result.refund_b
+        );
+
+        // Per-token conservation: nothing was created or destroyed.
+        let lp_original_a = 1_000_000_i128;
+        let lp_original_b = 1_000_000_i128;
+        assert_eq!(
+            f.ta.balance(&f.lp) + f.ta.balance(&f.migration_addr) + f.ta.balance(&f.v3_pool),
+            lp_original_a
+        );
+        assert_eq!(
+            f.tb.balance(&f.lp) + f.tb.balance(&f.migration_addr) + f.tb.balance(&f.v3_pool),
+            lp_original_b
+        );
+
+        // Admin's own V2 position was not swept up by the LP's migration.
+        assert_eq!(f.v2_lp.balance(&f.admin), 5_999_000_i128);
+    }
+
+    #[test]
+    fn test_partial_migration_burns_only_requested_shares() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let half = f.lp_shares / 2;
+        let result = f.migration.migrate(
+            &f.lp,
+            &half,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        // Exactly half the shares burned, the rest stays withdrawable.
+        assert_eq!(f.v2_lp.balance(&f.lp), 500_000_i128);
+        assert_eq!(result.deposited_a, 500_000_i128);
+        assert_eq!(result.deposited_b, 500_000_i128);
+        assert_eq!(f.v3.position_count(), 1_i128);
+
+        // The LP redeems the remaining 500k shares directly on the real AMM.
+        let v2 = AmmPoolClient::new(&env, &f.v2_pool);
+        let (out_a, out_b) = v2.remove_liquidity(&f.lp, &500_000_i128, &0_i128, &0_i128, &DEADLINE);
+        assert_eq!((out_a, out_b), (500_000_i128, 500_000_i128));
+
+        assert_eq!(f.v2_lp.balance(&f.lp), 0_i128);
+        assert_eq!(f.ta.balance(&f.lp), 500_000_i128);
+        assert_eq!(f.tb.balance(&f.lp), 500_000_i128);
+    }
+
+    #[test]
+    fn test_migrate_preview_ticks_match_executed_position() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        f.v3.set_current_tick(&1_000_i32);
+
+        let preview = f.migration.preview_range(&i32::MIN, &i32::MAX, &500);
+        assert_eq!(preview, (500, 1_500));
+
+        let result = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        assert_eq!((result.tick_lower, result.tick_upper), (500, 1_500));
+
+        let pos = f.v3.position(&result.position_id);
+        assert_eq!((pos.tick_lower, pos.tick_upper), (500, 1_500));
+    }
+
+    #[test]
+    fn test_migrate_revokes_v3_pool_approval_and_retains_no_tokens() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let _ = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        // Approvals granted to the V3 pool were revoked (fix #542).
+        assert_eq!(f.ta.allowance(&f.migration_addr, &f.v3_pool), 0_i128);
+        assert_eq!(f.tb.allowance(&f.migration_addr, &f.v3_pool), 0_i128);
+
+        // The shared migration contract retained nothing from this call.
+        assert_eq!(f.ta.balance(&f.migration_addr), 0_i128);
+        assert_eq!(f.tb.balance(&f.migration_addr), 0_i128);
+
+        // Behavioral proof: funds minted later to the contract are not spendable
+        // by the V3 pool through any lingering allowance.
+        f.ta_sac.mint(&f.migration_addr, &100_i128);
+        let steal =
+            f.ta.try_transfer_from(&f.v3_pool, &f.migration_addr, &f.lp, &100_i128);
+        assert!(
+            steal.is_err(),
+            "v3_pool must not be able to move post-migration balances"
+        );
+        assert_eq!(f.ta.balance(&f.migration_addr), 100_i128);
+
+        // Same guarantee for token B.
+        f.tb_sac.mint(&f.migration_addr, &100_i128);
+        let steal_b =
+            f.tb.try_transfer_from(&f.v3_pool, &f.migration_addr, &f.lp, &100_i128);
+        assert!(
+            steal_b.is_err(),
+            "v3_pool must not be able to move post-migration balances"
+        );
+        assert_eq!(f.tb.balance(&f.migration_addr), 100_i128);
+    }
+
+    // ── migrate failure paths and atomicity ─────────────────────────────────────
+
+    #[test]
+    fn test_migrate_zero_shares_is_rejected() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let result = f.migration.try_migrate(
+            &f.lp,
+            &0_i128,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+        assert!(matches!(result, Err(Ok(MigrationError::ZeroShares))));
+
+        let negative = f.migration.try_migrate(
+            &f.lp,
+            &-1_i128,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+        assert!(matches!(negative, Err(Ok(MigrationError::ZeroShares))));
+    }
+
+    #[test]
+    fn test_migrate_more_shares_than_owned_aborts_atomically() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let before_shares = f.v2_lp.balance(&f.lp);
+        let before_ta = f.ta.balance(&f.lp);
+        let before_tb = f.tb.balance(&f.lp);
+
+        let result = f.migration.try_migrate(
+            &f.lp,
+            &(f.lp_shares + 1),
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+        assert!(result.is_err(), "over-owning migration must panic/revert");
+
+        // Nothing moved: V2 shares, the LP's tokens and the V3 pool are untouched.
+        assert_eq!(f.v2_lp.balance(&f.lp), before_shares);
+        assert_eq!(f.ta.balance(&f.lp), before_ta);
+        assert_eq!(f.tb.balance(&f.lp), before_tb);
+        assert_eq!(f.ta.balance(&f.migration_addr), 0_i128);
+        assert_eq!(f.tb.balance(&f.migration_addr), 0_i128);
+        assert_eq!(f.v3.position_count(), 0_i128);
+    }
+
+    #[test]
+    fn test_migrate_past_deadline_aborts_atomically() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        env.ledger().set_timestamp(1_000);
+
+        let before_shares = f.v2_lp.balance(&f.lp);
+        let before_ta = f.ta.balance(&f.lp);
+        let before_tb = f.tb.balance(&f.lp);
+
+        let result = f.migration.try_migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &999_u64,
+        );
+        assert!(result.is_err(), "expired deadline must abort the migration");
+
+        assert_eq!(f.v2_lp.balance(&f.lp), before_shares);
+        assert_eq!(f.ta.balance(&f.lp), before_ta);
+        assert_eq!(f.tb.balance(&f.lp), before_tb);
+        assert_eq!(f.v3.position_count(), 0_i128);
+    }
+
+    #[test]
+    fn test_migrate_v2_slippage_aborts_atomically() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let before_shares = f.v2_lp.balance(&f.lp);
+
+        // min_amount_a impossibly high: the real AMM rejects the withdrawal.
+        let result = f.migration.try_migrate(
+            &f.lp,
+            &f.lp_shares,
+            &i128::MAX,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+        assert!(result.is_err(), "impossible V2 slippage must revert");
+
+        assert_eq!(f.v2_lp.balance(&f.lp), before_shares);
+        assert_eq!(f.v3.position_count(), 0_i128);
+        assert_eq!(f.ta.balance(&f.migration_addr), 0_i128);
+        assert_eq!(f.tb.balance(&f.migration_addr), 0_i128);
+    }
+
+    /// The atomicity guarantee under the issue's exact scenario: the V2 side
+    /// fully succeeds (shares burned and tokens withdrawn by the real AMM), but
+    /// the V3 deposit later fails on `min_v3_shares` — the whole migration must
+    /// roll back to exactly the pre-call state, including re-minting the burned
+    /// V2 LP shares and restoring every token balance.
+    #[test]
+    fn test_migrate_v3_slippage_aborts_entire_migration_atomically() {
+        let env = Env::default();
+        let f = fixture(&env);
+
+        let before_shares = f.v2_lp.balance(&f.lp);
+        let before_ta = f.ta.balance(&f.lp);
+        let before_tb = f.tb.balance(&f.lp);
+        let before_ta_contract = f.ta.balance(&f.migration_addr);
+        let before_tb_contract = f.tb.balance(&f.migration_addr);
+
+        let v2 = AmmPoolClient::new(&env, &f.v2_pool);
+        let before_info = v2.get_info();
+
+        let result = f.migration.try_migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &i128::MAX, // impossible: no position can satisfy this floor
+            &DEADLINE,
+        );
+        assert!(
+            result.is_err(),
+            "a V3 deposit below min_v3_shares must abort the migration"
+        );
+
+        // Zero state changes: the burned shares were re-minted by the rollback.
+        assert_eq!(f.v2_lp.balance(&f.lp), before_shares);
+        assert_eq!(f.ta.balance(&f.lp), before_ta);
+        assert_eq!(f.tb.balance(&f.lp), before_tb);
+        assert_eq!(f.ta.balance(&f.migration_addr), before_ta_contract);
+        assert_eq!(f.tb.balance(&f.migration_addr), before_tb_contract);
+
+        let after_info = v2.get_info();
+        assert_eq!(after_info.reserve_a, before_info.reserve_a);
+        assert_eq!(after_info.reserve_b, before_info.reserve_b);
+        assert_eq!(after_info.total_shares, before_info.total_shares);
+
+        // The V3 pool never saw the funds: no position, no token balance.
+        assert_eq!(f.v3.position_count(), 0_i128);
+        assert_eq!(f.ta.balance(&f.v3_pool), 0_i128);
+        assert_eq!(f.tb.balance(&f.v3_pool), 0_i128);
+
+        // And a follow-up migration still succeeds from the untouched state.
+        let retry = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+        assert_eq!(f.v2_lp.balance(&f.lp), 0_i128);
+        assert_eq!(f.v3.position_count(), 1_i128);
+        assert_eq!(retry.deposited_a + retry.deposited_b, 2_000_000_i128);
+    }
+
+    #[test]
+    fn test_migrate_with_wrong_address_auth_is_rejected() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+
+        let admin = Address::generate(&env);
+        let provider = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let ta = Address::generate(&env);
+        let tb = Address::generate(&env);
+
+        let v2_mock = env.register_contract(None, MockV2Pool);
+        MockV2PoolClient::new(&env, &v2_mock).set_v2_tokens(&ta, &tb);
+        let v3_mock = env.register_contract(None, MockV3Pool);
+        MockV3PoolClient::new(&env, &v3_mock).set_tokens(&ta, &tb);
+
+        let contract_addr = env.register_contract(None, MigrationContract);
+        let client = MigrationContractClient::new(&env, &contract_addr);
+
+        // Real auth checking: only admin, and only for initialize.
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_addr,
+                fn_name: "initialize",
+                args: (admin.clone(), v2_mock.clone(), v3_mock.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert_eq!(
+            client.try_initialize(&admin, &v2_mock, &v3_mock),
+            Ok(Ok(())),
+            "initialize with an authorized admin must succeed"
+        );
+
+        // Only the *wrong* address is authorized for the migration call: the LP
+        // (provider) is not, so `provider.require_auth()` fails immediately.
+        env.mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_addr,
+                fn_name: "migrate",
+                args: (
+                    provider.clone(),
+                    1_i128,
+                    0_i128,
+                    0_i128,
+                    100_i32,
+                    200_i32,
+                    0_i32,
+                    0_i128,
+                    DEADLINE,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = client.try_migrate(
+            &provider, &1_i128, &0_i128, &0_i128, &100_i32, &200_i32, &0_i32, &0_i128, &DEADLINE,
+        );
+        assert!(
+            result.is_err(),
+            "migration without the provider's authorization must fail"
+        );
+
+        // The contract was not corrupted: it still serves read-only previews.
+        assert_eq!(client.preview_range(&100, &200, &0), (100, 200));
+    }
+
+    /// Genuine gap uncovered while building this suite (kept as a failing,
+    /// ignored regression anchor per the issue's rules — file a separate issue):
+    ///
+    /// `migrate` validates a reversed V2/V3 token pair order-insensitively, but
+    /// then forwards the V2-side withdrawal amounts WITHOUT swapping them into
+    /// the V3 pool's own token order, and approves each token for its V2-side
+    /// amount. For a reversed pair the amounts are therefore mislabeled, so the
+    /// harness's SEP-41 pulls either exceed a token's allowance or deposit the
+    /// wrong side — meaning a reversed pair can never migrate correctly as
+    /// written. The migration contract should swap `amount_a`/`amount_b` (and
+    /// the matching approvals) when `v3_token_a != v2_token_a`.
+    #[ignore = "genuine bug: migrate does not swap amounts for a reversed V3 token pair"]
+    #[test]
+    fn test_migrate_reversed_v3_token_order_maps_amounts_correctly() {
+        let env = Env::default();
+        // Asymmetric deposit so amount_a != amount_b, making any swap bug
+        // observable instead of silently self-cancelling:
+        //   admin: 6M/6M → reserves 6M/6M, total 6M shares (5_999_000 + 1_000);
+        //   lp:    1M/2M → shares = min(1M*6M/6M, 2M*6M/6M) = 1M;
+        //   reserves 7M/8M, total shares 7M.
+        // Full exit: out_a = 1M*7M/7M = 1_000_000, out_b = 1M*8M/7M = 1_142_857.
+        let f = build_fixture(&env, 1_000_000, 2_000_000, true, 0);
+
+        let result = f.migration.migrate(
+            &f.lp,
+            &f.lp_shares,
+            &0_i128,
+            &0_i128,
+            &i32::MIN,
+            &i32::MAX,
+            &500_i32,
+            &0_i128,
+            &DEADLINE,
+        );
+
+        // The reversed V3 pool (token_a == V2's token_b) must receive the tb
+        // side as its amount_a and the ta side as its amount_b.
+        assert_eq!(result.deposited_a, 1_142_857_i128);
+        assert_eq!(result.deposited_b, 1_000_000_i128);
+
+        let pos = f.v3.position(&result.position_id);
+        assert_eq!(pos.deposited_a, 1_142_857_i128);
+        assert_eq!(pos.deposited_b, 1_000_000_i128);
+
+        // The underlying tokens landed on the correct sides: V3's token_a (==
+        // V2's token_b) is ahead by 1_142_857; V3's token_b (== V2's token_a)
+        // by 1_000_000.
+        assert_eq!(f.tb.balance(&f.v3_pool), 1_142_857_i128);
+        assert_eq!(f.ta.balance(&f.v3_pool), 1_000_000_i128);
     }
 }


### PR DESCRIPTION
## Overview

This PR closes the unit-test gap for the `v2_to_v3_migration` contract (issue #686) with a `mod tests` suite exercised end-to-end against **real registered contracts** — the actual `amm` V2 constant-product pool, real SEP-41 stellar-asset tokens, and the real repo `LpToken` — rather than hand-rolled stubs. The V3 side uses a small registered harness satisfying exactly the synthetic `V3PoolInterface` the migration depends on (the real `ConcentratedLiquidity` contract does not expose `add_liquidity_range`/`get_current_tick`), mirroring the repo's existing integration-test pattern.

## Related Issue

Closes #686

## Changes

### [ADD] Real-contract unit-test suite

- `contracts/v2_to_v3_migration/src/lib.rs` — 19 new tests (on top of the 7 pre-existing preview tests): initialize guards, preview-range semantics against a live pool, full/partial migration happy paths with concrete withdrawal math, per-token conservation, approval revocation (fix #542) including a post-migration "steal" attempt, and failure paths.
- **[[ADD]]** `TestV3Pool` harness contract (module-scoped to avoid `#[contractimpl]` helper-name collisions with the existing mocks) — records real positions with provider/ticks/balances and pulls tokens strictly through the SEP-41 allowances the migration grants, so allowance/slippage semantics are real.
- `contracts/v2_to_v3_migration/Cargo.toml` — `amm` dev-dependency (`testutils` feature) so the tests register the real V2 pool.

### [ADD] Atomicity coverage (the issue's core scenario)

- `test_migrate_v3_slippage_aborts_entire_migration_atomically` — the V2 side fully succeeds (shares burned, tokens withdrawn), the V3 deposit fails on `min_v3_shares`, and the whole call rolls back: re-minted LP shares, restored reserves and balances, zero positions, followed by a successful retry from the untouched state.

### [ADD] Regression anchor (genuine bug, kept `#[ignore]`)

- `test_migrate_reversed_v3_token_order_maps_amounts_correctly` — documented gap uncovered while building this suite (per repo convention it is kept as a failing, ignored anchor and should be a separate issue): `migrate` accepts a reversed V2/V3 token pair order-insensitively but does not swap `amount_a`/`amount_b` (or the matching approvals), so a reversed pair never migrates correctly as written.

## Verification Results

```
cargo test -p v2-to-v3-migration
test result: ok. 26 passed; 0 failed; 1 ignored

cargo clippy -p v2-to-v3-migration --tests -- -D warnings   # clean
cargo build -p v2-to-v3-migration --target wasm32v1-none --release  # ok
```

Local Windows note: the GNU toolchain's `dlltool` + Microsoft Defender race corrupts the `backtrace` crate's generated import library, so tests were verified locally using a temporary, machine-local API-compatible `backtrace` stub (reverted before this PR). Linux CI is unaffected.

Acceptance Criteria | Status
--- | ---
At least 15 unit tests for the migration contract | ✅ 19 new tests (26 passing total in `mod tests`)
Tests run against real registered contracts | ✅ real `amm` pool, real SEP-41 tokens, real `LpToken`; V3 harness mirrors the integration-test pattern
A failed migration provably rolls back atomically | ✅ full rollback asserted on V3 `min_v3_shares` failure, then a successful retry
Concrete numeric assertions, no behavior changes to contract logic | ✅ exact amounts/balances asserted; only tests + dev-dep + lockfile changed