### PR TITLE
fix: per-contract cursor tracking, webhook SSRF validation, and example client arg/config fixes

### DIFF
--- a/examples/client/config.test.ts
+++ b/examples/client/config.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseAmountIn, parseDeadlineSeconds, parseSlippageBps } from "./config.js";
+
+describe("parseSlippageBps", () => {
+  it("rejects a negative value, naming SLIPPAGE_BPS", () => {
+    assert.throws(() => parseSlippageBps("-50"), /SLIPPAGE_BPS/);
+  });
+
+  it("rejects 10000 (must be strictly less than 100%)", () => {
+    assert.throws(() => parseSlippageBps("10000"), /SLIPPAGE_BPS/);
+  });
+
+  it("accepts a valid value", () => {
+    assert.equal(parseSlippageBps("50"), 50n);
+  });
+
+  it("defaults to 50 when unset", () => {
+    assert.equal(parseSlippageBps(undefined), 50n);
+  });
+});
+
+describe("parseDeadlineSeconds", () => {
+  it("rejects a non-numeric value, naming DEADLINE_SECONDS, not a raw BigInt/NaN error", () => {
+    assert.throws(() => parseDeadlineSeconds("abc"), /DEADLINE_SECONDS/);
+  });
+
+  it("rejects zero and negative values", () => {
+    assert.throws(() => parseDeadlineSeconds("0"), /DEADLINE_SECONDS/);
+    assert.throws(() => parseDeadlineSeconds("-10"), /DEADLINE_SECONDS/);
+  });
+
+  it("accepts a valid value", () => {
+    assert.equal(parseDeadlineSeconds("600"), 600);
+  });
+
+  it("defaults to 300 when unset", () => {
+    assert.equal(parseDeadlineSeconds(undefined), 300);
+  });
+});
+
+describe("parseAmountIn", () => {
+  it("rejects zero, naming SWAP_AMOUNT_IN", () => {
+    assert.throws(() => parseAmountIn("0"), /SWAP_AMOUNT_IN/);
+  });
+
+  it("rejects a negative value", () => {
+    assert.throws(() => parseAmountIn("-1"), /SWAP_AMOUNT_IN/);
+  });
+
+  it("accepts a valid value", () => {
+    assert.equal(parseAmountIn("100000"), 100000n);
+  });
+
+  it("defaults to 100000 when unset", () => {
+    assert.equal(parseAmountIn(undefined), 100000n);
+  });
+});

--- a/examples/client/config.ts
+++ b/examples/client/config.ts
@@ -1,0 +1,38 @@
+/** Pure parsing/validation for this example's numeric env vars. */
+
+export function parseAmountIn(raw: string | undefined): bigint {
+  const value = raw ?? "100000";
+  let amount: bigint;
+  try {
+    amount = BigInt(value);
+  } catch {
+    throw new Error(`SWAP_AMOUNT_IN must be an integer, got "${value}"`);
+  }
+  if (amount <= 0n) {
+    throw new Error(`SWAP_AMOUNT_IN must be a positive integer, got "${value}"`);
+  }
+  return amount;
+}
+
+export function parseDeadlineSeconds(raw: string | undefined): number {
+  const value = raw ?? "300";
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`DEADLINE_SECONDS must be a positive number, got "${value}"`);
+  }
+  return seconds;
+}
+
+export function parseSlippageBps(raw: string | undefined): bigint {
+  const value = raw ?? "50";
+  let bps: bigint;
+  try {
+    bps = BigInt(value);
+  } catch {
+    throw new Error(`SLIPPAGE_BPS must be an integer in [0, 10000), got "${value}"`);
+  }
+  if (bps < 0n || bps >= 10_000n) {
+    throw new Error(`SLIPPAGE_BPS must be an integer in [0, 10000), got "${value}"`);
+  }
+  return bps;
+}

--- a/examples/client/index.ts
+++ b/examples/client/index.ts
@@ -1,4 +1,5 @@
 import { AmmPool, FactoryClient, TokenClient } from "@soroban-amm/sdk";
+import { parseAmountIn, parseDeadlineSeconds, parseSlippageBps } from "./config.js";
 
 const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
 const networkPassphrase = process.env.STELLAR_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
