### PR TITLE
fix(graphql-api, health-dashboard): implement TWAL, fix alert config validation, and dashboard rendering bugs

### DIFF
--- a/services/graphql-api/README.md
+++ b/services/graphql-api/README.md
@@ -55,6 +55,18 @@ query PriceHistory {
 }
 ```
 
+### Time-weighted average liquidity (TWAL)
+
+```graphql
+query PoolTwal {
+  twal(poolId: "pool-demo", windowSeconds: 3600)
+}
+```
+
+Returns a time-weighted average price over the trailing `windowSeconds`, or
+`null` if no price points were recorded for the pool in that window. Throws
+a GraphQL error if `windowSeconds` is not greater than zero.
+
 ### Complex nested query
 
 ```graphql

--- a/services/graphql-api/src/index.ts
+++ b/services/graphql-api/src/index.ts
@@ -3,7 +3,13 @@ import { GraphQLError } from "graphql";
 import { startStandaloneServer } from "@apollo/server/standalone";
 import { PubSub } from "graphql-subscriptions";
 import { typeDefs } from "./schema.js";
-import { defaultIndexer, type AlertConfig } from "./indexer.js";
+import {
+  defaultIndexer,
+  InvalidMetricError,
+  InvalidThresholdError,
+  type AlertConfig,
+  type AlertMetric,
+} from "./indexer.js";
 
 const pubsub = new PubSub();
 
@@ -44,9 +50,30 @@ const resolvers = {
         poolId,
         metric,
         thresholdBps,
-      }: { poolId: string; metric: string; thresholdBps: number },
-    ): AlertConfig =>
-      defaultIndexer.setAlertConfig({ poolId, metric, thresholdBps }),
+        thresholdValue,
+      }: {
+        poolId: string;
+        metric: string;
+        thresholdBps?: number;
+        thresholdValue?: number;
+      },
+    ): AlertConfig => {
+      try {
+        return defaultIndexer.setAlertConfig({
+          poolId,
+          metric: metric as AlertMetric,
+          thresholdBps,
+          thresholdValue,
+        });
+      } catch (error) {
+        if (error instanceof InvalidMetricError || error instanceof InvalidThresholdError) {
+          throw new GraphQLError(error.message, {
+            extensions: { code: "BAD_USER_INPUT" },
+          });
+        }
+        throw error;
+      }
+    },
     removeAlertConfig: (
       _: unknown,
       { poolId, metric }: { poolId: string; metric: string },

--- a/services/graphql-api/src/index.ts
+++ b/services/graphql-api/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloServer } from "@apollo/server";
+import { GraphQLError } from "graphql";
 import { startStandaloneServer } from "@apollo/server/standalone";
 import { PubSub } from "graphql-subscriptions";
 import { typeDefs } from "./schema.js";
@@ -20,7 +21,17 @@ const resolvers = {
       _: unknown,
       { poolId, from, to }: { poolId: string; from?: number; to?: number },
     ) => defaultIndexer.getPriceHistory(poolId, from, to),
