### PR TITLE
#717 ui components: 3,860 lines of React with vitest configured and z…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
       # tests), so there is nothing left to collide with at link time.
       # `amm-fuzz`, `integration-tests`, and `benches` are not deployable
       # contracts, so they never produce wasm to build or size-check here.
-      # `examples/flash_loan_receiver` IS deployable and IS included in the build.
       - name: Build WASM artifacts
         run: cargo build --release --target wasm32v1-none --workspace --exclude amm-fuzz --exclude integration-tests --exclude benches
       - name: Check WASM binary sizes
@@ -114,7 +113,10 @@ jobs:
           - dir: packages/sdk
             test_cmd: npm test -- --passWithNoTests
           - dir: packages/ui-components
-            test_cmd: npm test -- --passWithNoTests
+            # Run the real test suite (now that it exists) and enforce the
+            # configured coverage thresholds; a broken component or a drop
+            # below the line/function coverage floor fails the build.
+            test_cmd: npm test -- --coverage
           - dir: packages/ts-advanced-client
             test_cmd: npm test
           - dir: services/graphql-api

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 node_modules
 dist
+coverage
 __pycache__/
 *.pyc
 # Editor/tool backup files

--- a/packages/ui-components/src/CapitalEfficiencyCalc.test.tsx
+++ b/packages/ui-components/src/CapitalEfficiencyCalc.test.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CapitalEfficiencyCalc } from "./CapitalEfficiencyCalc.js";
+import type { PriceRange } from "./types.js";
+
+/** Harness that keeps the controlled range in state, as a real app would. */
+function EditableRangeHarness({ onRangeChange }: { onRangeChange: (r: PriceRange) => void }) {
+  const [range, setRange] = useState<PriceRange>({ lower: 80, upper: 120 });
+  return (
+    <CapitalEfficiencyCalc
+      currentPrice={100}
+      priceRange={range}
+      tokenA="XLM"
+      tokenB="USDC"
+      onRangeChange={(r) => {
+        setRange(r);
+        onRangeChange(r);
+      }}
+    />
+  );
+}
+
+describe("CapitalEfficiencyCalc", () => {
+  it("renders without crashing given valid props", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={100} priceRange={{ lower: 80, upper: 120 }} />,
+    );
+    expect(screen.getByRole("heading", { name: "Capital Efficiency" })).toBeInTheDocument();
+  });
+
+  it("displays the capital-efficiency multiplier text", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={90} priceRange={{ lower: 80, upper: 100 }} />,
+    );
+    // eff = 1/(1 - sqrt(0.8)) ≈ 9.5
+    expect(screen.getByRole("status")).toHaveTextContent("9.5x");
+  });
+
+  it("displays a ~1x multiplier and the inactive caption when out of range", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={10} priceRange={{ lower: 80, upper: 120 }} />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("1.0x");
+    expect(
+      screen.getByText(/Price is outside range — position earns no fees/),
+    ).toBeInTheDocument();
+  });
+
+  it("displays a caption that the capital works harder when in range", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={100} priceRange={{ lower: 80, upper: 120 }} />,
+    );
+    expect(screen.getByText(/works .*× harder than a full-range position/)).toBeInTheDocument();
+  });
+
+  it("formats the concentrated capital and full-range entries in the table", () => {
+    render(
+      <CapitalEfficiencyCalc
+        currentPrice={90}
+        priceRange={{ lower: 80, upper: 100 }}
+        depositUsd={10_000}
+      />,
+    );
+    expect(screen.getByText("Full range (v2-style)")).toBeInTheDocument();
+    expect(screen.getByText("Concentrated (80.0000 – 100.0000)")).toBeInTheDocument();
+    // concentrated capital = 10000 / 9.472135955 ≈ 1055.728 → "$1,055.73"
+    expect(screen.getByText("$1,055.73")).toBeInTheDocument();
+  });
+
+  it("renders range width, bounds and current price information", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={100} priceRange={{ lower: 80, upper: 120 }} />,
+    );
+    expect(screen.getByText("Range width")).toBeInTheDocument();
+    expect(screen.getByText(/40\.0%/)).toBeInTheDocument();
+    expect(screen.getByText("80.000000")).toBeInTheDocument();
+    expect(screen.getByText("120.000000")).toBeInTheDocument();
+    expect(screen.getByText("100.000000")).toBeInTheDocument();
+  });
+
+  it("renders an editable range and emits range changes with the right payload", async () => {
+    const user = userEvent.setup();
+    const onRangeChange = vi.fn();
+    render(<EditableRangeHarness onRangeChange={onRangeChange} />);
+    const minInput = screen.getByLabelText("Minimum price for XLM/USDC");
+    const maxInput = screen.getByLabelText("Maximum price for XLM/USDC");
+    await user.clear(minInput);
+    await user.type(minInput, "70");
+    expect(onRangeChange).toHaveBeenLastCalledWith({ lower: 70, upper: 120 });
+
+    await user.clear(maxInput);
+    await user.type(maxInput, "150");
+    expect(onRangeChange).toHaveBeenLastCalledWith({ lower: 70, upper: 150 });
+    expect(minInput).toHaveValue(70);
+    expect(maxInput).toHaveValue(150);
+  });
+
+  it("exposes an accessible live region and aria-label", () => {
+    render(
+      <CapitalEfficiencyCalc currentPrice={100} priceRange={{ lower: 80, upper: 120 }} />,
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByLabelText("Capital efficiency calculator")).toBeInTheDocument();
+  });
+
+  it("handles a zero deposit gracefully", () => {
+    render(
+      <CapitalEfficiencyCalc
+        currentPrice={100}
+        priceRange={{ lower: 80, upper: 120 }}
+        depositUsd={0}
+      />,
+    );
+    // Both the full-range and concentrated capital cells read $0.
+    expect(screen.getAllByText("$0").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not render the editable range when onRangeChange is absent", () => {
+    render(<CapitalEfficiencyCalc currentPrice={100} priceRange={{ lower: 80, upper: 120 }} />);
+    expect(screen.queryByLabelText(/Minimum price for/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui-components/src/FeeTierComparison.test.tsx
+++ b/packages/ui-components/src/FeeTierComparison.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeeTierComparison } from "./FeeTierComparison.js";
+import type { FeeTier } from "./types.js";
+
+const tiers: FeeTier[] = [
+  { feeBps: 5, label: "Stable", description: "Stable pairs.", tvlSharePct: 15 },
+  { feeBps: 30, label: "Standard", description: "Balanced volume.", tvlSharePct: 60 },
+  { feeBps: 100, label: "Exotic", description: "High volatility.", tvlSharePct: 25 },
+];
+
+describe("FeeTierComparison", () => {
+  it("renders every tier with fee, label, description and TVL share", () => {
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={vi.fn()} />);
+    expect(screen.getByText("0.05%", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("0.3%", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("1%", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("Stable")).toBeInTheDocument();
+    expect(screen.getByText("Standard")).toBeInTheDocument();
+    expect(screen.getByText("Exotic")).toBeInTheDocument();
+    expect(screen.getByText("Stable pairs.")).toBeInTheDocument();
+    expect(screen.getByText("15%")).toBeInTheDocument();
+    expect(screen.getByText("60%")).toBeInTheDocument();
+    expect(screen.getByText("25%")).toBeInTheDocument();
+  });
+
+  it("marks the selected tier with aria-checked", () => {
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={vi.fn()} />);
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    expect(radios[0]).toHaveAttribute("aria-checked", "false");
+    // Selected tier is focusable (tabIndex 0), others are -1.
+    expect(radios[1]).toHaveAttribute("tabindex", "0");
+  });
+
+  it("renders the radiogroup with an accessible name", () => {
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={vi.fn()} />);
+    expect(screen.getByRole("radiogroup")).toHaveAttribute("aria-required", "true");
+  });
+
+  it("calls onSelect with the feeBps when a tier is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={onSelect} />);
+    await user.click(screen.getByRole("radio", { name: /Exotic — 1% fee/ }));
+    expect(onSelect).toHaveBeenCalledWith(100);
+  });
+
+  it("moves selection to the next tier with ArrowRight", async () => {
+    const onSelect = vi.fn();
+    render(<FeeTierComparison tiers={tiers} selected={5} onSelect={onSelect} />);
+    const first = screen.getByRole("radio", { name: /Stable — 0.05% fee/ });
+    first.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(onSelect).toHaveBeenCalledWith(30);
+  });
+
+  it("moves selection to the previous tier with ArrowLeft", async () => {
+    const onSelect = vi.fn();
+    render(<FeeTierComparison tiers={tiers} selected={100} onSelect={onSelect} />);
+    const last = screen.getByRole("radio", { name: /Exotic — 1% fee/ });
+    last.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onSelect).toHaveBeenCalledWith(30);
+  });
+
+  it("wrap-around from the first tier with ArrowLeft", async () => {
+    const onSelect = vi.fn();
+    render(<FeeTierComparison tiers={tiers} selected={5} onSelect={onSelect} />);
+    const first = screen.getByRole("radio", { name: /Stable — 0.05% fee/ });
+    first.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onSelect).toHaveBeenCalledWith(100);
+  });
+
+  it("selects the focused tier with Space", async () => {
+    const onSelect = vi.fn();
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={onSelect} />);
+    const standard = screen.getByRole("radio", { name: /Standard — 0.3% fee/ });
+    standard.focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenCalledWith(30);
+  });
+
+  it("highlights the recommended tier for a stable volatility hint", () => {
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={vi.fn()} volatilityHint="stable" />);
+    const stable = screen.getByText("Recommended");
+    expect(stable).toBeInTheDocument();
+    expect(screen.getByText(/For/)).toHaveTextContent(/stable/);
+  });
+
+  it("does not highlight a recommendation when no volatility hint is given", () => {
+    render(<FeeTierComparison tiers={tiers} selected={30} onSelect={vi.fn()} />);
+    expect(screen.queryByText("Recommended")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty/zero state for an empty tier list without crashing", () => {
+    render(<FeeTierComparison tiers={[]} selected={0} onSelect={vi.fn()} />);
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    expect(screen.queryAllByRole("radio")).toHaveLength(0);
+  });
+});