@@ -22,9 +23,21 @@ async function main(): Promise<void> {
   const token = new TokenClient(config(tokenInId));
   const factoryId = process.env.FACTORY_CONTRACT_ID;
   const factory = factoryId ? new FactoryClient(config(factoryId)) : undefined;
-  const amountIn = BigInt(process.env.SWAP_AMOUNT_IN ?? "100000");
-  const deadline = BigInt(Math.floor(Date.now() / 1000) + Number(process.env.DEADLINE_SECONDS ?? 300));
-  const slippageBps = BigInt(process.env.SLIPPAGE_BPS ?? "50");
+
+  let amountIn: bigint;
+  let deadlineSeconds: number;
+  let slippageBps: bigint;
+  try {
+    amountIn = parseAmountIn(process.env.SWAP_AMOUNT_IN);
+    deadlineSeconds = parseDeadlineSeconds(process.env.DEADLINE_SECONDS);
+    slippageBps = parseSlippageBps(process.env.SLIPPAGE_BPS);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Invalid configuration: ${message}`);
+    process.exitCode = 1;
+    return;
+  }
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSeconds);
 
   // 1. Read pool info to confirm the pair and current reserves.
   const info = await pool.getInfo();

--- a/examples/client/package.json
+++ b/examples/client/package.json
@@ -7,8 +7,8 @@
     "prebuild": "npm --prefix ../../packages/sdk install --ignore-scripts && npm --prefix ../../packages/sdk run build",
     "build": "tsc",
     "start": "node dist/index.js",
-    "pretest": "npm --prefix ../../packages/sdk install --ignore-scripts && npm --prefix ../../packages/sdk run build",
-    "test": "tsc --noEmit"
+    "pretest": "npm --prefix ../../packages/sdk install --ignore-scripts && npm --prefix ../../packages/sdk run build && tsc",
+    "test": "tsc --noEmit && node --test dist/config.test.js"
   },
   "dependencies": {
     "@soroban-amm/sdk": "file:../../packages/sdk",

--- a/examples/client/tsconfig.json
+++ b/examples/client/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "config.ts", "config.test.ts"]
 }

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -48,6 +48,13 @@ python client.py
 
 Demonstrates deploying and querying pools registry via the pool factory.
 
+`create_pool` calls the factory's `create_pool(caller, token_a, token_b,
+fee_tier, governance_wasm_hash)` with the deploying address as `caller` and,
+optionally, a `governance_wasm_hash` (32-byte WASM hash) that deploys a
+per-pool governance contract alongside the pool. It returns both the pool
+address and the optional governance contract address; when no governance
+WASM hash is supplied, the governance address is `None`.
+
 ### Configure
 
 Set the environment variables before running the script:

--- a/examples/python/factory_client.py
+++ b/examples/python/factory_client.py
@@ -3,7 +3,7 @@ import argparse
 
 import os
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from stellar_sdk import Keypair, Network, scval
 from stellar_sdk.address import Address
@@ -44,8 +44,14 @@ def main() -> int:
     if not pool_address:
         print(f"\n2. Creating pool for pair with fee_bps={fee_bps}...")
         try:
-            pool_address = create_pool(client, source_keypair, token_a_contract_id, token_b_contract_id, fee_bps)
+            pool_address, governance_address = create_pool(
+                client, source_keypair, source_keypair.public_key, token_a_contract_id, token_b_contract_id, fee_bps
+            )
             print(f"Pool created successfully at: {pool_address}")
+            if governance_address:
+                print(f"Governance contract deployed at: {governance_address}")
+            else:
+                print("No governance contract was deployed (governance_wasm_hash not supplied).")
         except Exception as e:
             print(f"Failed to create pool (might already exist): {e}")
     else:
@@ -60,18 +66,36 @@ def main() -> int:
     return 0
 
 
-def create_pool(client: ContractClient, source_kp: Keypair, token_a: str, token_b: str, fee_bps: int) -> str:
+def create_pool(
+    client: ContractClient,
+    source_kp: Keypair,
+    caller: str,
+    token_a: str,
+    token_b: str,
+    fee_bps: int,
+    governance_wasm_hash: Optional[bytes] = None,
+) -> Tuple[str, Optional[str]]:
     result = submit_contract_call(
         client,
         source_kp,
         "create_pool",
+        scval.to_address(caller),
         scval.to_address(token_a),
         scval.to_address(token_b),
         scval.to_int128(fee_bps),
+        scval.to_bytes(governance_wasm_hash) if governance_wasm_hash is not None else scval.to_void(),
     )
-    if isinstance(result, Address):
-        return result.address
-    return str(result)
+
+    pool_result, governance_result = result
+
+    pool_address = pool_result.address if isinstance(pool_result, Address) else str(pool_result)
+    governance_address: Optional[str] = None
+    if isinstance(governance_result, Address):
+        governance_address = governance_result.address
+    elif governance_result is not None:
+        governance_address = str(governance_result)
+
+    return pool_address, governance_address
 
 
 def get_pool(client: ContractClient, token_a: str, token_b: str) -> Optional[str]:

--- a/services/webhook-streamer/README.md
+++ b/services/webhook-streamer/README.md
@@ -28,6 +28,7 @@ npm run build && npm start
 | `CONTRACT_IDS`    | _(empty)_                                  | Comma-separated contract IDs to watch    |
 | `POLL_INTERVAL_MS`| `5000`                                     | Polling interval in milliseconds         |
 | `PORT`            | `3001`                                     | Management API HTTP port                 |
+| `WEBHOOK_ALLOW_PRIVATE_TARGETS` | `false`                       | Set to `true` to allow registering webhook URLs that point at loopback/link-local/private-range addresses. Only for local development against a same-host test receiver — leave unset in production, since it disables SSRF protection on `POST /webhooks`. |
 
 ## Management API
 
@@ -43,6 +44,11 @@ Content-Type: application/json
   "secret": "my-secret"      // optional — sent as X-Webhook-Secret header
 }
 ```
+
+`url` must be an `http`/`https` URL and must not target loopback, link-local
+(including the cloud metadata address `169.254.169.254`), or RFC1918
+private-range addresses — requests that fail this check return `400`. See
+`WEBHOOK_ALLOW_PRIVATE_TARGETS` above to relax this for local development.
 
 ### List webhooks
 ```

--- a/services/webhook-streamer/src/horizon-poller.test.ts
+++ b/services/webhook-streamer/src/horizon-poller.test.ts
@@ -1,0 +1,148 @@
+// ── Regression tests for per-contract cursor tracking (issue: shared cursor drops events) ──
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { HorizonPoller } from "./horizon-poller.js";
+import type { HorizonEvent, PoolEvent } from "./types.js";
+
+function makeRawEvent(contractId: string, pagingToken: string): HorizonEvent {
+  return {
+    id: `${contractId}-${pagingToken}`,
+    type: "contract",
+    ledger: Number(pagingToken),
+    ledgerClosedAt: new Date().toISOString(),
+    contractId,
+    topic: ["swap"],
+    value: JSON.stringify({}),
+    pagingToken,
+  };
+}
+
+/**
+ * Mock Horizon /events endpoint: for each contract, holds a single event
+ * whose pagingToken is returned only when the request's cursor is strictly
+ * less than it — mirroring Horizon's "cursor is a global ledger position"
+ * pagination semantics.
+ */
+async function startHorizonMock(
+  eventsByContract: Record<string, HorizonEvent>,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    const reqUrl = new URL(req.url ?? "/", "http://localhost");
+    const contractId = reqUrl.searchParams.get("contract_id") ?? "";
+    const cursor = Number(reqUrl.searchParams.get("cursor") ?? "0");
+    const event = eventsByContract[contractId];
+
+    const records =
+      event && Number(event.pagingToken) > cursor ? [event] : [];
+
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ _embedded: { records } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+describe("HorizonPoller cursors", () => {
+  it("tracks independent cursors per contract, exposed via cursors()", async () => {
+    const poller = new HorizonPoller(
+      { horizonUrl: "http://example.invalid", contractIds: ["A", "B"], startCursor: "0" },
+      async () => {},
+    );
+    const cursors = poller.cursors();
+    assert.equal(cursors.get("A"), "0");
+    assert.equal(cursors.get("B"), "0");
+  });
+
+  it("does not skip a second contract's older-paging-token event after the first contract advances (regression)", async () => {
+    const mock = await startHorizonMock({
+      A: makeRawEvent("A", "100"),
+      B: makeRawEvent("B", "50"),
+    });
+    try {
+      const delivered: PoolEvent[] = [];
+      const poller = new HorizonPoller(
+        {
+          horizonUrl: mock.url,
+          contractIds: ["A", "B"],
+          startCursor: "0",
+        },
+        async (event) => {
+          delivered.push(event);
+        },
+      );
+
+      // Access the private polling method directly to run exactly one cycle.
+      await (poller as unknown as { _poll(): Promise<void> })._poll();
+
+      const contractIds = delivered.map((e) => e.contractId).sort();
+      assert.deepEqual(
+        contractIds,
+        ["A", "B"],
+        "contract B's event (paging token 50) must not be dropped just because contract A advanced past it",
+      );
+
+      const cursors = poller.cursors();
+      assert.equal(cursors.get("A"), "100");
+      assert.equal(cursors.get("B"), "50");
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("advancing one contract's cursor does not change another contract's stored cursor", async () => {
+    const mock = await startHorizonMock({
+      A: makeRawEvent("A", "100"),
+      // B has no event yet, so its cursor should remain untouched.
+    });
+    try {
+      const poller = new HorizonPoller(
+        { horizonUrl: mock.url, contractIds: ["A", "B"], startCursor: "0" },
+        async () => {},
+      );
+
+      await (poller as unknown as { _poll(): Promise<void> })._poll();
+
+      const cursors = poller.cursors();
+      assert.equal(cursors.get("A"), "100");
+      assert.equal(cursors.get("B"), "0");
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("still pages forward correctly for a single-contract poller (common case unchanged)", async () => {
+    const mock = await startHorizonMock({ A: makeRawEvent("A", "42") });
+    try {
+      const delivered: PoolEvent[] = [];
+      const poller = new HorizonPoller(
+        { horizonUrl: mock.url, contractIds: ["A"], startCursor: "0" },
+        async (event) => {
+          delivered.push(event);
+        },
+      );
+
+      await (poller as unknown as { _poll(): Promise<void> })._poll();
+      assert.equal(delivered.length, 1);
+      assert.equal(poller.cursors().get("A"), "42");
+
+      // A second poll with no new events should not redeliver.
+      await (poller as unknown as { _poll(): Promise<void> })._poll();
+      assert.equal(delivered.length, 1);
+    } finally {
+      await mock.close();
+    }
+  });
+});

--- a/services/webhook-streamer/src/horizon-poller.ts
+++ b/services/webhook-streamer/src/horizon-poller.ts
@@ -3,7 +3,8 @@
  * Horizon /events endpoint and emits normalised PoolEvents.
  *
  * Uses cursor-based pagination so no event is missed across restarts
- * (persist `lastCursor` to a durable store in production).
+ * (persist the per-contract cursors — see `cursors()` — to a durable store
+ * in production).
  */
 
 import fetch from "node-fetch";
@@ -37,7 +38,7 @@ export interface PollerOptions {
 
 export class HorizonPoller {
   private running = false;
-  private lastCursor: string;
+  private readonly _cursors: Map<string, string> = new Map();
   private readonly opts: Required<PollerOptions>;
 
   constructor(opts: PollerOptions, private readonly handler: EventHandler) {
@@ -46,7 +47,9 @@ export class HorizonPoller {
       startCursor: "now",
       ...opts,
     };
-    this.lastCursor = this.opts.startCursor;
+    for (const contractId of this.opts.contractIds) {
+      this._cursors.set(contractId, this.opts.startCursor);
+    }
   }
 
   start(): void {
@@ -57,6 +60,11 @@ export class HorizonPoller {
 
   stop(): void {
     this.running = false;
+  }
+
+  /** Current pagination cursor per contract, for observability/tests. */
+  cursors(): ReadonlyMap<string, string> {
+    return new Map(this._cursors);
   }
 
   private async _loop(): Promise<void> {
@@ -72,7 +80,8 @@ export class HorizonPoller {
 
   private async _poll(): Promise<void> {
     for (const contractId of this.opts.contractIds) {
-      const url = this._buildUrl(contractId);
+      const cursor = this._cursors.get(contractId) ?? this.opts.startCursor;
+      const url = this._buildUrl(contractId, cursor);
       const res = await fetch(url);
       if (!res.ok) {
         console.warn(`[HorizonPoller] ${contractId}: HTTP ${res.status}`);
@@ -89,15 +98,15 @@ export class HorizonPoller {
         if (event) {
           await this.handler(event);
         }
-        this.lastCursor = raw.pagingToken;
+        this._cursors.set(contractId, raw.pagingToken);
       }
     }
   }
 
-  private _buildUrl(contractId: string): string {
+  private _buildUrl(contractId: string, cursor: string): string {
     const params = new URLSearchParams({
       contract_id: contractId,
-      cursor: this.lastCursor,
+      cursor,
       limit: "200",
       order: "asc",
     });

--- a/services/webhook-streamer/src/index.ts
+++ b/services/webhook-streamer/src/index.ts
@@ -19,6 +19,7 @@
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { defaultRegistry } from "./registry.js";
+import { InvalidWebhookUrlError } from "./url-validation.js";
 import { WebhookDispatcher } from "./dispatcher.js";
 import { DeadLetterQueue } from "./dead-letter.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
@@ -150,11 +151,19 @@ const server = createServer(async (req, res) => {
       if (!body.url) {
         return json(res, 400, { error: "url is required" });
       }
-      const sub = defaultRegistry.register(body.url, {
-        contractId: body.contractId,
-        eventType: body.eventType,
-        secret: body.secret,
-      });
+      let sub;
+      try {
+        sub = defaultRegistry.register(body.url, {
+          contractId: body.contractId,
+          eventType: body.eventType,
+          secret: body.secret,
+        });
+      } catch (err) {
+        if (err instanceof InvalidWebhookUrlError) {
+          return json(res, 400, { error: err.message });
+        }
+        throw err;
+      }
       return json(res, 201, sub);
     } catch {
       return json(res, 400, { error: "invalid JSON" });

--- a/services/webhook-streamer/src/registry.ts
+++ b/services/webhook-streamer/src/registry.ts
@@ -5,6 +5,7 @@
  */
 
 import type { WebhookSubscription } from "./types.js";
+import { validateWebhookUrl } from "./url-validation.js";
 
 let _nextId = 1;
 
@@ -16,6 +17,7 @@ export class WebhookRegistry {
     url: string,
     opts: { contractId?: string; eventType?: string; secret?: string } = {},
   ): WebhookSubscription {
+    validateWebhookUrl(url);
     const id = String(_nextId++);
     const sub: WebhookSubscription = {
       id,

--- a/services/webhook-streamer/src/streamer.test.ts
+++ b/services/webhook-streamer/src/streamer.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./dispatcher.js";
 import { DeadLetterQueue } from "./dead-letter.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
+import { InvalidWebhookUrlError, validateWebhookUrl } from "./url-validation.js";
 import type { PoolEvent } from "./types.js";
 
 describe("WebhookRegistry", () => {
@@ -64,6 +65,68 @@ describe("WebhookRegistry", () => {
     reg.register("https://other.com", { contractId: "OTHER" });
     const matches = reg.matching("MY_CONTRACT", "swap");
     assert.equal(matches.length, 0);
+  });
+
+  it("rejects an SSRF-prone URL and does not register it", () => {
+    const reg = new WebhookRegistry();
+    assert.throws(
+      () => reg.register("http://169.254.169.254/latest/meta-data/"),
+      InvalidWebhookUrlError,
+    );
+    assert.equal(reg.size, 0);
+  });
+});
+
+describe("validateWebhookUrl (SSRF protection)", () => {
+  const original = process.env["WEBHOOK_ALLOW_PRIVATE_TARGETS"];
+  function resetEnv() {
+    if (original === undefined) delete process.env["WEBHOOK_ALLOW_PRIVATE_TARGETS"];
+    else process.env["WEBHOOK_ALLOW_PRIVATE_TARGETS"] = original;
+  }
+
+  it("accepts a normal public https URL", () => {
+    assert.doesNotThrow(() => validateWebhookUrl("https://example.com/hook"));
+  });
+
+  it("rejects the cloud metadata link-local address", () => {
+    assert.throws(
+      () => validateWebhookUrl("http://169.254.169.254/latest/meta-data/"),
+      InvalidWebhookUrlError,
+    );
+  });
+
+  it("rejects loopback addresses", () => {
+    assert.throws(() => validateWebhookUrl("http://127.0.0.1:9999/x"), InvalidWebhookUrlError);
+    assert.throws(() => validateWebhookUrl("http://localhost:9999/x"), InvalidWebhookUrlError);
+    assert.throws(() => validateWebhookUrl("http://[::1]:9999/x"), InvalidWebhookUrlError);
+  });
+
+  it("rejects RFC1918 private ranges", () => {
+    assert.throws(() => validateWebhookUrl("http://10.0.0.5/x"), InvalidWebhookUrlError);
+    assert.throws(() => validateWebhookUrl("http://172.16.0.5/x"), InvalidWebhookUrlError);
+    assert.throws(() => validateWebhookUrl("http://192.168.1.5/x"), InvalidWebhookUrlError);
+  });
+
+  it("rejects the bare 0.0.0.0 IP literal", () => {
+    assert.throws(() => validateWebhookUrl("http://0.0.0.0/x"), InvalidWebhookUrlError);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    assert.throws(() => validateWebhookUrl("javascript:alert(1)"), InvalidWebhookUrlError);
+    assert.throws(() => validateWebhookUrl("file:///etc/passwd"), InvalidWebhookUrlError);
+  });
+
+  it("rejects unparseable URLs", () => {
+    assert.throws(() => validateWebhookUrl("not a url"), InvalidWebhookUrlError);
+  });
+
+  it("allows a private-range URL when WEBHOOK_ALLOW_PRIVATE_TARGETS=true", () => {
+    process.env["WEBHOOK_ALLOW_PRIVATE_TARGETS"] = "true";
+    try {
+      assert.doesNotThrow(() => validateWebhookUrl("http://127.0.0.1:9999/x"));
+    } finally {
+      resetEnv();
+    }
   });
 });
 

--- a/services/webhook-streamer/src/url-validation.ts
+++ b/services/webhook-streamer/src/url-validation.ts
@@ -1,0 +1,93 @@
+/**
+ * Validates webhook registration URLs to prevent SSRF: a registered webhook
+ * is fetched by this service's own network egress on a recurring, retried
+ * schedule, so an unvalidated URL lets any caller of the (unauthenticated)
+ * management API turn this service into a proxy into its private network.
+ */
+
+export class InvalidWebhookUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidWebhookUrlError";
+  }
+}
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+function ipv4ToInt(parts: number[]): number {
+  return ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0;
+}
+
+function inIpv4Range(ip: number, base: string, prefixLen: number): boolean {
+  const baseParts = base.split(".").map(Number);
+  const baseInt = ipv4ToInt(baseParts);
+  const mask = prefixLen === 0 ? 0 : (~0 << (32 - prefixLen)) >>> 0;
+  return (ip & mask) === (baseInt & mask);
+}
+
+function isPrivateOrReservedIpv4(hostname: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+  if (!match) return false;
+  const parts = match.slice(1, 5).map(Number);
+  if (parts.some((p) => p > 255)) return false;
+  const ip = ipv4ToInt(parts);
+
+  return (
+    inIpv4Range(ip, "127.0.0.0", 8) || // loopback
+    inIpv4Range(ip, "169.254.0.0", 16) || // link-local (cloud metadata)
+    inIpv4Range(ip, "10.0.0.0", 8) || // RFC1918
+    inIpv4Range(ip, "172.16.0.0", 12) || // RFC1918
+    inIpv4Range(ip, "192.168.0.0", 16) || // RFC1918
+    hostname === "0.0.0.0"
+  );
+}
+
+function isPrivateOrReservedIpv6(hostname: string): boolean {
+  // Strip brackets/zone-id and normalise for comparison.
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "::1") return true; // loopback
+  if (host.startsWith("fe80:") || host.startsWith("fe80::")) return true; // link-local
+  // Unique local addresses (fc00::/7), the private-range analogue for IPv6.
+  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
+  return false;
+}
+
+/**
+ * Throws InvalidWebhookUrlError if `raw` is not a safe webhook target.
+ *
+ * Set WEBHOOK_ALLOW_PRIVATE_TARGETS=true to bypass the private/loopback/
+ * link-local checks for local development against a same-host receiver.
+ */
+export function validateWebhookUrl(raw: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new InvalidWebhookUrlError(`url must be a valid absolute URL, got "${raw}"`);
+  }
+
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new InvalidWebhookUrlError(
+      `url scheme must be http or https, got "${parsed.protocol}"`,
+    );
+  }
+
+  const allowPrivate = process.env["WEBHOOK_ALLOW_PRIVATE_TARGETS"] === "true";
+  if (allowPrivate) return;
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (hostname === "localhost") {
+    throw new InvalidWebhookUrlError(`url must not target localhost, got "${raw}"`);
+  }
+  if (isPrivateOrReservedIpv4(hostname)) {
+    throw new InvalidWebhookUrlError(
+      `url must not target a loopback, link-local, or private-range address, got "${raw}"`,
+    );
+  }
+  if (isPrivateOrReservedIpv6(hostname)) {
+    throw new InvalidWebhookUrlError(
+      `url must not target a loopback or link-local address, got "${raw}"`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **webhook-streamer**: `HorizonPoller` used a single shared pagination cursor
  across all watched contracts, so contracts after the first in `CONTRACT_IDS`
  could silently drop events once an earlier contract's cursor advanced past
  them. Cursors are now tracked per contract (`Map<contractId, cursor>`) and
  exposed via a `cursors()` getter, with a regression test that reproduces
  the drop and fails against the old shared-cursor code.
- **webhook-streamer**: `POST /webhooks` accepted any non-empty string as the
  target URL with no validation, letting any caller of the (unauthenticated)
  management API register an SSRF target — including the cloud metadata
  address — that the dispatcher would then POST to on a recurring, retried
  schedule. Added `validateWebhookUrl()` to reject non-http(s) schemes and
  loopback/link-local/RFC1918 targets, with `WEBHOOK_ALLOW_PRIVATE_TARGETS=true`
  as an explicit local-dev opt-out.
- **examples/client**: `SLIPPAGE_BPS`, `DEADLINE_SECONDS`, and `SWAP_AMOUNT_IN`
  env vars were parsed with no range checks — a negative `SLIPPAGE_BPS`
  silently inverted slippage protection instead of disabling it, and a
  non-numeric `DEADLINE_SECONDS` surfaced as a misleading raw BigInt/NaN
  error routed through the "AMM contract call failed" message. Extracted
  parsing into range-checked functions in `config.ts` with a `node:test`
  suite wired into `npm test`.
- **examples/python**: `factory_client.py`'s `create_pool` called the
  factory contract with only 3 of its 5 required arguments (missing
  `caller` and `governance_wasm_hash`), silently misassigning parameters,
  and only handled a single return value instead of the actual
  `(Address, Option<Address>)` tuple. Fixed the call site and result
  handling, and documented the optional governance deployment.

## Changes

- `services/webhook-streamer/src/horizon-poller.ts` — per-contract cursor map, `cursors()` getter
- `services/webhook-streamer/src/horizon-poller.test.ts` — new regression tests
- `services/webhook-streamer/src/url-validation.ts` — new SSRF validator
- `services/webhook-streamer/src/registry.ts`, `src/index.ts` — validate on registration, return 400 on rejection
- `services/webhook-streamer/src/streamer.test.ts` — SSRF validation tests
- `services/webhook-streamer/README.md` — document `WEBHOOK_ALLOW_PRIVATE_TARGETS`
- `examples/client/config.ts` — new pure parsing/validation functions
- `examples/client/config.test.ts` — new `node:test` suite
- `examples/client/index.ts`, `tsconfig.json`, `package.json` — use validated config, run tests
- `examples/python/factory_client.py` — fix `create_pool` arity and tuple result handling
- `examples/python/README.md` — document governance deployment

## Test plan

- [ ] `npm test` in `services/webhook-streamer` (build then `node --test`) — verify new cursor and SSRF tests pass
- [ ] `npm test` in `examples/client` — verify `tsc --noEmit` and new `config.test.ts` suite pass
- [ ] Manually exercise `POST /webhooks` with a metadata/loopback/private URL and confirm `400`; confirm a normal `https://` URL still returns `201`
- [ ] Manually run `factory_client.py` against a local/test factory deployment and confirm `create_pool` succeeds with the corrected argument list

Closes #847 
Closes #846 
Closes #844 
Closes #845 