-    twal: () => null,
+    twal: (
+      _: unknown,
+      { poolId, windowSeconds }: { poolId: string; windowSeconds: number },
+    ) => {
+      if (windowSeconds <= 0) {
+        throw new GraphQLError("windowSeconds must be greater than 0", {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      return defaultIndexer.getTwal(poolId, windowSeconds);
+    },
     poolHealth: (_: unknown, { poolId }: { poolId: string }) =>
       defaultIndexer.getPoolHealth(poolId),
     alertConfigs: (_: unknown, { poolId }: { poolId?: string }) =>

--- a/services/graphql-api/src/indexer.test.ts
+++ b/services/graphql-api/src/indexer.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PoolIndexer } from "./indexer.js";
+
+function makeIndexer() {
+  return new PoolIndexer();
+}
+
+test("getTwal returns null when there is no price history in the window", () => {
+  const indexer = makeIndexer();
+  assert.equal(indexer.getTwal("pool-x", 3600), null);
+});
+
+test("getTwal returns a time-weighted value that differs from the naive mean for unevenly spaced points", () => {
+  const indexer = makeIndexer();
+  const now = Date.now();
+  // Price held at 1.0 for a long stretch, then briefly spikes to 2.0 just before "now".
+  indexer.recordPrice({ poolId: "pool-x", timestamp: now - 3000, price: 1.0, feeBps: 30 });
+  indexer.recordPrice({ poolId: "pool-x", timestamp: now - 100, price: 2.0, feeBps: 30 });
+
+  const twal = indexer.getTwal("pool-x", 3600);
+  const naiveMean = (1.0 + 2.0) / 2;
+
+  assert.notEqual(twal, null);
+  assert.notEqual(twal, naiveMean);
+  // The 1.0 price dominates the window (2900ms vs 100ms), so twal should be close to 1.0.
+  assert.ok(twal! < naiveMean);
+});
+
+test("getTwal ignores price points outside the requested window", () => {
+  const indexer = makeIndexer();
+  const now = Date.now();
+  indexer.recordPrice({ poolId: "pool-x", timestamp: now - 7200 * 1000, price: 5.0, feeBps: 30 });
+  indexer.recordPrice({ poolId: "pool-x", timestamp: now - 10, price: 1.0, feeBps: 30 });
+
+  const twal = indexer.getTwal("pool-x", 60);
+  assert.equal(twal, 1.0);
+});
+
+test("getTwal is scoped to the given poolId", () => {
+  const indexer = makeIndexer();
+  const now = Date.now();
+  indexer.recordPrice({ poolId: "pool-a", timestamp: now - 10, price: 1.0, feeBps: 30 });
+  assert.equal(indexer.getTwal("pool-b", 3600), null);
+});

--- a/services/graphql-api/src/indexer.test.ts
+++ b/services/graphql-api/src/indexer.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { PoolIndexer } from "./indexer.js";
+import { InvalidMetricError, InvalidThresholdError, PoolIndexer } from "./indexer.js";
 
 function makeIndexer() {
   return new PoolIndexer();
@@ -42,4 +42,47 @@ test("getTwal is scoped to the given poolId", () => {
   const now = Date.now();
   indexer.recordPrice({ poolId: "pool-a", timestamp: now - 10, price: 1.0, feeBps: 30 });
   assert.equal(indexer.getTwal("pool-b", 3600), null);
+});
+
+test("setAlertConfig rejects an unrecognized metric and does not store it", () => {
+  const indexer = makeIndexer();
+  assert.throws(
+    () => indexer.setAlertConfig({ poolId: "pool-a", metric: "not_a_real_metric" as never, thresholdValue: 10 }),
+    InvalidMetricError,
+  );
+  assert.deepEqual(indexer.getAlertConfigs("pool-a"), []);
+});
+
+test("setAlertConfig rejects a negative threshold", () => {
+  const indexer = makeIndexer();
+  assert.throws(
+    () => indexer.setAlertConfig({ poolId: "pool-a", metric: "tvl", thresholdValue: -5 }),
+    InvalidThresholdError,
+  );
+  assert.deepEqual(indexer.getAlertConfigs("pool-a"), []);
+});
+
+test("setAlertConfig accepts each valid metric and getAlertConfigs returns it", () => {
+  const indexer = makeIndexer();
+  indexer.setAlertConfig({ poolId: "pool-a", metric: "price_deviation", thresholdBps: 100 });
+  indexer.setAlertConfig({ poolId: "pool-a", metric: "tvl", thresholdValue: 500 });
+  indexer.setAlertConfig({ poolId: "pool-a", metric: "volume24h", thresholdValue: 1000 });
+
+  const configs = indexer.getAlertConfigs("pool-a");
+  assert.equal(configs.length, 3);
+  assert.ok(configs.some((c) => c.metric === "price_deviation" && c.thresholdBps === 100));
+  assert.ok(configs.some((c) => c.metric === "tvl" && c.thresholdValue === 500));
+  assert.ok(configs.some((c) => c.metric === "volume24h" && c.thresholdValue === 1000));
+});
+
+test("setAlertConfig requires the correct threshold field for the given metric", () => {
+  const indexer = makeIndexer();
+  assert.throws(
+    () => indexer.setAlertConfig({ poolId: "pool-a", metric: "price_deviation" }),
+    InvalidThresholdError,
+  );
+  assert.throws(
+    () => indexer.setAlertConfig({ poolId: "pool-a", metric: "tvl" }),
+    InvalidThresholdError,
+  );
 });

--- a/services/graphql-api/src/indexer.ts
+++ b/services/graphql-api/src/indexer.ts
@@ -69,10 +69,34 @@ export interface PoolHealth {
   alertsFired: HealthAlert[];
 }
 
+export const VALID_ALERT_METRICS = ["price_deviation", "tvl", "volume24h"] as const;
+export type AlertMetric = (typeof VALID_ALERT_METRICS)[number];
+
+export class InvalidMetricError extends Error {
+  constructor(metric: string) {
+    super(`Invalid alert metric "${metric}". Must be one of: ${VALID_ALERT_METRICS.join(", ")}`);
+    this.name = "InvalidMetricError";
+  }
+}
+
+export class InvalidThresholdError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidThresholdError";
+  }
+}
+
+function isValidMetric(metric: string): metric is AlertMetric {
+  return (VALID_ALERT_METRICS as readonly string[]).includes(metric);
+}
+
 export interface AlertConfig {
   poolId: string;
-  metric: string;
-  thresholdBps: number;
+  metric: AlertMetric;
+  /** Basis-points threshold. Required (and only meaningful) for "price_deviation". */
+  thresholdBps?: number;
+  /** Raw-value threshold in the metric's native units. Required for "tvl" and "volume24h". */
+  thresholdValue?: number;
 }
 
 export class PoolIndexer {
@@ -235,6 +259,21 @@ export class PoolIndexer {
   // ── Alert configuration ─────────────────────────────────────────────────────
 
   setAlertConfig(config: AlertConfig): AlertConfig {
+    if (!isValidMetric(config.metric)) {
+      throw new InvalidMetricError(config.metric);
+    }
+    const threshold = config.metric === "price_deviation" ? config.thresholdBps : config.thresholdValue;
+    if (threshold === undefined || !Number.isFinite(threshold)) {
+      throw new InvalidThresholdError(
+        config.metric === "price_deviation"
+          ? "thresholdBps is required for metric \"price_deviation\""
+          : `thresholdValue is required for metric "${config.metric}"`,
+      );
+    }
+    if (threshold < 0) {
+      throw new InvalidThresholdError("Threshold must be >= 0");
+    }
+
     const key = `${config.poolId}:${config.metric}`;
     this.alertConfigs.set(key, config);
     return config;
@@ -264,20 +303,26 @@ export class PoolIndexer {
   private checkAlerts(poolId: string, stats: PoolStats): void {
     const configs = this.getAlertConfigs(poolId);
     for (const cfg of configs) {
-      let currentValue = 0;
+      // Metrics are validated (allow-listed) at write time in setAlertConfig,
+      // so every branch here is reachable and there is no silent fallthrough.
+      let currentValue: number;
+      let threshold: number;
       if (cfg.metric === "price_deviation") {
         currentValue = stats.priceDeviationBps;
+        threshold = cfg.thresholdBps!;
       } else if (cfg.metric === "tvl") {
         currentValue = stats.tvl;
-      } else if (cfg.metric === "volume24h") {
+        threshold = cfg.thresholdValue!;
+      } else {
         currentValue = stats.volume24h;
+        threshold = cfg.thresholdValue!;
       }
 
-      if (currentValue > cfg.thresholdBps) {
+      if (currentValue > threshold) {
         const alert: HealthAlert = {
           poolId,
           metric: cfg.metric,
-          threshold: cfg.thresholdBps,
+          threshold,
           currentValue,
           firedAt: Date.now(),
         };

--- a/services/graphql-api/src/indexer.ts
+++ b/services/graphql-api/src/indexer.ts
@@ -158,6 +158,33 @@ export class PoolIndexer {
     });
   }
 
+  /**
+   * Time-weighted average liquidity (price) over the trailing `windowSeconds`.
+   * Each price point is weighted by the duration it was in effect: the time
+   * until the next point, or until now for the most recent point.
+   */
+  getTwal(poolId: string, windowSeconds: number): number | null {
+    const now = Date.now();
+    const from = now - windowSeconds * 1000;
+    const points = this.getPriceHistory(poolId, from, now).sort(
+      (a, b) => a.timestamp - b.timestamp,
+    );
+    if (points.length === 0) return null;
+
+    let weightedSum = 0;
+    let totalWeight = 0;
+    for (let i = 0; i < points.length; i++) {
+      const point = points[i];
+      const nextTimestamp = i + 1 < points.length ? points[i + 1].timestamp : now;
+      const weight = Math.max(0, nextTimestamp - point.timestamp);
+      weightedSum += point.price * weight;
+      totalWeight += weight;
+    }
+
+    if (totalWeight === 0) return points[points.length - 1].price;
+    return weightedSum / totalWeight;
+  }
+
   // ── Health scoring ──────────────────────────────────────────────────────────
 
   getPoolHealth(poolId: string): PoolHealth | null {

--- a/services/graphql-api/src/schema.ts
+++ b/services/graphql-api/src/schema.ts
@@ -52,10 +52,17 @@ export const typeDefs = `#graphql
     firedAt: Float!
   }
 
+  """
+  Configured alert threshold for a pool metric. metric must be one of
+  "price_deviation", "tvl", "volume24h". "price_deviation" uses thresholdBps
+  (basis points); "tvl" and "volume24h" use thresholdValue (a raw value in
+  the metric's native units, not basis points).
+  """
   type AlertConfig {
     poolId: ID!
     metric: String!
-    thresholdBps: Int!
+    thresholdBps: Int
+    thresholdValue: Float
   }
 
   type Query {
@@ -69,7 +76,12 @@ export const typeDefs = `#graphql
   }
 
   type Mutation {
-    setAlertConfig(poolId: ID!, metric: String!, thresholdBps: Int!): AlertConfig!
+    """
+    metric must be one of "price_deviation", "tvl", "volume24h". Pass
+    thresholdBps for "price_deviation"; pass thresholdValue for "tvl" and
+    "volume24h". Both fields must be >= 0.
+    """
+    setAlertConfig(poolId: ID!, metric: String!, thresholdBps: Int, thresholdValue: Float): AlertConfig!
     removeAlertConfig(poolId: ID!, metric: String!): Boolean!
   }
 

--- a/services/health-dashboard/index.html
+++ b/services/health-dashboard/index.html
@@ -111,7 +111,7 @@
           <option value="tvl">TVL drop below</option>
           <option value="volume24h">24h Volume above</option>
         </select>
-        <input id="alert-threshold" type="number" placeholder="Threshold" min="0" style="width:120px" aria-label="Alert threshold" />
+        <input id="alert-threshold" type="number" placeholder="Threshold" min="0" style="width:120px" aria-label="Alert threshold (bps for price deviation, raw value for TVL/volume)" />
         <button id="btn-add-alert">Add Alert</button>
       </div>
       <div class="alert-list" id="alert-list" aria-label="Configured alerts">

--- a/services/health-dashboard/index.html
+++ b/services/health-dashboard/index.html
@@ -99,7 +99,12 @@
 
     <!-- Alert configuration -->
     <div class="alerts-panel">
-      <h2>Configurable Alerts</h2>
+      <h2 id="fired-alerts-heading">Fired Alerts</h2>
+      <div class="alert-list" id="fired-alert-list" aria-label="Fired alerts">
+        <div class="empty-state">No alerts have fired for this pool</div>
+      </div>
+
+      <h2 id="configured-alerts-heading">Configured Alerts</h2>
       <div class="alert-form">
         <select id="alert-metric" aria-label="Alert metric">
           <option value="price_deviation">Price Deviation (bps)</option>
@@ -109,7 +114,7 @@
         <input id="alert-threshold" type="number" placeholder="Threshold" min="0" style="width:120px" aria-label="Alert threshold" />
         <button id="btn-add-alert">Add Alert</button>
       </div>
-      <div class="alert-list" id="alert-list">
+      <div class="alert-list" id="alert-list" aria-label="Configured alerts">
         <div class="empty-state">No alerts configured for this pool</div>
       </div>
     </div>

--- a/services/health-dashboard/src/dashboard.js
+++ b/services/health-dashboard/src/dashboard.js
@@ -182,7 +182,8 @@ export function createDashboardController({ apiUrl, poolId, pollIntervalMs = DEF
     results.forEach((result, index) => { const key = Object.keys(QUERY)[index]; if (result.status === "fulfilled") data[key] = result.value; else failures.push(`${key}: ${formatError(result.reason)}`); });
     renderStats(data.stats?.poolStats); renderHealth(data.health?.poolHealth); renderEvents(data.events?.poolEvents); renderHistory(data.history?.priceHistory); renderHeatmap(data.events?.poolEvents); if (data.alerts?.alertConfigs) { configs = data.alerts.alertConfigs; renderAlertConfigs(configs, removeAlert); }
     if (failures.length === Object.keys(QUERY).length) { setStatus("Error", "error", failures.join("; ")); setSectionState(`Unable to load dashboard data. ${failures[0]}`); $("btn-retry").hidden = false; }
-    else { setStatus(failures.length ? "Degraded" : "Connected", failures.length ? "error" : "connected", failures.join("; ")); setSectionState(failures.length ? `Degraded: ${failures.join("; ")}` : data.stats?.poolStats?.length ? "" : "No pools indexed yet"); $("btn-retry").hidden = false; setText("last-updated", `Last updated ${new Date().toLocaleTimeString()}`); }
+    // Retry is only useful when something failed; hide it on a fully successful refresh.
+    else { setStatus(failures.length ? "Degraded" : "Connected", failures.length ? "error" : "connected", failures.join("; ")); setSectionState(failures.length ? `Degraded: ${failures.join("; ")}` : data.stats?.poolStats?.length ? "" : "No pools indexed yet"); $("btn-retry").hidden = !failures.length; setText("last-updated", `Last updated ${new Date().toLocaleTimeString()}`); }
     refreshing = false;
   }
 
@@ -193,7 +194,9 @@ export function createDashboardController({ apiUrl, poolId, pollIntervalMs = DEF
     const thresholdBps = metric === "price_deviation" ? threshold : undefined;
     const thresholdValue = metric === "price_deviation" ? undefined : threshold;
     const currentPool = $("pool-id")?.value.trim() || pool;
-    const previous = configs; const next = [...configs.filter((item) => item.metric !== metric), { poolId: currentPool, metric, thresholdBps, thresholdValue }]; configs = next; renderAlertConfigs(configs, removeAlert); $("alert-threshold").value = "";
+    // Dedup by metric AND poolId — filtering by metric alone would drop other pools' alerts
+    // for the same metric when the Pool ID field is blank (alertConfigs(poolId: undefined) spans all pools).
+    const previous = configs; const next = [...configs.filter((item) => !(item.metric === metric && item.poolId === currentPool)), { poolId: currentPool, metric, thresholdBps, thresholdValue }]; configs = next; renderAlertConfigs(configs, removeAlert); $("alert-threshold").value = "";
     const currentUrl = $("api-url")?.value.trim() || url;
     try { await gql(currentUrl, `mutation SetAlert($poolId: ID!, $metric: String!, $thresholdBps: Int, $thresholdValue: Float) { setAlertConfig(poolId: $poolId, metric: $metric, thresholdBps: $thresholdBps, thresholdValue: $thresholdValue) { poolId metric thresholdBps thresholdValue } }`, { poolId: currentPool, metric, thresholdBps, thresholdValue }); } catch (error) { configs = previous; renderAlertConfigs(configs, removeAlert); setSectionState(`Alert was not saved: ${formatError(error)}`); }
   }

--- a/services/health-dashboard/src/dashboard.js
+++ b/services/health-dashboard/src/dashboard.js
@@ -47,7 +47,7 @@ export async function gql(apiUrl, query, variables = {}) {
 const QUERY = {
   stats: `query Stats($poolId: ID) { poolStats(poolId: $poolId) { poolId tokenA tokenB tvl volume24h fees24h swapCount priceDeviationBps } }`,
   health: `query Health($poolId: ID!) { poolHealth(poolId: $poolId) { poolId healthScore tvlScore volumeScore feeEfficiencyScore priceDeviationBps status alertsFired { poolId metric threshold currentValue firedAt } } }`,
-  alerts: `query Alerts($poolId: ID) { alertConfigs(poolId: $poolId) { poolId metric thresholdBps } }`,
+  alerts: `query Alerts($poolId: ID) { alertConfigs(poolId: $poolId) { poolId metric thresholdBps thresholdValue } }`,
   history: `query History($poolId: ID!) { priceHistory(poolId: $poolId, from: 0) { poolId timestamp price feeBps } }`,
   events: `query Events($poolId: ID) { poolEvents(poolId: $poolId, limit: 200) { id poolId type timestamp payload } }`,
 };
@@ -148,7 +148,7 @@ export function renderAlertConfigs(configs, onRemove) {
   if (!list) return;
   list.replaceChildren();
   if (!configs.length) { list.innerHTML = '<div class="empty-state">No alerts configured for this pool</div>'; return; }
-  configs.forEach((alert) => { const item = document.createElement("div"); item.className = "alert-item"; item.textContent = `${alert.metric} > ${alert.thresholdBps} bps `; const button = document.createElement("button"); button.className = "remove"; button.type = "button"; button.textContent = "×"; button.setAttribute("aria-label", `Remove ${alert.metric} alert`); button.addEventListener("click", () => onRemove(alert)); item.appendChild(button); list.appendChild(item); });
+  configs.forEach((alert) => { const item = document.createElement("div"); item.className = "alert-item"; const label = alert.metric === "price_deviation" ? `${alert.metric} > ${alert.thresholdBps} bps` : `${alert.metric} > ${alert.thresholdValue}`; item.textContent = `${label} `; const button = document.createElement("button"); button.className = "remove"; button.type = "button"; button.textContent = "×"; button.setAttribute("aria-label", `Remove ${alert.metric} alert`); button.addEventListener("click", () => onRemove(alert)); item.appendChild(button); list.appendChild(item); });
 }
 
 function addDashboardMessages() {
@@ -188,11 +188,14 @@ export function createDashboardController({ apiUrl, poolId, pollIntervalMs = DEF
 
   async function mutate(query, variables) { return gql(url, query, variables); }
   async function addAlert() {
-    const metric = $("alert-metric").value; const thresholdBps = Number($("alert-threshold").value); if (!metric || !Number.isFinite(thresholdBps) || thresholdBps < 0) return;
+    const metric = $("alert-metric").value; const threshold = Number($("alert-threshold").value); if (!metric || !Number.isFinite(threshold) || threshold < 0) return;
+    // "price_deviation" is basis points; "tvl" and "volume24h" are raw values in the metric's native units.
+    const thresholdBps = metric === "price_deviation" ? threshold : undefined;
+    const thresholdValue = metric === "price_deviation" ? undefined : threshold;
     const currentPool = $("pool-id")?.value.trim() || pool;
-    const previous = configs; const next = [...configs.filter((item) => item.metric !== metric), { poolId: currentPool, metric, thresholdBps }]; configs = next; renderAlertConfigs(configs, removeAlert); $("alert-threshold").value = "";
+    const previous = configs; const next = [...configs.filter((item) => item.metric !== metric), { poolId: currentPool, metric, thresholdBps, thresholdValue }]; configs = next; renderAlertConfigs(configs, removeAlert); $("alert-threshold").value = "";
     const currentUrl = $("api-url")?.value.trim() || url;
-    try { await gql(currentUrl, `mutation SetAlert($poolId: ID!, $metric: String!, $thresholdBps: Int!) { setAlertConfig(poolId: $poolId, metric: $metric, thresholdBps: $thresholdBps) { poolId metric thresholdBps } }`, { poolId: currentPool, metric, thresholdBps }); } catch (error) { configs = previous; renderAlertConfigs(configs, removeAlert); setSectionState(`Alert was not saved: ${formatError(error)}`); }
+    try { await gql(currentUrl, `mutation SetAlert($poolId: ID!, $metric: String!, $thresholdBps: Int, $thresholdValue: Float) { setAlertConfig(poolId: $poolId, metric: $metric, thresholdBps: $thresholdBps, thresholdValue: $thresholdValue) { poolId metric thresholdBps thresholdValue } }`, { poolId: currentPool, metric, thresholdBps, thresholdValue }); } catch (error) { configs = previous; renderAlertConfigs(configs, removeAlert); setSectionState(`Alert was not saved: ${formatError(error)}`); }
   }
   async function removeAlert(alert) {
     const previous = configs; configs = configs.filter((item) => !(item.metric === alert.metric && item.poolId === alert.poolId)); renderAlertConfigs(configs, removeAlert);

--- a/services/health-dashboard/src/dashboard.js
+++ b/services/health-dashboard/src/dashboard.js
@@ -89,9 +89,11 @@ function renderHealth(health) {
   renderFiredAlerts(health.alertsFired || []);
 }
 
-function renderFiredAlerts(alerts) {
-  const list = $("alert-list");
-  if (!list || !alerts.length) return;
+export function renderFiredAlerts(alerts) {
+  const list = $("fired-alert-list");
+  if (!list) return;
+  list.replaceChildren();
+  if (!alerts.length) { list.innerHTML = '<div class="empty-state">No alerts have fired for this pool</div>'; return; }
   for (const alert of alerts) {
     const item = document.createElement("div");
     item.className = "alert-item alert-fired";
@@ -141,7 +143,7 @@ function renderHeatmap(events) {
   buckets.forEach((amount, index) => { const bar = document.createElement("div"); bar.className = "heatmap-bar"; bar.style.height = `${Math.max(4, amount / max * 56)}px`; bar.title = `${23 - index}h ago: ${formatMetric(amount)}`; heatmap.appendChild(bar); });
 }
 
-function renderAlertConfigs(configs, onRemove) {
+export function renderAlertConfigs(configs, onRemove) {
   const list = $("alert-list");
   if (!list) return;
   list.replaceChildren();

--- a/services/health-dashboard/src/dashboard.test.js
+++ b/services/health-dashboard/src/dashboard.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { compareThreshold, formatError, formatMetric, formatTimestamp, healthColor } from "./dashboard.js";
+import { compareThreshold, formatError, formatMetric, formatTimestamp, healthColor, renderAlertConfigs, renderFiredAlerts } from "./dashboard.js";
+import { installFakeDocument } from "./dom-stub.js";
 
 test("formats millions", () => assert.equal(formatMetric(1_250_000), "1.25M"));
 test("formats thousands", () => assert.equal(formatMetric(12_500), "12.5K"));
@@ -12,3 +13,39 @@ test("compares below thresholds", () => assert.equal(compareThreshold(9, 10, "be
 test("rejects invalid threshold values", () => assert.equal(compareThreshold("x", 10), false));
 test("selects health colors", () => { assert.equal(healthColor(80), "var(--green)"); assert.equal(healthColor(50), "var(--yellow)"); assert.equal(healthColor(10), "var(--red)"); });
 test("formats invocation errors", () => assert.equal(formatError(new Error("offline")), "offline"));
+
+test("fired alerts render into their own container and survive renderAlertConfigs running afterward", () => {
+  const doc = installFakeDocument(["fired-alert-list", "alert-list"]);
+  renderFiredAlerts([{ metric: "tvl", threshold: 100, currentValue: 200, firedAt: Date.now() }]);
+  renderAlertConfigs([{ poolId: "pool-a", metric: "tvl", thresholdBps: 100 }], () => {});
+
+  const firedList = doc.getElementById("fired-alert-list");
+  const configList = doc.getElementById("alert-list");
+  assert.equal(firedList.children.length, 1);
+  assert.equal(configList.children.length, 1);
+});
+
+test("renderFiredAlerts does not accumulate stale entries across calls", () => {
+  const doc = installFakeDocument(["fired-alert-list"]);
+  renderFiredAlerts([{ metric: "tvl", threshold: 100, currentValue: 200, firedAt: Date.now() }]);
+  renderFiredAlerts([{ metric: "volume24h", threshold: 50, currentValue: 60, firedAt: Date.now() }]);
+
+  const firedList = doc.getElementById("fired-alert-list");
+  assert.equal(firedList.children.length, 1);
+  assert.ok(firedList.children[0].textContent.includes("volume24h"));
+});
+
+test("renderAlertConfigs still renders configured thresholds with working remove buttons", () => {
+  const doc = installFakeDocument(["alert-list"]);
+  let removed = null;
+  renderAlertConfigs(
+    [{ poolId: "pool-a", metric: "price_deviation", thresholdBps: 50 }],
+    (alert) => { removed = alert; },
+  );
+  const configList = doc.getElementById("alert-list");
+  assert.equal(configList.children.length, 1);
+  const button = configList.children[0].children.find((c) => c.tagName === "button" || c.className === "remove");
+  assert.ok(button);
+  button.listeners.click[0]();
+  assert.deepEqual(removed, { poolId: "pool-a", metric: "price_deviation", thresholdBps: 50 });
+});

--- a/services/health-dashboard/src/dashboard.test.js
+++ b/services/health-dashboard/src/dashboard.test.js
@@ -1,7 +1,36 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { compareThreshold, formatError, formatMetric, formatTimestamp, healthColor, renderAlertConfigs, renderFiredAlerts } from "./dashboard.js";
+import { compareThreshold, createDashboardController, formatError, formatMetric, formatTimestamp, healthColor, renderAlertConfigs, renderFiredAlerts } from "./dashboard.js";
 import { installFakeDocument } from "./dom-stub.js";
+
+const QUERY_RESPONSES = {
+  Stats: { poolStats: [] },
+  Health: { poolHealth: null },
+  Alerts: { alertConfigs: [] },
+  History: { priceHistory: [] },
+  Events: { poolEvents: [] },
+};
+
+function installFakeFetch(failingKeys = []) {
+  globalThis.fetch = async (_url, options) => {
+    const { query } = JSON.parse(options.body);
+    const key = Object.keys(QUERY_RESPONSES).find((k) => query.includes(`query ${k}`));
+    if (failingKeys.includes(key)) {
+      return { ok: false, status: 500, json: async () => ({ errors: [{ message: `${key} failed` }] }) };
+    }
+    return { ok: true, json: async () => ({ data: QUERY_RESPONSES[key] }) };
+  };
+}
+
+function setupRefreshTestDom() {
+  const doc = installFakeDocument([
+    "connection-status", "dashboard-state", "api-url", "pool-id", "btn-retry",
+    "m-tvl", "m-vol", "m-fees", "m-swaps", "health-score-text", "last-updated",
+    "fired-alert-list", "alert-list",
+  ]);
+  doc.getElementById("btn-retry").hidden = true;
+  return doc;
+}
 
 test("formats millions", () => assert.equal(formatMetric(1_250_000), "1.25M"));
 test("formats thousands", () => assert.equal(formatMetric(12_500), "12.5K"));
@@ -48,4 +77,52 @@ test("renderAlertConfigs still renders configured thresholds with working remove
   assert.ok(button);
   button.listeners.click[0]();
   assert.deepEqual(removed, { poolId: "pool-a", metric: "price_deviation", thresholdBps: 50 });
+});
+
+test("btn-retry stays hidden after a fully successful refresh", async () => {
+  const doc = setupRefreshTestDom();
+  installFakeFetch([]);
+  const controller = createDashboardController({ apiUrl: "http://api.test", poolId: "pool-a" });
+  await controller.refresh();
+  assert.equal(doc.getElementById("btn-retry").hidden, true);
+});
+
+test("btn-retry is shown after a partial failure", async () => {
+  const doc = setupRefreshTestDom();
+  installFakeFetch(["Alerts"]);
+  const controller = createDashboardController({ apiUrl: "http://api.test", poolId: "pool-a" });
+  await controller.refresh();
+  assert.equal(doc.getElementById("btn-retry").hidden, false);
+});
+
+test("btn-retry is shown after every query fails", async () => {
+  const doc = setupRefreshTestDom();
+  installFakeFetch(Object.keys(QUERY_RESPONSES));
+  const controller = createDashboardController({ apiUrl: "http://api.test", poolId: "pool-a" });
+  await controller.refresh();
+  assert.equal(doc.getElementById("btn-retry").hidden, false);
+});
+
+test("addAlert with a blank Pool ID does not drop another pool's alert with the same metric", async () => {
+  const doc = setupRefreshTestDom();
+  installFakeFetch([]);
+  doc.registerElement("alert-metric", { value: "tvl" });
+  doc.registerElement("alert-threshold", { value: "10" });
+
+  const controller = createDashboardController({ apiUrl: "http://api.test", poolId: "" });
+
+  doc.getElementById("pool-id").value = "pool-a";
+  await controller.addAlert();
+
+  doc.getElementById("pool-id").value = "pool-b";
+  doc.getElementById("alert-threshold").value = "20";
+  await controller.addAlert();
+
+  // Blank Pool ID: previously this dropped both prior entries because the
+  // dedup filter only matched on metric, ignoring poolId.
+  doc.getElementById("pool-id").value = "";
+  doc.getElementById("alert-threshold").value = "30";
+  await controller.addAlert();
+
+  assert.equal(doc.getElementById("alert-list").children.length, 3);
 });

--- a/services/health-dashboard/src/dom-stub.js
+++ b/services/health-dashboard/src/dom-stub.js
@@ -1,0 +1,54 @@
+/**
+ * Minimal DOM stub used by dashboard.test.js so render functions (which call
+ * document.getElementById/createElement) can be exercised under `node --test`
+ * without pulling in a full jsdom dependency.
+ */
+
+class FakeClassList {
+  constructor(el) { this.el = el; }
+  add(name) { if (!this.el.className.split(/\s+/).includes(name)) this.el.className = `${this.el.className} ${name}`.trim(); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.attributes = {};
+    this._textContent = "";
+    this.className = "";
+    this.hidden = false;
+    this.style = {};
+    this.dataset = {};
+    this.listeners = {};
+    this.classList = new FakeClassList(this);
+  }
+  set textContent(value) { this._textContent = value; this.children = []; }
+  get textContent() { return this._textContent; }
+  set innerHTML(value) { this._innerHTML = value; this.children = []; this._textContent = ""; }
+  get innerHTML() { return this._innerHTML || ""; }
+  appendChild(child) { this.children.push(child); return child; }
+  prepend(child) { this.children.unshift(child); return child; }
+  replaceChildren(...nodes) { this.children = nodes; this._innerHTML = ""; this._textContent = ""; }
+  setAttribute(name, value) { this.attributes[name] = value; }
+  getAttribute(name) { return this.attributes[name]; }
+  addEventListener(type, handler) { (this.listeners[type] ||= []).push(handler); }
+  querySelectorAll(selector) {
+    if (selector !== ".alert-item") return [];
+    return this.children.filter((c) => c.className?.includes("alert-item"));
+  }
+}
+
+export class FakeDocument {
+  constructor() { this.elements = new Map(); }
+  registerElement(id, el) { this.elements.set(id, el); }
+  getElementById(id) { return this.elements.get(id) || null; }
+  createElement(tag) { return new FakeElement(tag); }
+  querySelector() { return new FakeElement("div"); }
+}
+
+export function installFakeDocument(ids = []) {
+  const doc = new FakeDocument();
+  for (const id of ids) doc.registerElement(id, new FakeElement("div"));
+  globalThis.document = doc;
+  return doc;
+}

--- a/services/health-dashboard/src/dom-stub.js
+++ b/services/health-dashboard/src/dom-stub.js
@@ -20,6 +20,7 @@ class FakeElement {
     this.style = {};
     this.dataset = {};
     this.listeners = {};
+    this.value = "";
     this.classList = new FakeClassList(this);
   }
   set textContent(value) { this._textContent = value; this.children = []; }


### PR DESCRIPTION
## Summary

- **graphql-api: implement `twal` query** — replaces the hardcoded `null` stub
  with a real time-weighted-average-liquidity calculation over
  `PoolIndexer.priceHistory`, weighting each price point by the time it was
  in effect. Throws a `GraphQLError` for `windowSeconds <= 0`, returns `null`
  only when there's no price history in the requested window. Adds a README
  example and `indexer.test.ts` coverage.

- **health-dashboard: separate fired alerts from configured alerts** — fired
  alerts and configured thresholds both rendered into `#alert-list`, and
  `renderAlertConfigs`'s unconditional `replaceChildren()` wiped out fired
  alerts on every refresh. Fired alerts now get their own `#fired-alert-list`
  container with a distinct heading, cleared on each render to avoid stale
  entries.

- **graphql-api: validate alert metrics and split threshold units** —
  `setAlertConfig` accepted any `metric` string (unrecognized metrics were
  silently dead — they never fired) and reused `thresholdBps` as a raw value
  for `tvl`/`volume24h` despite the name implying basis points. Adds a
  `price_deviation | tvl | volume24h` allow-list enforced at write time via a
  typed `InvalidMetricError`, rejects negative thresholds via
  `InvalidThresholdError`, and splits the field into `thresholdBps`
  (`price_deviation` only) and `thresholdValue` (`tvl`/`volume24h`). Dashboard
  alert form and mutation updated to match.

- **health-dashboard: fix retry button and alert dedup bugs** — the
  `refresh()` success branch always unhid `#btn-retry`, even on full success,
  contradicting the documented "retry on failure only" behavior. `addAlert()`'s
  local dedup filtered by `metric` alone, so adding an alert with a blank
  Pool ID could silently drop other pools' alerts sharing that metric from
  the rendered list. Both fixed, with comments flagging the
  easy-to-reintroduce single-character-level bugs.

## Related Issues
Closes #840 
Closes #841 
Closes #842 
Closes #843 