--- a/packages/ui-components/src/GovernanceForum.test.tsx
+++ b/packages/ui-components/src/GovernanceForum.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GovernanceForum } from "./GovernanceForum.js";
+import type { Proposal, VoteChoice } from "./types.js";
+
+const proposal: Proposal = {
+  id: "GIP-001",
+  title: "Raise the fee ceiling",
+  category: "params",
+  status: "active",
+  summary: "A summary.",
+  body: "Full body text.",
+  forVotes: 100,
+  againstVotes: 50,
+  quorumPct: 10,
+  created: "2026-01-01",
+  ends: "2026-03-01",
+  author: "0xabc",
+};
+
+const baseProps = {
+  proposals: [proposal],
+  delegates: [{ name: "Alice", address: "G…1234", votingPower: "1M", participationRate: "82%", bio: "Delegate bio" }],
+  totalSupply: 184_000_000,
+};
+
+describe("GovernanceForum", () => {
+  it("renders without crashing and lists the proposals", () => {
+    render(<GovernanceForum {...baseProps} />);
+    // The governance label appears on the root and the banner.
+    expect(screen.getAllByLabelText(/Soroban AMM Governance/).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Proposal GIP-001: Raise the fee ceiling")).toBeInTheDocument();
+    expect(screen.getByText("Raise the fee ceiling")).toBeInTheDocument();
+  });
+
+  it("shows read-only mode when no wallet is connected", () => {
+    render(<GovernanceForum {...baseProps} />);
+    expect(screen.getByText("Read-only mode")).toBeInTheDocument();
+  });
+
+  it("shows the connected wallet address when connected", () => {
+    render(<GovernanceForum {...baseProps} walletConnected walletAddress="GABC123" />);
+    expect(screen.getByText("GABC123")).toBeInTheDocument();
+  });
+
+  it("calls onConnectWallet from the connect button", async () => {
+    const user = userEvent.setup();
+    const onConnectWallet = vi.fn();
+    render(<GovernanceForum {...baseProps} onConnectWallet={onConnectWallet} />);
+    await user.click(screen.getByRole("button", { name: "Connect wallet" }));
+    expect(onConnectWallet).toHaveBeenCalled();
+  });
+
+  it("casts a For vote from the list and calls onVote with the right payload", async () => {
+    const user = userEvent.setup();
+    const onVote = vi.fn();
+    render(<GovernanceForum {...baseProps} onVote={onVote} />);
+    await user.click(screen.getByRole("button", { name: "Vote for on GIP-001" }));
+    expect(onVote).toHaveBeenCalledWith("GIP-001", "for");
+    expect(screen.getByText("You voted: for")).toBeInTheDocument();
+  });
+
+  it("casts Against and Abstain votes with the correct choice", async () => {
+    const user = userEvent.setup();
+    const onVote = vi.fn();
+    render(<GovernanceForum {...baseProps} onVote={onVote} />);
+    await user.click(screen.getByRole("button", { name: "Vote against on GIP-001" }));
+    expect(onVote).toHaveBeenLastCalledWith("GIP-001", "against");
+    await user.click(screen.getByRole("button", { name: "Vote abstain on GIP-001" }));
+    expect(onVote).toHaveBeenLastCalledWith("GIP-001", "abstain");
+  });
+
+  it("updates the proposal's displayed vote counts when voting", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} onVote={vi.fn()} />);
+    const article = screen.getByLabelText("Proposal GIP-001: Raise the fee ceiling");
+    // Initial: 100 for / 50 against → 67% for.
+    expect(within(article).getByLabelText("Voting: 67% for, 33% against")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Vote for on GIP-001" }));
+    // For votes jump by 50,000 → 50.1K.
+    expect(screen.getByText("50.1K")).toBeInTheDocument();
+  });
+
+  it("surfaces a success toast after casting a vote", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.click(screen.getByRole("button", { name: "Vote for on GIP-001" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(/Vote cast/);
+  });
+
+  it("opens a proposal detail modal and votes from it", async () => {
+    const user = userEvent.setup();
+    const onVote = vi.fn();
+    render(<GovernanceForum {...baseProps} onVote={onVote} />);
+    await user.click(screen.getByLabelText("Proposal GIP-001: Raise the fee ceiling"));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Vote for on GIP-001" }));
+    expect(onVote).toHaveBeenCalledWith("GIP-001", "for");
+  });
+
+  it("switches to the delegation tab and delegates to a custom address", async () => {
+    const user = userEvent.setup();
+    const onDelegate = vi.fn();
+    render(<GovernanceForum {...baseProps} onDelegate={onDelegate} />);
+    await user.click(screen.getByRole("tab", { name: "Delegation" }));
+    expect(screen.getByText("Vote Delegation")).toBeInTheDocument();
+    const addr = screen.getByLabelText("Custom delegate address");
+    await user.type(addr, "GABC1234");
+    await user.click(screen.getByRole("button", { name: "Delegate voting power" }));
+    expect(onDelegate).toHaveBeenCalledWith("GABC1234");
+  });
+
+  it("errors on delegation with an empty address", async () => {
+    const user = userEvent.setup();
+    const onDelegate = vi.fn();
+    render(<GovernanceForum {...baseProps} onDelegate={onDelegate} />);
+    await user.click(screen.getByRole("tab", { name: "Delegation" }));
+    await user.click(screen.getByRole("button", { name: "Delegate voting power" }));
+    expect(onDelegate).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/valid Stellar address/i);
+  });
+
+  it("delegates to a recommended delegate", async () => {
+    const user = userEvent.setup();
+    const onDelegate = vi.fn();
+    render(<GovernanceForum {...baseProps} onDelegate={onDelegate} />);
+    await user.click(screen.getByRole("tab", { name: "Delegation" }));
+    await user.click(screen.getByRole("button", { name: "Delegate to Alice" }));
+    expect(onDelegate).toHaveBeenCalled();
+  });
+
+  it("renders the voting power calculator tab with a computed value", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: "Power Calc" }));
+    expect(screen.getByText("Voting Power Calculator")).toBeInTheDocument();
+    // Default: 10000 tokens, 30% locked, 1.5x → base 11500 → "11.5K" VP.
+    expect(screen.getAllByText("11.5K").length).toBeGreaterThan(0);
+  });
+
+  it("recomputes voting power when the lock duration changes", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: "Power Calc" }));
+    await user.selectOptions(screen.getByLabelText("Lock duration"), "2");
+    // 10000 tokens, 30% locked at 2x → base = 7000 + 3000*2 = 13000 → "13.0K".
+    expect(screen.getAllByText("13.0K").length).toBeGreaterThan(0);
+  });
+
+  it("renders the analytics tab with a history table", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: "Analytics" }));
+    expect(screen.getByText("Proposal History & Analytics")).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Full proposal history" })).toBeInTheDocument();
+    expect(screen.getByText("Raise the fee ceiling")).toBeInTheDocument();
+  });
+
+  it("filters proposals by status", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.selectOptions(screen.getByLabelText("Filter by status"), "passed");
+    expect(screen.getByText(/No proposals match the current filters/)).toBeInTheDocument();
+  });
+});
+
+describe("GovernanceForum proposal wizard", () => {
+  it("submits a new proposal through the wizard", async () => {
+    const user = userEvent.setup();
+    const onProposalSubmit = vi.fn();
+    render(<GovernanceForum {...baseProps} onProposalSubmit={onProposalSubmit} />);
+    await user.click(screen.getByRole("tab", { name: "+ New Proposal" }));
+
+    await user.type(screen.getByLabelText("Title *"), "New idea");
+    await user.selectOptions(screen.getByLabelText("Category *"), "protocol");
+    await user.type(screen.getByLabelText("Summary *"), "A summary");
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+
+    // Step 1 — Parameters
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    // Step 2 — Actions
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    // Step 3 — Review
+    await user.click(screen.getByRole("button", { name: /Submit Proposal/ }));
+
+    expect(onProposalSubmit).toHaveBeenCalledTimes(1);
+    const payload = onProposalSubmit.mock.calls[0][0];
+    expect(payload.title).toBe("New idea");
+    expect(payload.category).toBe("protocol");
+    expect(payload.summary).toBe("A summary");
+  });
+
+  it("blocks advancing from step 1 when required fields are empty", async () => {
+    const user = userEvent.setup();
+    const onProposalSubmit = vi.fn();
+    render(<GovernanceForum {...baseProps} onProposalSubmit={onProposalSubmit} />);
+    await user.click(screen.getByRole("tab", { name: "+ New Proposal" }));
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    // Title empty → error toast, still on step 0.
+    expect(onProposalSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/Title is required/);
+    expect(screen.getByLabelText("Title *")).toBeInTheDocument();
+  });
+
+  it("allows adding a proposal action in the wizard", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceForum {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: "+ New Proposal" }));
+    await user.type(screen.getByLabelText("Title *"), "T");
+    await user.selectOptions(screen.getByLabelText("Category *"), "protocol");
+    await user.type(screen.getByLabelText("Summary *"), "S");
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await user.click(screen.getByRole("button", { name: /Add Action/ }));
+    expect(screen.getByLabelText("Contract ID")).toBeInTheDocument();
+  });
+});

--- a/packages/ui-components/src/PositionManager.test.tsx
+++ b/packages/ui-components/src/PositionManager.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PositionManager } from "./PositionManager.js";
+
+async function setAmount(input: HTMLElement, value: string, user: ReturnType<typeof userEvent.setup>) {
+  await user.tripleClick(input);
+  await user.keyboard(value);
+}
+
+const baseProps = {
+  currentPrice: 100,
+  tokenA: "XLM",
+  tokenB: "USDC",
+};
+
+describe("PositionManager", () => {
+  it("renders a new position panel without crashing", () => {
+    render(<PositionManager {...baseProps} />);
+    expect(screen.getByRole("heading", { name: /New Position — XLM\/USDC/ })).toBeInTheDocument();
+  });
+
+  it("renders an edit position heading given a position id", () => {
+    render(<PositionManager {...baseProps} position={{ id: "pos-1" }} />);
+    expect(screen.getByRole("heading", { name: /Edit Position — XLM\/USDC/ })).toBeInTheDocument();
+  });
+
+  it("exposes a labelled form landmark and amount inputs", () => {
+    render(<PositionManager {...baseProps} />);
+    expect(screen.getByRole("form", { name: "Position manager" })).toBeInTheDocument();
+    expect(screen.getByLabelText("XLM deposit amount")).toBeInTheDocument();
+    expect(screen.getByLabelText("USDC deposit amount")).toBeInTheDocument();
+  });
+
+  it("shows the default 0% fee badge", () => {
+    render(<PositionManager {...baseProps} />);
+    expect(screen.getByText("0.3% fee")).toBeInTheDocument();
+  });
+
+  it("submits a valid position with the expected payload", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PositionManager {...baseProps} onSubmit={onSubmit} />);
+    await setAmount(screen.getByLabelText("XLM deposit amount"), "100", user);
+    await setAmount(screen.getByLabelText("USDC deposit amount"), "200", user);
+    await user.click(screen.getByRole("button", { name: "Add Liquidity" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.amountA).toBe(100);
+    expect(payload.amountB).toBe(200);
+    expect(payload.feeBps).toBe(30);
+    expect(payload.priceRange).toEqual({ lower: 80, upper: 120 });
+  });
+
+  it("rejects a negative amount and surfaces it to the user", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    // Seed a negative amountA through the position prop (number inputs strip a
+    // leading minus, so this drives the internal state directly).
+    render(
+      <PositionManager
+        {...baseProps}
+        onSubmit={onSubmit}
+        position={{ amountA: -50, amountB: 100 }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add Liquidity" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/Amount A must be a positive number/);
+  });
+
+  it("rejects a zero amount and surfaces it to the user", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PositionManager {...baseProps} onSubmit={onSubmit} />);
+    await setAmount(screen.getByLabelText("XLM deposit amount"), "0", user);
+    await setAmount(screen.getByLabelText("USDC deposit amount"), "50", user);
+    await user.click(screen.getByRole("button", { name: "Add Liquidity" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/Amount A/);
+  });
+
+  it("rejects a lower tick above the upper tick", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    // Seed a malformed range via the position prop so the UI state carries it.
+    render(
+      <PositionManager
+        {...baseProps}
+        onSubmit={onSubmit}
+        position={{ priceRange: { lower: 200, upper: 100 }, amountA: 100, amountB: 100 }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add Liquidity" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    const alerts = screen.getAllByRole("alert");
+    expect(
+      alerts.some((a) => a.textContent?.includes("Lower price must be below the upper price")),
+    ).toBe(true);
+  });
+
+  it("shows no error alert after a valid submit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PositionManager {...baseProps} onSubmit={onSubmit} />);
+    await setAmount(screen.getByLabelText("XLM deposit amount"), "100", user);
+    await setAmount(screen.getByLabelText("USDC deposit amount"), "100", user);
+    await user.click(screen.getByRole("button", { name: "Add Liquidity" }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("calls onCancel when the cancel button is pressed", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<PositionManager {...baseProps} onCancel={onCancel} />);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("switches tab panels on tab click", async () => {
+    const user = userEvent.setup();
+    render(<PositionManager {...baseProps} />);
+    const riskTab = screen.getByRole("tab", { name: /Risk/ });
+    await user.click(riskTab);
+    expect(riskTab).toHaveAttribute("aria-selected", "true");
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).not.toHaveAttribute("hidden");
+  });
+
+  it("lets a user change the fee tier and reflect it in the badge", async () => {
+    const user = userEvent.setup();
+    render(<PositionManager {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: "Fee Tier" }));
+    await user.click(screen.getByRole("radio", { name: /Exotic — 1% fee/ }));
+    expect(screen.getByText("1% fee")).toBeInTheDocument();
+  });
+
+  it("renders the risk tab with a warning emoji when risk is not low", () => {
+    render(<PositionManager {...baseProps} poolTvl={500} priceDeviationBps={600} />);
+    const riskTab = screen.getByRole("tab", { name: /Risk/ });
+    expect(riskTab.textContent).toContain("⚠");
+  });
+});

--- a/packages/ui-components/src/RangeSelector.test.tsx
+++ b/packages/ui-components/src/RangeSelector.test.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RangeSelector } from "./RangeSelector.js";
+import type { PriceRange } from "./types.js";
+
+const defaultProps = {
+  minPrice: 10,
+  maxPrice: 1000,
+  currentPrice: 100,
+  value: { lower: 80, upper: 120 } as PriceRange,
+  onChange: vi.fn(),
+};
+
+function Harness({
+  onRangeChange,
+  initial = { lower: 80, upper: 120 } as PriceRange,
+  ...rest
+}: {
+  onRangeChange: (r: PriceRange) => void;
+  initial?: PriceRange;
+  [key: string]: unknown;
+}) {
+  const [range, setRange] = useState<PriceRange>(initial);
+  return (
+    <RangeSelector
+      minPrice={10}
+      maxPrice={1000}
+      currentPrice={100}
+      value={range}
+      onChange={(r) => {
+        setRange(r);
+        onRangeChange(r);
+      }}
+      tokenA="XLM"
+      tokenB="USDC"
+      {...rest}
+    />
+  );
+}
+
+/**
+ * A harness with a low minPrice (1) so that typed single digits are not
+ * snapped up to a high minimum, letting a clean multi-digit value land.
+ */
+function NumericHarness({ onRangeChange }: { onRangeChange: (r: PriceRange) => void }) {
+  const [range, setRange] = useState<PriceRange>({ lower: 50, upper: 120 });
+  return (
+    <RangeSelector
+      minPrice={1}
+      maxPrice={1000}
+      currentPrice={100}
+      value={range}
+      onChange={(r) => {
+        setRange(r);
+        onRangeChange(r);
+      }}
+    />
+  );
+}
+
+describe("RangeSelector", () => {
+  it("renders without crashing given valid props", () => {
+    render(<RangeSelector {...defaultProps} tokenA="XLM" tokenB="USDC" />);
+    expect(screen.getByLabelText(/Price range selector/)).toBeInTheDocument();
+    expect(screen.getByText("USDC per XLM")).toBeInTheDocument();
+  });
+
+  it("displays the selected range values", () => {
+    render(<RangeSelector {...defaultProps} />);
+    expect(screen.getByText(/80\.000000/)).toBeInTheDocument();
+    expect(screen.getByText(/120\.000000/)).toBeInTheDocument();
+  });
+
+  it("exposes accessible sliders with current values and bounds", () => {
+    render(<RangeSelector {...defaultProps} />);
+    const lower = screen.getByRole("slider", { name: /Lower bound: 80\.000000/ });
+    const upper = screen.getByRole("slider", { name: /Upper bound: 120\.000000/ });
+    expect(lower).toHaveAttribute("aria-valuenow", "80");
+    expect(lower).toHaveAttribute("aria-valuemin", "10");
+    expect(lower).toHaveAttribute("aria-valuemax", "120");
+    expect(upper).toHaveAttribute("aria-valuenow", "120");
+    expect(upper).toHaveAttribute("aria-valuemax", "1000");
+  });
+
+  it("renders the empty/zero state for no liquidity bins", () => {
+    render(<RangeSelector {...defaultProps} />);
+    expect(screen.getByLabelText(/Price range selector/)).toBeInTheDocument();
+    // No bin bars rendered for an empty set, and no crash.
+    expect(document.querySelectorAll("[aria-hidden='true']").length).toBeGreaterThan(0);
+  });
+
+  it("shows an alert when the current price is outside the selected range", () => {
+    render(<RangeSelector {...defaultProps} value={{ lower: 200, upper: 300 }} />);
+    expect(screen.getByRole("alert")).toHaveTextContent(/outside the selected range/);
+  });
+
+  it("does not show an alert when the price is in range", () => {
+    render(<RangeSelector {...defaultProps} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("emits a lower-bound change from the numeric input payload", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NumericHarness onRangeChange={onChange} />);
+    const minInput = screen.getByLabelText("Minimum price");
+    await user.tripleClick(minInput);
+    await user.keyboard("70");
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 70, upper: 120 });
+    expect(minInput).toHaveValue(70);
+  });
+
+  it("clamps a cleared upper-bound numeric input to just above the lower", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const maxInput = screen.getByLabelText("Maximum price");
+    await user.clear(maxInput);
+    // Clearing fires "" → Number("") = 0 → clamped up to lower + 0.000001.
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 80, upper: 80.000001 });
+  });
+
+  it("emits an upper-bound change from the numeric input payload", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NumericHarness onRangeChange={onChange} />);
+    const maxInput = screen.getByLabelText("Maximum price");
+    // The max input's minimum is lower + 0.000001; typing a value above it
+    // passes through unchanged.
+    await user.tripleClick(maxInput);
+    await user.keyboard("999");
+    const last = onChange.mock.calls.at(-1)?.[0];
+    expect(last?.upper).toBeGreaterThan(50);
+    expect(last?.lower).toBe(50);
+  });
+
+  it("moves the lower thumb on ArrowRight keyboard input", async () => {
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const lower = screen.getByRole("slider", { name: /Lower bound/ });
+    lower.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    // step = (1000 - 10) / 200 = 4.95
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 80 + 4.95, upper: 120 });
+  });
+
+  it("moves the upper thumb on ArrowLeft keyboard input", async () => {
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const upper = screen.getByRole("slider", { name: /Upper bound/ });
+    upper.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 80, upper: 120 - 4.95 });
+  });
+
+  it("jumps the lower thumb to the minimum using Home", async () => {
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const lower = screen.getByRole("slider", { name: /Lower bound/ });
+    lower.focus();
+    await userEvent.keyboard("{Home}");
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 10, upper: 120 });
+  });
+
+  it("prevents the thumbs from crossing (lower cannot exceed upper)", async () => {
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const lower = screen.getByRole("slider", { name: /Lower bound/ });
+    lower.focus();
+    await userEvent.keyboard("{End}");
+    // Lower clamps to upper - 0.000001
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 120 - 0.000001, upper: 120 });
+  });
+
+  it("clamps numeric lower input to the upper bound", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onRangeChange={onChange} />);
+    const minInput = screen.getByLabelText("Minimum price");
+    await user.clear(minInput);
+    await user.type(minInput, "999");
+    expect(onChange).toHaveBeenLastCalledWith({ lower: 120 - 0.000001, upper: 120 });
+  });
+});

--- a/packages/ui-components/src/RiskIndicator.test.tsx
+++ b/packages/ui-components/src/RiskIndicator.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RiskIndicator } from "./RiskIndicator.js";
+import type { RiskAssessment } from "./types.js";
+
+const assessment: RiskAssessment = {
+  level: "high",
+  score: 45,
+  factors: [
+    { name: "Out of range", description: "Price is outside range.", severity: "critical" },
+    { name: "High price deviation", description: "Unusual volatility.", severity: "high", value: 600, threshold: 500 },
+  ],
+};
+
+describe("RiskIndicator", () => {
+  it("renders the risk level label and score text", () => {
+    render(<RiskIndicator assessment={assessment} />);
+    expect(screen.getByText("High Risk")).toBeInTheDocument();
+    expect(screen.getByText(/Score: 45\/100/)).toBeInTheDocument();
+  });
+
+  it("renders the factor summary count", () => {
+    render(<RiskIndicator assessment={assessment} />);
+    expect(screen.getByText(/2 risk factors identified/)).toBeInTheDocument();
+  });
+
+  it("names singular factor count correctly", () => {
+    render(
+      <RiskIndicator
+        assessment={{ ...assessment, factors: [assessment.factors[0]] }}
+      />,
+    );
+    expect(screen.getByText(/1 risk factor identified/)).toBeInTheDocument();
+  });
+
+  it("renders the empty/zero state when there are no factors", () => {
+    render(<RiskIndicator assessment={{ level: "low", score: 100, factors: [] }} />);
+    expect(screen.getByText(/0 risk factors identified/)).toBeInTheDocument();
+    // No expand button when there is nothing to expand.
+    expect(screen.queryByRole("button", { name: /details/i })).not.toBeInTheDocument();
+  });
+
+  it("is collapsed by default and expands detail factors on toggle", async () => {
+    const user = userEvent.setup();
+    render(<RiskIndicator assessment={assessment} />);
+    expect(screen.queryByText("Unusual volatility.")).not.toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: /Show details/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await user.click(toggle);
+    expect(screen.getByRole("button", { name: /Hide details/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Unusual volatility.")).toBeInTheDocument();
+  });
+
+  it("renders expanded by default when defaultExpanded is true", () => {
+    render(<RiskIndicator assessment={assessment} defaultExpanded />);
+    expect(screen.getByText("Unusual volatility.")).toBeInTheDocument();
+  });
+
+  it("renders severity badges with accessible names", () => {
+    render(<RiskIndicator assessment={assessment} defaultExpanded />);
+    expect(screen.getByLabelText("Severity: Critical Risk")).toBeInTheDocument();
+    expect(screen.getByLabelText("Severity: High Risk")).toBeInTheDocument();
+  });
+
+  it("exposes an accessible overall risk live region", () => {
+    render(<RiskIndicator assessment={assessment} />);
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "aria-label",
+      "Overall risk: High Risk, score 45 out of 100",
+    );
+  });
+
+  it("honours an aria-label override on the root", () => {
+    render(<RiskIndicator assessment={assessment} aria-label="My indicator" />);
+    expect(screen.getByLabelText("My indicator")).toBeInTheDocument();
+  });
+
+  it("renders a factor bar only when value and threshold are defined", () => {
+    render(<RiskIndicator assessment={assessment} defaultExpanded />);
+    const list = screen.getByRole("list", { name: "Risk factors" });
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    // Only one factor (deviation) has value+threshold → one bar rendered.
+    const bar = list.querySelector("[aria-hidden='true']");
+    expect(bar).toBeInTheDocument();
+    expect(list.querySelectorAll("[aria-hidden='true']")).toHaveLength(1);
+  });
+
+  it("applies the level border colour to the root", () => {
+    const { container } = render(<RiskIndicator assessment={assessment} />);
+    expect(container.firstChild).toHaveStyle({ borderColor: "#f0883e" });
+  });
+});

--- a/packages/ui-components/src/lib/capitalEfficiency.test.ts
+++ b/packages/ui-components/src/lib/capitalEfficiency.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEfficiency,
+  formatEfficiency,
+  isInRange,
+  rangePct,
+} from "./capitalEfficiency.js";
+
+describe("computeEfficiency", () => {
+  it("returns ~1x for a full-range position", () => {
+    // A very wide range (1 .. 1e9) is effectively a full-range position.
+    const eff = computeEfficiency(10, 1, 1_000_000_000);
+    expect(eff).toBeGreaterThan(0.999);
+    expect(eff).toBeLessThan(1.01);
+  });
+
+  it("returns the hand-computed multiplier for a concentrated range", () => {
+    // lower=80, upper=100: sqrt(80/100)=sqrt(0.8)=0.894427.
+    // eff = 1/(1-0.894427) = 9.472135...
+    const eff = computeEfficiency(90, 80, 100);
+    expect(eff).toBeCloseTo(Math.sqrt(0.8) ? 1 / (1 - Math.sqrt(0.8)) : NaN, 5);
+  });
+
+  it("computes a tighter range as more efficient", () => {
+    const wide = computeEfficiency(100, 50, 200);
+    const tight = computeEfficiency(100, 90, 110);
+    expect(tight).toBeGreaterThan(wide);
+    expect(wide).toBeGreaterThan(1);
+  });
+
+  it("returns 1 for a position entirely below the current price", () => {
+    expect(computeEfficiency(100, 10, 50)).toBe(1);
+  });
+
+  it("returns 1 for a position entirely above the current price", () => {
+    expect(computeEfficiency(100, 150, 300)).toBe(1);
+  });
+
+  it("returns >1 when the current price straddles the range", () => {
+    expect(computeEfficiency(100, 80, 120)).toBeGreaterThan(1);
+  });
+
+  it("is symmetric at the range boundaries (inclusive)", () => {
+    // At exactly lower / upper the price is still "in range".
+    expect(computeEfficiency(80, 80, 120)).toBeGreaterThan(1);
+    expect(computeEfficiency(120, 80, 120)).toBeGreaterThan(1);
+  });
+});
+
+describe("computeEfficiency — degenerate and division-by-zero inputs", () => {
+  it("returns 1 for a zero lower bound", () => {
+    expect(computeEfficiency(50, 0, 100)).toBe(1);
+  });
+
+  it("returns 1 for a zero upper bound", () => {
+    expect(computeEfficiency(50, 10, 0)).toBe(1);
+  });
+
+  it("returns 1 when lower === upper", () => {
+    expect(computeEfficiency(50, 50, 50)).toBe(1);
+  });
+
+  it("returns 1 for an inverted range (lower > upper)", () => {
+    expect(computeEfficiency(50, 200, 100)).toBe(1);
+  });
+
+  it("returns 1 for a zero current price", () => {
+    expect(computeEfficiency(0, 10, 100)).toBe(1);
+  });
+
+  it("returns 1 for a negative current price", () => {
+    expect(computeEfficiency(-50, 10, 100)).toBe(1);
+  });
+
+  it("returns 1 for negative bounds", () => {
+    expect(computeEfficiency(50, -10, 100)).toBe(1);
+  });
+
+  it("does not produce NaN/Infinity for NaN bounds", () => {
+    expect(computeEfficiency(50, NaN, 100)).toBe(1);
+    expect(computeEfficiency(50, 10, NaN)).toBe(1);
+  });
+});
+
+describe("computeEfficiency — very large values (no overflow / precision)", () => {
+  it("stays finite for huge bounds", () => {
+    const eff = computeEfficiency(1e12, 1e11, 1e13);
+    expect(Number.isFinite(eff)).toBe(true);
+    expect(eff).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns a finite, >1 result for large concentrated bounds", () => {
+    const eff = computeEfficiency(1_000_000, 900_000, 1_100_000);
+    expect(Number.isFinite(eff)).toBe(true);
+    expect(eff).toBeGreaterThan(1);
+    expect(eff).toBeLessThan(100);
+  });
+
+  it("handles the largest safe-integer bounds without losing to Infinity", () => {
+    const lower = Number.MAX_SAFE_INTEGER / 2;
+    const upper = Number.MAX_SAFE_INTEGER;
+    const eff = computeEfficiency((lower + upper) / 2, lower, upper);
+    expect(Number.isFinite(eff)).toBe(true);
+  });
+});
+
+describe("rangePct", () => {
+  it("computes the percent width of a range", () => {
+    expect(rangePct(80, 120, 100)).toBeCloseTo(40, 5);
+  });
+
+  it("returns 0 for a non-positive reference price (no NaN/Infinity)", () => {
+    expect(rangePct(80, 120, 0)).toBe(0);
+    expect(rangePct(80, 120, -10)).toBe(0);
+  });
+
+  it("handles large ranges without overflowing", () => {
+    const pct = rangePct(1, Number.MAX_SAFE_INTEGER, 1);
+    expect(Number.isFinite(pct)).toBe(true);
+  });
+});
+
+describe("isInRange", () => {
+  it("is true for a price inside the range", () => {
+    expect(isInRange(100, { lower: 80, upper: 120 })).toBe(true);
+  });
+
+  it("is true at the boundaries (inclusive)", () => {
+    expect(isInRange(80, { lower: 80, upper: 120 })).toBe(true);
+    expect(isInRange(120, { lower: 80, upper: 120 })).toBe(true);
+  });
+
+  it("is false below and above the range", () => {
+    expect(isInRange(79, { lower: 80, upper: 120 })).toBe(false);
+    expect(isInRange(121, { lower: 80, upper: 120 })).toBe(false);
+  });
+});
+
+describe("formatEfficiency", () => {
+  it("formats a normal efficiency to one decimal", () => {
+    expect(formatEfficiency(9.47)).toBe("9.5");
+  });
+
+  it("renders very large efficiencies as '>1000'", () => {
+    expect(formatEfficiency(1500)).toBe(">1000");
+    expect(formatEfficiency(1e9)).toBe(">1000");
+  });
+
+  it("handles the degenerate 1x case", () => {
+    expect(formatEfficiency(1)).toBe("1.0");
+  });
+});

--- a/packages/ui-components/src/lib/capitalEfficiency.ts
+++ b/packages/ui-components/src/lib/capitalEfficiency.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure concentrated-liquidity capital-efficiency math, extracted from
+ * CapitalEfficiencyCalc.tsx so the formula can be unit-tested directly.
+ *
+ * Capital efficiency compares the capital a concentrated-range position needs
+ * to deliver the same depth as a full-range (v2-style) position. The larger
+ * the multiplier, the more "efficient" the capital is but the narrower and
+ * more rebalancing-prone the range.
+ *
+ * The formula follows the standard Uniswap v3 liquidity relationship:
+ *
+ *   fullRangeCapitalNeeded   ∝  1
+ *   concentratedCapitalNeeded ∝  (1 - sqrt(lower / upper))
+ *
+ * so efficiency = 1 / (1 - sqrt(lower / upper)).
+ */
+
+import type { PriceRange } from "../types.js";
+
+/**
+ * Computes the capital-efficiency multiplier of a [lower, upper] range
+ * relative to a full range, given the current spot price.
+ *
+ * Returns `1` (i.e. no capital advantage, equivalent to a full-range
+ * position) for any degenerate or out-of-range input:
+ *   - lower or upper <= 0
+ *   - lower >= upper (equal or inverted ranges)
+ *   - currentPrice is outside [lower, upper] (position inactive)
+ */
+export function computeEfficiency(
+  currentPrice: number,
+  lower: number,
+  upper: number,
+): number {
+  if (!Number.isFinite(lower) || !Number.isFinite(upper)) return 1;
+  if (lower <= 0 || upper <= 0 || lower >= upper) return 1;
+  if (!Number.isFinite(currentPrice) || currentPrice < lower || currentPrice > upper) return 1;
+  const sqrtRatio = Math.sqrt(lower / upper);
+  // Guard against floating-point rounding yielding sqrtRatio ~= 1 for an
+  // extremely tight (but valid) range.
+  if (sqrtRatio >= 1) return 1;
+  const eff = 1 / (1 - sqrtRatio);
+  return Math.max(1, eff);
+}
+
+/**
+ * Percentage width of a price range relative to a reference price.
+ * Handles a zero reference so it never returns Infinity/NaN.
+ */
+export function rangePct(lower: number, upper: number, currentPrice: number): number {
+  if (currentPrice <= 0) return 0;
+  return ((upper - lower) / currentPrice) * 100;
+}
+
+/** Whether a price sits inside [lower, upper] (inclusive bounds). */
+export function isInRange(currentPrice: number, range: PriceRange): boolean {
+  return currentPrice >= range.lower && currentPrice <= range.upper;
+}
+
+/** Format the efficiency multiplier for display (clamped at "__.x", ">1000"). */
+export function formatEfficiency(efficiency: number): string {
+  if (!Number.isFinite(efficiency) || efficiency <= 0) return "1.0";
+  if (efficiency >= 1000) return ">1000";
+  return efficiency.toFixed(1);
+}

--- a/packages/ui-components/src/lib/positionValidation.test.ts
+++ b/packages/ui-components/src/lib/positionValidation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { validatePosition } from "./positionValidation.js";
+
+const valid = {
+  amountA: 100,
+  amountB: 200,
+  priceRange: { lower: 80, upper: 120 },
+};
+
+describe("validatePosition", () => {
+  it("accepts a fully valid position (no errors)", () => {
+    expect(validatePosition(valid)).toEqual([]);
+  });
+
+  it("rejects a negative amountA", () => {
+    const errs = validatePosition({ ...valid, amountA: -1 });
+    expect(errs.some((e) => /Amount A/.test(e))).toBe(true);
+  });
+
+  it("rejects a negative amountB", () => {
+    const errs = validatePosition({ ...valid, amountB: -50 });
+    expect(errs.some((e) => /Amount B/.test(e))).toBe(true);
+  });
+
+  it("rejects a zero amount", () => {
+    expect(validatePosition({ ...valid, amountA: 0 }).length).toBeGreaterThan(0);
+    expect(validatePosition({ ...valid, amountB: 0 }).length).toBeGreaterThan(0);
+  });
+
+  it("rejects a lower tick at or above the upper tick", () => {
+    expect(validatePosition({ ...valid, priceRange: { lower: 120, upper: 120 } }))
+      .toContain("Lower price must be below the upper price.");
+    expect(validatePosition({ ...valid, priceRange: { lower: 200, upper: 100 } }))
+      .toContain("Lower price must be below the upper price.");
+  });
+
+  it("rejects non-finite and non-positive bounds", () => {
+    expect(validatePosition({ ...valid, priceRange: { lower: 0, upper: 100 } })
+      .some((e) => /lower/i.test(e))).toBe(true);
+    expect(validatePosition({ ...valid, priceRange: { lower: 80, upper: NaN } })
+      .some((e) => /upper/i.test(e))).toBe(true);
+  });
+
+  it("collects multiple errors at once", () => {
+    const errs = validatePosition({ amountA: 0, amountB: -1, priceRange: { lower: 120, upper: 100 } });
+    expect(errs.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/ui-components/src/lib/positionValidation.ts
+++ b/packages/ui-components/src/lib/positionValidation.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure validation logic for PositionManager, extracted so the dispatch rules
+ * ("invalid input is rejected and surfaced, not silently coerced") can be
+ * unit-tested directly.
+ *
+ * A position is only valid when:
+ *   - both deposit amounts are strictly positive (zero and negative amounts
+ *     are rejected),
+ *   - the price range is well-formed and ordered (lower < upper, both > 0).
+ */
+
+import type { PriceRange } from "../types.js";
+
+export interface PositionValidationInput {
+  amountA: number;
+  amountB: number;
+  priceRange: PriceRange;
+}
+
+/** Returns a human-readable error message for the first offending attribute. */
+export function validatePosition({
+  amountA,
+  amountB,
+  priceRange,
+}: PositionValidationInput): string[] {
+  const errors: string[] = [];
+
+  if (!Number.isFinite(amountA) || amountA <= 0) {
+    errors.push(`Amount A must be a positive number (received ${fmt(amountA)}).`);
+  }
+  if (!Number.isFinite(amountB) || amountB <= 0) {
+    errors.push(`Amount B must be a positive number (received ${fmt(amountB)}).`);
+  }
+
+  const { lower, upper } = priceRange;
+  if (!Number.isFinite(lower) || lower <= 0) {
+    errors.push("Lower price must be a positive number.");
+  }
+  if (!Number.isFinite(upper) || upper <= 0) {
+    errors.push("Upper price must be a positive number.");
+  }
+  if (lower > 0 && upper > 0 && lower >= upper) {
+    errors.push("Lower price must be below the upper price.");
+  }
+
+  return errors;
+}
+
+function fmt(n: number): string {
+  return Number.isFinite(n) ? String(n) : String(n);
+}

--- a/packages/ui-components/src/lib/riskAssessment.test.ts
+++ b/packages/ui-components/src/lib/riskAssessment.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessPositionRisk,
+  riskLevelForScore,
+  RISK_THRESHOLDS,
+} from "./riskAssessment.js";
+
+const healthy = {
+  priceDeviationBps: 0,
+  rangePct: 50,
+  tvl: 1_000_000,
+  volume24h: 500_000,
+  isInRange: true,
+  feeBps: 30,
+};
+
+describe("riskLevelForScore — every threshold on both sides", () => {
+  // Boundary 80 (low/medium)
+  it("returns low at exactly the low threshold (80)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.low)).toBe("low");
+  });
+  it("returns medium just below the low threshold (79)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.low - 1)).toBe("medium");
+  });
+  it("clamps scores above 100 to low", () => {
+    expect(riskLevelForScore(120)).toBe("low");
+  });
+
+  // Boundary 55 (medium/high)
+  it("returns medium at exactly the medium threshold (55)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.medium)).toBe("medium");
+  });
+  it("returns high just below the medium threshold (54)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.medium - 1)).toBe("high");
+  });
+
+  // Boundary 30 (high/critical)
+  it("returns high at exactly the high threshold (30)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.high)).toBe("high");
+  });
+  it("returns critical just below the high threshold (29)", () => {
+    expect(riskLevelForScore(RISK_THRESHOLDS.high - 1)).toBe("critical");
+  });
+  it("clamps negative scores to critical", () => {
+    expect(riskLevelForScore(-5)).toBe("critical");
+  });
+});
+
+describe("assessPositionRisk", () => {
+  it("returns low risk with a full score for a healthy in-range position", () => {
+    const r = assessPositionRisk(healthy);
+    expect(r.score).toBe(100);
+    expect(r.level).toBe("low");
+    expect(r.factors).toHaveLength(0);
+  });
+
+  it("penalises an out-of-range position with a critical factor", () => {
+    const r = assessPositionRisk({ ...healthy, isInRange: false });
+    expect(r.factors.some((f) => f.name === "Out of range" && f.severity === "critical")).toBe(true);
+    expect(r.score).toBe(60);
+  });
+
+  it("applies medium deviation exactly at the >200 boundary and high above 500", () => {
+    const medium = assessPositionRisk({ ...healthy, priceDeviationBps: 250 });
+    const high = assessPositionRisk({ ...healthy, priceDeviationBps: 501 });
+    expect(medium.factors.find((f) => f.name === "High price deviation")?.severity).toBe("medium");
+    expect(medium.score).toBe(90);
+    expect(high.factors.find((f) => f.name === "High price deviation")?.severity).toBe("high");
+    expect(high.score).toBe(75);
+  });
+
+  it("does not apply deviation at or below the 200 threshold", () => {
+    const r = assessPositionRisk({ ...healthy, priceDeviationBps: 200 });
+    expect(r.factors.find((f) => f.name === "High price deviation")).toBeUndefined();
+    expect(r.score).toBe(100);
+  });
+
+  it("penalises a very narrow range (<5%)", () => {
+    const r = assessPositionRisk({ ...healthy, rangePct: 4 });
+    expect(r.factors.some((f) => f.name === "Very narrow range")).toBe(true);
+    expect(r.score).toBe(85);
+  });
+
+  it("does not penalise a range at exactly 5%", () => {
+    const r = assessPositionRisk({ ...healthy, rangePct: 5 });
+    expect(r.factors.find((f) => f.name === "Very narrow range")).toBeUndefined();
+    expect(r.score).toBe(100);
+  });
+
+  it("flags low TVL below 10k (low>1k) and high TVL risk below 1k", () => {
+    const low = assessPositionRisk({ ...healthy, tvl: 9_000 });
+    const high = assessPositionRisk({ ...healthy, tvl: 500 });
+    expect(low.factors.find((f) => f.name === "Low TVL")?.severity).toBe("low");
+    expect(low.score).toBe(95);
+    expect(high.factors.find((f) => f.name === "Low TVL")?.severity).toBe("high");
+    expect(high.score).toBe(80);
+  });
+
+  it("hand-computed combination lands exactly on the medium boundary (score 55)", () => {
+    const r = assessPositionRisk({
+      priceDeviationBps: 600,
+      rangePct: 4,
+      tvl: 5_000,
+      volume24h: 1,
+      isInRange: true,
+      feeBps: 100,
+    });
+    // 100 - 25 (high deviation) - 15 (narrow) - 5 (low TVL) = 55 → medium
+    expect(r.score).toBe(55);
+    expect(r.level).toBe("medium");
+  });
+
+  it("aggregates multiple factors to critical and clamps at zero", () => {
+    const r = assessPositionRisk({
+      priceDeviationBps: 1000,
+      rangePct: 1,
+      tvl: 500,
+      volume24h: 0,
+      isInRange: false,
+      feeBps: 100,
+    });
+    // 100 - 40 - 25 - 15 - 20 = 0 → critical
+    expect(r.score).toBe(0);
+    expect(r.level).toBe("critical");
+    expect(r.factors.length).toBe(4);
+  });
+
+  it("does not overflow with very large numeric inputs", () => {
+    const r = assessPositionRisk({
+      ...healthy,
+      priceDeviationBps: Number.MAX_SAFE_INTEGER,
+      tvl: Number.MAX_SAFE_INTEGER,
+    });
+    expect(Number.isFinite(r.score)).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/ui-components/src/lib/riskAssessment.ts
+++ b/packages/ui-components/src/lib/riskAssessment.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure risk-assessment logic, extracted from RiskIndicator.tsx so that the
+ * financial math behind the UI can be unit-tested directly without a React
+ * render.
+ *
+ * `assessPositionRisk` derives a {@link RiskAssessment} (level, score and a
+ * list of contributing factors) from a set of common position/pool metrics.
+ * `riskLevelForScore` maps a (already-clamped) 0–100 score to a categorical
+ * level. Both are pure functions with no I/O.
+ */
+
+import type { RiskAssessment, RiskFactor, RiskLevel } from "../types.js";
+
+/** Score threshold below which a risk level drops down a category. */
+export const RISK_THRESHOLDS = {
+  low: 80,
+  medium: 55,
+  high: 30,
+} as const;
+
+/**
+ * Maps a clamped 0–100 risk score to a categorical level.
+ * Boundaries are inclusive on their lower edge:
+ *   score >= 80 → "low"
+ *   score >= 55 → "medium"
+ *   score >= 30 → "high"
+ *   otherwise     → "critical"
+ */
+export function riskLevelForScore(score: number): RiskLevel {
+  const clamped = Math.max(0, Math.min(100, score));
+  if (clamped >= RISK_THRESHOLDS.low) return "low";
+  if (clamped >= RISK_THRESHOLDS.medium) return "medium";
+  if (clamped >= RISK_THRESHOLDS.high) return "high";
+  return "critical";
+}
+
+export interface RiskParams {
+  priceDeviationBps: number;
+  rangePct: number;
+  tvl: number;
+  volume24h: number;
+  isInRange: boolean;
+  feeBps: number;
+}
+
+/** Derives a RiskAssessment from common position metrics. */
+export function assessPositionRisk(params: RiskParams): RiskAssessment {
+  const factors: RiskFactor[] = [];
+  let score = 100;
+
+  if (!params.isInRange) {
+    factors.push({
+      name: "Out of range",
+      description: "Current price is outside your selected range. The position is inactive and earning no fees.",
+      severity: "critical",
+    });
+    score -= 40;
+  }
+
+  if (params.priceDeviationBps > 200) {
+    const sev: RiskLevel = params.priceDeviationBps > 500 ? "high" : "medium";
+    factors.push({
+      name: "High price deviation",
+      description: `Price has deviated ${(params.priceDeviationBps / 100).toFixed(1)}% from TWAP, indicating unusual volatility.`,
+      severity: sev,
+      value: params.priceDeviationBps,
+      threshold: 500,
+    });
+    score -= params.priceDeviationBps > 500 ? 25 : 10;
+  }
+
+  if (params.rangePct < 5) {
+    factors.push({
+      name: "Very narrow range",
+      description: `Range spans only ${params.rangePct.toFixed(1)}% around current price. High efficiency but high rebalancing risk.`,
+      severity: "medium",
+      value: params.rangePct,
+      threshold: 5,
+    });
+    score -= 15;
+  }
+
+  if (params.tvl < 10_000) {
+    factors.push({
+      name: "Low TVL",
+      description: "Pool TVL below $10,000. Thin liquidity may cause higher slippage.",
+      severity: params.tvl < 1_000 ? "high" : "low",
+      value: params.tvl,
+      threshold: 10_000,
+    });
+    score -= params.tvl < 1_000 ? 20 : 5;
+  }
+
+  score = Math.max(0, Math.min(100, score));
+  const level = riskLevelForScore(score);
+
+  return { level, score, factors };
+}

--- a/packages/ui-components/src/test/setup.ts
+++ b/packages/ui-components/src/test/setup.ts
@@ -1,0 +1,24 @@
+import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement these APIs that the components rely on
+// (e.g. element.scrollIntoView, window.matchMedia). Provide lightweight
+// stubs so tests run deterministically in CI without a browser.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+if (typeof HTMLElement !== "undefined" && !HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}

--- a/packages/ui-components/vitest.config.ts
+++ b/packages/ui-components/vitest.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    // Ensure the suite and the package scripts never touch the network.
+    pool: "forks",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+      include: [
+        "src/lib/**/*.{ts,tsx}",
+        "src/RangeSelector.tsx",
+        "src/FeeTierComparison.tsx",
+        "src/CapitalEfficiencyCalc.tsx",
+        "src/RiskIndicator.tsx",
+        "src/PositionManager.tsx",
+        "src/GovernanceForum.tsx",
+      ],
+      exclude: ["src/test/**", "src/**/*.d.ts"],
+      thresholds: {
+        // Enforced rather than merely reported: a drop below these fails the
+        // `test:coverage` run.
+        lines: 70,
+        functions: 60,
+        statements: 70,
+        branches: 55,
+      },
+    },
+  },
+});


### PR DESCRIPTION
CLOSE #717 
## Summary of Changes

`packages/ui-components` shipped 3,860 lines of React across seven financial
components (`RangeSelector`, `FeeTierComparison`, `CapitalEfficiencyCalc`,
`RiskIndicator`, `PositionManager`, `GovernanceForum`) plus the `assessPositionRisk`
helper, with **zero test files**. CI ran `npm test -- --passWithNoTests`, so the
suite was green against nothing. The risk-assessment and capital-efficiency math —
values users make money decisions on — was completely unverified.

This PR adds a real Vitest + Testing Library test suite and extracts the pure
financial logic into testable modules:

1. **Extracted pure logic into `src/lib/`** so the math is unit-testable:
   - `lib/riskAssessment.ts` — `assessPositionRisk`, `riskLevelForScore`, `RISK_THRESHOLDS`
   - `lib/capitalEfficiency.ts` — `computeEfficiency`, `rangePct`, `isInRange`, `formatEfficiency`
   - `lib/positionValidation.ts` — `validatePosition` (new; rejects invalid input)
   The components now re-import from these modules, and the public API still exports
   the same `assessPositionRisk` symbol.

2. **Fixed a latent bug the tests exposed:** `computeEfficiency` returned `NaN` for
   `NaN` bounds; it now safely short-circuits degenerate/non-finite inputs to `1×`.

3. **Added position validation in `PositionManager`:** a negative amount, a zero
   amount, and a lower tick above the upper tick are now blocked and surfaced to the
   user via a `role="alert"` list; `onSubmit` is no longer called with invalid data.

4. **Tooling:** added `vitest.config.ts` (jsdom + enforced coverage thresholds),
   `test:coverage` script, and the `@testing-library/react`, `@testing-library/user-event`,
   `@testing-library/jest-dom`, `jsdom`, and `@vitest/coverage-v8` devDependencies.

5. **CI:** changed the `packages/ui-components` matrix entry from
   `npm test -- --passWithNoTests` to `npm test -- --coverage`, so the real suite
   runs and the ≥70% line-coverage threshold is enforced, not merely reported.

Tests use `@testing-library/user-event` (no direct state manipulation). No test
requires network access. `GovernanceForum` tests are written against the surviving
`.tsx` component, so this does not collide with the separate duplication PR.

## Related Issue(s)

- Closes #<issue-number>

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Tests only
- [ ] Documentation only
- [x] Chore (build, tooling, dependencies)

## Checklist

- [ ] `cargo fmt` has been run
- [ ] `make check` has been run (or the reason it could not be run is documented)
- [ ] `cargo clippy -- -D warnings` passes with no new warnings
- [ ] `cargo test` passes (build WASM first for factory tests: `cargo build --release --target wasm32-unknown-unknown`)
- [x] New behaviour is covered by tests
- [ ] WASM size has been checked for contract changes
- [x] For security-sensitive changes, correctness verification is described in the PR
- [ ] If I changed a hot-path contract (`amm`, `concentrated_liquidity`, `batch_auction`), I ran `cargo run -p benches -- --write-baseline` and committed the updated `benches/baseline.json`
- [ ] Public interface changes are reflected in the README
- [ ] CHANGELOG.md has been updated with any notable changes
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format