### PR TITLE
fix: align simulator accounting and harden UI risk and range interactions

### DIFF
--- a/packages/amm-simulator/src/io.rs
+++ b/packages/amm-simulator/src/io.rs
@@ -130,3 +130,355 @@ fn load_trade_records_csv(path: &Path) -> Result<Vec<TradeRecord>> {
 
     Ok(records)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replay::TradeAction;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file(extension: &str) -> std::path::PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after UNIX epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!(
+            "amm-simulator-io-test-{}-{}.{}",
+            std::process::id(),
+            timestamp,
+            extension
+        ))
+    }
+
+    fn write_temp_file(extension: &str, contents: &str) -> std::path::PathBuf {
+        let path = temp_file(extension);
+        fs::write(&path, contents).expect("test fixture should be writable");
+        path
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_trade_records_csv_parses_swap_exact_in() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             100,swap_exact_in,swap-a,XLM,USDC,5000,, , , ,4900,,,,\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("CSV should parse successfully");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].timestamp, 100);
+        assert_eq!(records[0].label.as_deref(), Some("swap-a"));
+
+        match &records[0].action {
+            TradeAction::SwapExactIn {
+                token_in,
+                amount_in,
+                min_out,
+            } => {
+                assert_eq!(token_in, "XLM");
+                assert_eq!(*amount_in, 5000);
+                assert_eq!(*min_out, 4900);
+            }
+            other => panic!("expected SwapExactIn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_csv_parses_swap_exact_out() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             200,swap_exact_out,swap-b,,USDC,,3000,,,,,3200,,,,\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("CSV should parse successfully");
+        assert_eq!(records.len(), 1);
+
+        match &records[0].action {
+            TradeAction::SwapExactOut {
+                token_out,
+                amount_out,
+                max_in,
+            } => {
+                assert_eq!(token_out, "USDC");
+                assert_eq!(*amount_out, 3000);
+                assert_eq!(*max_in, Some(3200));
+            }
+            other => panic!("expected SwapExactOut, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_csv_parses_add_liquidity() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             300,add_liquidity,deposit,,,,,10000,20000,, , ,9000,,\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("CSV should parse successfully");
+        assert_eq!(records.len(), 1);
+
+        match &records[0].action {
+            TradeAction::AddLiquidity {
+                amount_a,
+                amount_b,
+                min_shares,
+            } => {
+                assert_eq!(*amount_a, 10000);
+                assert_eq!(*amount_b, 20000);
+                assert_eq!(*min_shares, 9000);
+            }
+            other => panic!("expected AddLiquidity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_csv_parses_remove_liquidity() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             400,remove_liquidity,withdraw,,,,,,,2500,,, ,2000,3000\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("CSV should parse successfully");
+        assert_eq!(records.len(), 1);
+
+        match &records[0].action {
+            TradeAction::RemoveLiquidity {
+                shares,
+                min_a,
+                min_b,
+            } => {
+                assert_eq!(*shares, 2500);
+                assert_eq!(*min_a, 2000);
+                assert_eq!(*min_b, 3000);
+            }
+            other => panic!("expected RemoveLiquidity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_csv_unknown_kind_returns_invalid_input() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             500,unknown_trade,test,XLM,USDC,1000,,,,,,,,,\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        match result {
+            Err(SimulationError::InvalidInput(message)) => {
+                assert_eq!(message, "unknown trade kind `unknown_trade`");
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_csv_blank_optional_columns_use_expected_defaults() {
+        let path = write_temp_file(
+            "csv",
+            "timestamp,kind,label,token_in,token_out,amount_in,amount_out,amount_a,amount_b,shares,min_out,max_in,min_shares,min_a,min_b\n\
+             600,swap_exact_in,,,,,,,,,,,,,\n\
+             601,swap_exact_out,, ,USDC,,,,,,,,,,,\n\
+             602,add_liquidity,,,,,,1000,2000,,,,,,\n\
+             603,remove_liquidity,,,,,,,,500,,,,,\n",
+        );
+
+        let result = load_trade_records_csv(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("CSV should parse successfully");
+        assert_eq!(records.len(), 4);
+
+        match &records[0].action {
+            TradeAction::SwapExactIn {
+                token_in,
+                amount_in,
+                min_out,
+            } => {
+                assert_eq!(token_in, "");
+                assert_eq!(*amount_in, 0);
+                assert_eq!(*min_out, 0);
+            }
+            other => panic!("expected SwapExactIn, got {other:?}"),
+        }
+
+        match &records[1].action {
+            TradeAction::SwapExactOut {
+                token_out,
+                amount_out,
+                max_in,
+            } => {
+                assert_eq!(token_out.trim(), "USDC");
+                assert_eq!(*amount_out, 0);
+                assert_eq!(*max_in, None);
+            }
+            other => panic!("expected SwapExactOut, got {other:?}"),
+        }
+
+        match &records[2].action {
+            TradeAction::AddLiquidity {
+                amount_a,
+                amount_b,
+                min_shares,
+            } => {
+                assert_eq!(*amount_a, 1000);
+                assert_eq!(*amount_b, 2000);
+                assert_eq!(*min_shares, 0);
+            }
+            other => panic!("expected AddLiquidity, got {other:?}"),
+        }
+
+        match &records[3].action {
+            TradeAction::RemoveLiquidity {
+                shares,
+                min_a,
+                min_b,
+            } => {
+                assert_eq!(*shares, 500);
+                assert_eq!(*min_a, 0);
+                assert_eq!(*min_b, 0);
+            }
+            other => panic!("expected RemoveLiquidity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_json_parses_bare_array() {
+        let path = write_temp_file(
+            "json",
+            r#"[
+                {
+                    "timestamp": 1000,
+                    "label": "json-array",
+                    "action": {
+                        "SwapExactIn": {
+                            "token_in": "XLM",
+                            "amount_in": 5000,
+                            "min_out": 4500
+                        }
+                    }
+                }
+            ]"#,
+        );
+
+        let result = load_trade_records_json(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("bare JSON array should parse successfully");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].timestamp, 1000);
+        assert_eq!(records[0].label.as_deref(), Some("json-array"));
+
+        match &records[0].action {
+            TradeAction::SwapExactIn {
+                token_in,
+                amount_in,
+                min_out,
+            } => {
+                assert_eq!(token_in, "XLM");
+                assert_eq!(*amount_in, 5000);
+                assert_eq!(*min_out, 4500);
+            }
+            other => panic!("expected SwapExactIn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_json_parses_trades_wrapper() {
+        let path = write_temp_file(
+            "json",
+            r#"{
+                "trades": [
+                    {
+                        "timestamp": 2000,
+                        "label": "json-wrapper",
+                        "action": {
+                            "RemoveLiquidity": {
+                                "shares": 2500,
+                                "min_a": 1000,
+                                "min_b": 1500
+                            }
+                        }
+                    }
+                ]
+            }"#,
+        );
+
+        let result = load_trade_records_json(&path);
+
+        cleanup(&path);
+
+        let records = result.expect("wrapped JSON should parse successfully");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].timestamp, 2000);
+        assert_eq!(records[0].label.as_deref(), Some("json-wrapper"));
+
+        match &records[0].action {
+            TradeAction::RemoveLiquidity {
+                shares,
+                min_a,
+                min_b,
+            } => {
+                assert_eq!(*shares, 2500);
+                assert_eq!(*min_a, 1000);
+                assert_eq!(*min_b, 1500);
+            }
+            other => panic!("expected RemoveLiquidity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_trade_records_json_malformed_input_returns_json_error() {
+        let path = write_temp_file(
+            "json",
+            r#"{
+                "trades": [
+                    {
+                        "timestamp": 3000,
+                        "action":
+                    }
+                ]
+            "#,
+        );
+
+        let result = load_trade_records_json(&path);
+
+        cleanup(&path);
+
+        match result {
+            Err(SimulationError::Json { path: error_path, .. }) => {
+                assert!(error_path.ends_with(".json"));
+            }
+            other => panic!("expected JSON error, got {other:?}"),
+        }
+    }
+}

--- a/packages/amm-simulator/src/monte_carlo.rs
+++ b/packages/amm-simulator/src/monte_carlo.rs
@@ -1,7 +1,7 @@
 use crate::engine::AmmSimulator;
 use crate::error::Result;
 use crate::pool::PoolState;
-use crate::replay::TradeRecord;
+use crate::replay::{TradeAction, TradeRecord};
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +37,11 @@ pub struct MonteCarloReport {
 }
 
 impl MonteCarloReport {
-    pub fn run(base_pool: &PoolState, trades: &[TradeRecord], config: MonteCarloConfig) -> Result<Self> {
+    pub fn run(
+        base_pool: &PoolState,
+        trades: &[TradeRecord],
+        config: MonteCarloConfig,
+    ) -> Result<Self> {
         let mut rng = SmallRng::seed_from_u64(config.seed);
         let mut reserve_a_samples = Vec::with_capacity(config.iterations);
         let mut reserve_b_samples = Vec::with_capacity(config.iterations);
@@ -48,15 +52,19 @@ impl MonteCarloReport {
         for _ in 0..config.iterations {
             let mut simulator = AmmSimulator::new(base_pool.clone());
             let mut scenario = trades.to_vec();
+
             if config.shuffle_trades {
                 scenario.shuffle(&mut rng);
                 let start_ts = scenario.first().map(|trade| trade.timestamp).unwrap_or(0);
+
                 for (idx, trade) in scenario.iter_mut().enumerate() {
                     trade.timestamp = start_ts + idx as u64;
                 }
             }
+
             let scenario = perturb_trades(&scenario, config.amount_shock_bps, &mut rng);
             simulator.replay(&scenario)?;
+
             if simulator.steps.iter().any(|step| step.error.is_some()) {
                 failed_paths += 1;
             } else {
@@ -67,6 +75,8 @@ impl MonteCarloReport {
             }
         }
 
+        // A report with no successful paths has no meaningful distribution
+        // statistics, so return the documented all-zero report.
         if reserve_a_samples.is_empty() {
             return Ok(Self {
                 config,
@@ -91,14 +101,22 @@ impl MonteCarloReport {
         reserve_a_samples.sort_unstable();
         reserve_b_samples.sort_unstable();
 
-        let mean_final_reserve_a = reserve_a_samples.iter().map(|v| *v as f64).sum::<f64>()
-            / reserve_a_samples.len() as f64;
-        let mean_final_reserve_b = reserve_b_samples.iter().map(|v| *v as f64).sum::<f64>()
-            / reserve_b_samples.len() as f64;
-        let mean_final_price = price_samples.iter().sum::<f64>() / price_samples.len() as f64;
+        let mean_final_reserve_a =
+            reserve_a_samples.iter().map(|v| *v as f64).sum::<f64>()
+                / reserve_a_samples.len() as f64;
+
+        let mean_final_reserve_b =
+            reserve_b_samples.iter().map(|v| *v as f64).sum::<f64>()
+                / reserve_b_samples.len() as f64;
+
+        let mean_final_price =
+            price_samples.iter().sum::<f64>() / price_samples.len() as f64;
 
         let median_index = reserve_a_samples.len() / 2;
-        let p95_index = ((reserve_a_samples.len() as f64) * 0.95).floor() as usize;
+
+        let p95_index =
+            ((reserve_a_samples.len() as f64) * 0.95).floor() as usize;
+
         let p95_index = p95_index.min(reserve_a_samples.len() - 1);
 
         Ok(Self {
@@ -122,7 +140,11 @@ impl MonteCarloReport {
     }
 }
 
-fn perturb_trades(trades: &[TradeRecord], amount_shock_bps: u32, rng: &mut SmallRng) -> Vec<TradeRecord> {
+fn perturb_trades(
+    trades: &[TradeRecord],
+    amount_shock_bps: u32,
+    rng: &mut SmallRng,
+) -> Vec<TradeRecord> {
     if amount_shock_bps == 0 {
         return trades.to_vec();
     }
@@ -132,50 +154,370 @@ fn perturb_trades(trades: &[TradeRecord], amount_shock_bps: u32, rng: &mut Small
         .cloned()
         .map(|mut trade| {
             trade.action = match trade.action {
-                crate::replay::TradeAction::SwapExactIn {
+                TradeAction::SwapExactIn {
                     token_in,
                     amount_in,
                     min_out,
-                } => crate::replay::TradeAction::SwapExactIn {
+                } => TradeAction::SwapExactIn {
                     token_in,
                     amount_in: shock_amount(amount_in, amount_shock_bps, rng),
                     min_out,
                 },
-                crate::replay::TradeAction::SwapExactOut {
+
+                TradeAction::SwapExactOut {
                     token_out,
                     amount_out,
                     max_in,
-                } => crate::replay::TradeAction::SwapExactOut {
+                } => TradeAction::SwapExactOut {
                     token_out,
                     amount_out: shock_amount(amount_out, amount_shock_bps, rng),
                     max_in,
                 },
-                crate::replay::TradeAction::AddLiquidity {
+
+                TradeAction::AddLiquidity {
                     amount_a,
                     amount_b,
                     min_shares,
-                } => crate::replay::TradeAction::AddLiquidity {
+                } => TradeAction::AddLiquidity {
                     amount_a: shock_amount(amount_a, amount_shock_bps, rng),
                     amount_b: shock_amount(amount_b, amount_shock_bps, rng),
                     min_shares,
                 },
-                crate::replay::TradeAction::RemoveLiquidity {
+
+                TradeAction::RemoveLiquidity {
                     shares,
                     min_a,
                     min_b,
-                } => crate::replay::TradeAction::RemoveLiquidity {
+                } => TradeAction::RemoveLiquidity {
                     shares: shock_amount(shares, amount_shock_bps, rng),
                     min_a,
                     min_b,
                 },
             };
+
             trade
         })
         .collect()
 }
 
-fn shock_amount(amount: i128, shock_bps: u32, rng: &mut SmallRng) -> i128 {
-    let shock = rng.gen_range(-(shock_bps as i128)..=(shock_bps as i128));
+fn shock_amount(
+    amount: i128,
+    shock_bps: u32,
+    rng: &mut SmallRng,
+) -> i128 {
+    let shock =
+        rng.gen_range(-(shock_bps as i128)..=(shock_bps as i128));
+
     let perturbed = amount + amount * shock / 10_000;
+
+    // Trade amounts must never fall below one after perturbation.
     perturbed.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn funded_pool() -> PoolState {
+        let mut pool = PoolState::new("TOKEN_A", "TOKEN_B", 30).unwrap();
+
+        pool.reserve_a = 1_000_000;
+        pool.reserve_b = 2_000_000;
+        pool.total_shares = 1_000_000;
+
+        pool
+    }
+
+    fn successful_trades() -> Vec<TradeRecord> {
+        vec![TradeRecord {
+            timestamp: 1,
+            label: Some("deterministic swap".into()),
+            action: TradeAction::SwapExactIn {
+                token_in: "TOKEN_A".into(),
+                amount_in: 10_000,
+                min_out: 1,
+            },
+        }]
+    }
+
+    fn failed_trades() -> Vec<TradeRecord> {
+        vec![TradeRecord {
+            timestamp: 1,
+            label: Some("empty pool swap".into()),
+            action: TradeAction::SwapExactIn {
+                token_in: "TOKEN_A".into(),
+                amount_in: 1_000,
+                min_out: 1,
+            },
+        }]
+    }
+
+    #[test]
+    fn monte_carlo_same_seed_produces_reproducible_statistics() {
+        let pool = funded_pool();
+        let trades = successful_trades();
+
+        let config = MonteCarloConfig {
+            iterations: 20,
+            amount_shock_bps: 500,
+            shuffle_trades: false,
+            seed: 42,
+        };
+
+        let first =
+            MonteCarloReport::run(&pool, &trades, config.clone()).unwrap();
+
+        let second =
+            MonteCarloReport::run(&pool, &trades, config).unwrap();
+
+        assert_eq!(
+            first.successful_paths,
+            second.successful_paths
+        );
+        assert_eq!(first.failed_paths, second.failed_paths);
+
+        assert_eq!(
+            first.mean_final_reserve_a,
+            second.mean_final_reserve_a
+        );
+        assert_eq!(
+            first.mean_final_reserve_b,
+            second.mean_final_reserve_b
+        );
+        assert_eq!(first.mean_final_price, second.mean_final_price);
+
+        assert_eq!(
+            first.median_final_reserve_a,
+            second.median_final_reserve_a
+        );
+        assert_eq!(
+            first.median_final_reserve_b,
+            second.median_final_reserve_b
+        );
+
+        assert_eq!(
+            first.p95_final_reserve_a,
+            second.p95_final_reserve_a
+        );
+        assert_eq!(
+            first.p95_final_reserve_b,
+            second.p95_final_reserve_b
+        );
+
+        assert_eq!(
+            first.min_final_reserve_a,
+            second.min_final_reserve_a
+        );
+        assert_eq!(
+            first.max_final_reserve_a,
+            second.max_final_reserve_a
+        );
+    }
+
+    #[test]
+    fn monte_carlo_all_failed_paths_returns_zero_report() {
+        let pool = PoolState::new("TOKEN_A", "TOKEN_B", 30).unwrap();
+        let trades = failed_trades();
+
+        let config = MonteCarloConfig {
+            iterations: 10,
+            amount_shock_bps: 0,
+            shuffle_trades: false,
+            seed: 7,
+        };
+
+        let report =
+            MonteCarloReport::run(&pool, &trades, config).unwrap();
+
+        assert_eq!(report.successful_paths, 0);
+        assert_eq!(report.failed_paths, 10);
+
+        assert_eq!(report.mean_final_reserve_a, 0.0);
+        assert_eq!(report.mean_final_reserve_b, 0.0);
+        assert_eq!(report.mean_final_price, 0.0);
+
+        assert_eq!(report.median_final_reserve_a, 0);
+        assert_eq!(report.median_final_reserve_b, 0);
+        assert_eq!(report.p95_final_reserve_a, 0);
+        assert_eq!(report.p95_final_reserve_b, 0);
+
+        assert_eq!(report.min_final_reserve_a, 0);
+        assert_eq!(report.max_final_reserve_a, 0);
+        assert_eq!(report.min_final_reserve_b, 0);
+        assert_eq!(report.max_final_reserve_b, 0);
+    }
+
+    #[test]
+    fn monte_carlo_p95_never_exceeds_maximum() {
+        let pool = funded_pool();
+        let trades = successful_trades();
+
+        for iterations in [1, 2, 5, 10, 25, 50] {
+            let config = MonteCarloConfig {
+                iterations,
+                amount_shock_bps: 1_000,
+                shuffle_trades: false,
+                seed: 123,
+            };
+
+            let report =
+                MonteCarloReport::run(&pool, &trades, config).unwrap();
+
+            assert!(
+                report.successful_paths > 0,
+                "expected at least one successful path for {iterations} iterations"
+            );
+
+            assert!(
+                report.p95_final_reserve_a <= report.max_final_reserve_a,
+                "p95 reserve A ({}) exceeded max reserve A ({})",
+                report.p95_final_reserve_a,
+                report.max_final_reserve_a
+            );
+
+            assert!(
+                report.p95_final_reserve_b <= report.max_final_reserve_b,
+                "p95 reserve B ({}) exceeded max reserve B ({})",
+                report.p95_final_reserve_b,
+                report.max_final_reserve_b
+            );
+        }
+    }
+
+    #[test]
+    fn shock_amount_never_returns_less_than_one() {
+        let mut rng = SmallRng::seed_from_u64(99);
+
+        for _ in 0..1_000 {
+            let shocked = shock_amount(1, 100_000, &mut rng);
+
+            assert!(
+                shocked >= 1,
+                "shock_amount returned invalid value: {shocked}"
+            );
+        }
+    }
+
+    #[test]
+    fn perturb_trades_preserves_trade_count_and_actions() {
+        let trades = vec![
+            TradeRecord {
+                timestamp: 1,
+                label: Some("swap in".into()),
+                action: TradeAction::SwapExactIn {
+                    token_in: "TOKEN_A".into(),
+                    amount_in: 1_000,
+                    min_out: 1,
+                },
+            },
+            TradeRecord {
+                timestamp: 2,
+                label: Some("swap out".into()),
+                action: TradeAction::SwapExactOut {
+                    token_out: "TOKEN_B".into(),
+                    amount_out: 500,
+                    max_in: Some(1_000),
+                },
+            },
+            TradeRecord {
+                timestamp: 3,
+                label: Some("add".into()),
+                action: TradeAction::AddLiquidity {
+                    amount_a: 2_000,
+                    amount_b: 4_000,
+                    min_shares: 1,
+                },
+            },
+            TradeRecord {
+                timestamp: 4,
+                label: Some("remove".into()),
+                action: TradeAction::RemoveLiquidity {
+                    shares: 100,
+                    min_a: 1,
+                    min_b: 1,
+                },
+            },
+        ];
+
+        let mut rng = SmallRng::seed_from_u64(11);
+        let perturbed = perturb_trades(&trades, 500, &mut rng);
+
+        assert_eq!(perturbed.len(), trades.len());
+
+        for (original, updated) in trades.iter().zip(perturbed.iter()) {
+            assert_eq!(original.timestamp, updated.timestamp);
+            assert_eq!(original.label, updated.label);
+
+            match (&original.action, &updated.action) {
+                (
+                    TradeAction::SwapExactIn {
+                        token_in: original_token,
+                        min_out: original_min_out,
+                        ..
+                    },
+                    TradeAction::SwapExactIn {
+                        token_in: updated_token,
+                        min_out: updated_min_out,
+                        amount_in,
+                    },
+                ) => {
+                    assert_eq!(original_token, updated_token);
+                    assert_eq!(original_min_out, updated_min_out);
+                    assert!(*amount_in >= 1);
+                }
+
+                (
+                    TradeAction::SwapExactOut {
+                        token_out: original_token,
+                        max_in: original_max_in,
+                        ..
+                    },
+                    TradeAction::SwapExactOut {
+                        token_out: updated_token,
+                        max_in: updated_max_in,
+                        amount_out,
+                    },
+                ) => {
+                    assert_eq!(original_token, updated_token);
+                    assert_eq!(original_max_in, updated_max_in);
+                    assert!(*amount_out >= 1);
+                }
+
+                (
+                    TradeAction::AddLiquidity {
+                        min_shares: original_min_shares,
+                        ..
+                    },
+                    TradeAction::AddLiquidity {
+                        min_shares: updated_min_shares,
+                        amount_a,
+                        amount_b,
+                    },
+                ) => {
+                    assert_eq!(original_min_shares, updated_min_shares);
+                    assert!(*amount_a >= 1);
+                    assert!(*amount_b >= 1);
+                }
+
+                (
+                    TradeAction::RemoveLiquidity {
+                        min_a: original_min_a,
+                        min_b: original_min_b,
+                        ..
+                    },
+                    TradeAction::RemoveLiquidity {
+                        min_a: updated_min_a,
+                        min_b: updated_min_b,
+                        shares,
+                    },
+                ) => {
+                    assert_eq!(original_min_a, updated_min_a);
+                    assert_eq!(original_min_b, updated_min_b);
+                    assert!(*shares >= 1);
+                }
+
+                _ => panic!("trade action variant changed during perturbation"),
+            }
+        }
+    }
 }

--- a/packages/amm-simulator/src/pool.rs
+++ b/packages/amm-simulator/src/pool.rs
@@ -5,6 +5,13 @@ use std::convert::TryFrom;
 const BPS_DENOMINATOR: i128 = 10_000;
 const PRICE_SCALE: i128 = 1_000_000;
 
+/// Minimum liquidity permanently locked on the first successful deposit.
+///
+/// This mirrors `contracts/amm::MINIMUM_LIQUIDITY` and prevents dust-pool
+/// draining attacks by ensuring the first liquidity provider cannot withdraw
+/// the entire pool's initial share supply.
+pub const MINIMUM_LIQUIDITY: i128 = 1_000;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PoolState {
     pub token_a: String,
@@ -15,6 +22,11 @@ pub struct PoolState {
     pub fee_bps: i128,
     #[serde(default)]
     pub protocol_fee_bps: i128,
+    /// Percentage of the protocol fee returned to LP reserves.
+    ///
+    /// This mirrors the AMM contract's `LpRebateBps` storage value.
+    #[serde(default)]
+    pub lp_rebate_bps: i128,
     #[serde(default)]
     pub accrued_fee_a: i128,
     #[serde(default)]
@@ -27,10 +39,25 @@ pub struct PoolState {
     pub last_timestamp: u64,
     #[serde(default)]
     pub paused: bool,
+    /// Indicates that the first-deposit minimum liquidity has been locked.
+    ///
+    /// This mirrors the contract's `DataKey::MinLiquidityLocked`.
+    #[serde(default)]
+    pub min_liquidity_locked: bool,
+    /// Pool-level accounting for the permanently locked minimum liquidity.
+    ///
+    /// The simulator intentionally has no per-provider share ledger, so the
+    /// locked shares are tracked as pool-level state for reporting purposes.
+    #[serde(default)]
+    pub locked_liquidity: i128,
 }
 
 impl PoolState {
-    pub fn new(token_a: impl Into<String>, token_b: impl Into<String>, fee_bps: i128) -> Result<Self> {
+    pub fn new(
+        token_a: impl Into<String>,
+        token_b: impl Into<String>,
+        fee_bps: i128,
+    ) -> Result<Self> {
         let pool = Self {
             token_a: token_a.into(),
             token_b: token_b.into(),
@@ -39,12 +66,15 @@ impl PoolState {
             total_shares: 0,
             fee_bps,
             protocol_fee_bps: 0,
+            lp_rebate_bps: 0,
             accrued_fee_a: 0,
             accrued_fee_b: 0,
             price_cumulative_a: 0,
             price_cumulative_b: 0,
             last_timestamp: 0,
             paused: false,
+            min_liquidity_locked: false,
+            locked_liquidity: 0,
         };
         pool.validate()?;
         Ok(pool)
@@ -56,16 +86,73 @@ impl PoolState {
                 token: self.token_a.clone(),
             });
         }
+
         if !(0..=BPS_DENOMINATOR).contains(&self.fee_bps) {
             return Err(SimulationError::InvalidFeeBps {
                 fee_bps: self.fee_bps,
             });
         }
+
         if !(0..=self.fee_bps).contains(&self.protocol_fee_bps) {
             return Err(SimulationError::InvalidFeeBps {
                 fee_bps: self.protocol_fee_bps,
             });
         }
+
+        if !(0..=BPS_DENOMINATOR).contains(&self.lp_rebate_bps) {
+            return Err(SimulationError::InvalidFeeBps {
+                fee_bps: self.lp_rebate_bps,
+            });
+        }
+
+        if self.total_shares < 0 {
+            return Err(SimulationError::InvalidInput(
+                "total_shares cannot be negative".into(),
+            ));
+        }
+
+        if self.locked_liquidity < 0 {
+            return Err(SimulationError::InvalidInput(
+                "locked_liquidity cannot be negative".into(),
+            ));
+        }
+
+        if self.min_liquidity_locked {
+            if self.locked_liquidity != MINIMUM_LIQUIDITY {
+                return Err(SimulationError::InvalidInput(format!(
+                    "locked_liquidity must equal MINIMUM_LIQUIDITY ({MINIMUM_LIQUIDITY}) \
+                     when min_liquidity_locked is true"
+                )));
+            }
+
+            if self.total_shares < MINIMUM_LIQUIDITY {
+                return Err(SimulationError::InvalidInput(
+                    "total_shares cannot be below MINIMUM_LIQUIDITY when the lock is active"
+                        .into(),
+                ));
+            }
+        } else {
+            if self.locked_liquidity != 0 {
+                return Err(SimulationError::InvalidInput(
+                    "locked_liquidity must be zero when min_liquidity_locked is false".into(),
+                ));
+            }
+
+            // Existing fixtures are deserializable because the new fields use
+            // serde defaults. However, a populated pool with no lock marker is
+            // inconsistent with the contract's first-deposit semantics.
+            //
+            // We deliberately reject this state rather than silently guessing
+            // whether 1,000 shares were already locked.
+            if self.total_shares > MINIMUM_LIQUIDITY {
+                return Err(SimulationError::InvalidInput(
+                    "pool with total_shares above MINIMUM_LIQUIDITY must have \
+                     min_liquidity_locked set"
+                        .into(),
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -96,53 +183,81 @@ impl PoolState {
                 self.last_timestamp
             )));
         }
+
         if timestamp == self.last_timestamp {
             return Ok(());
         }
+
         let delta = timestamp - self.last_timestamp;
+
         if !self.is_empty() {
             let spot_a = self.spot_price_a();
             let spot_b = self.spot_price_b();
-            let delta_i128 = i128::try_from(delta).map_err(|_| SimulationError::Overflow)?;
+            let delta_i128 =
+                i128::try_from(delta).map_err(|_| SimulationError::Overflow)?;
+
             self.price_cumulative_a = self
                 .price_cumulative_a
-                .checked_add(spot_a.checked_mul(delta_i128).ok_or(SimulationError::Overflow)?)
+                .checked_add(
+                    spot_a
+                        .checked_mul(delta_i128)
+                        .ok_or(SimulationError::Overflow)?,
+                )
                 .ok_or(SimulationError::Overflow)?;
+
             self.price_cumulative_b = self
                 .price_cumulative_b
-                .checked_add(spot_b.checked_mul(delta_i128).ok_or(SimulationError::Overflow)?)
+                .checked_add(
+                    spot_b
+                        .checked_mul(delta_i128)
+                        .ok_or(SimulationError::Overflow)?,
+                )
                 .ok_or(SimulationError::Overflow)?;
         }
+
         self.last_timestamp = timestamp;
         Ok(())
     }
 
-    pub fn quote_swap_exact_in(&self, token_in: &str, amount_in: i128) -> Result<SwapQuote> {
+    pub fn quote_swap_exact_in(
+        &self,
+        token_in: &str,
+        amount_in: i128,
+    ) -> Result<SwapQuote> {
         if amount_in <= 0 {
             return Err(SimulationError::ZeroAmount);
         }
+
         let (reserve_in, reserve_out, token_out) = self.token_pair(token_in)?;
+
         if reserve_in <= 0 || reserve_out <= 0 {
             return Err(SimulationError::EmptyPool);
         }
+
         let amount_in_with_fee = amount_in
             .checked_mul(BPS_DENOMINATOR - self.fee_bps)
             .ok_or(SimulationError::Overflow)?;
+
         let numerator = amount_in_with_fee
             .checked_mul(reserve_out)
             .ok_or(SimulationError::Overflow)?;
+
         let denominator = reserve_in
             .checked_mul(BPS_DENOMINATOR)
             .ok_or(SimulationError::Overflow)?
             .checked_add(amount_in_with_fee)
             .ok_or(SimulationError::Overflow)?;
+
         let amount_out = numerator / denominator;
+
         let fee_amount = amount_in
             .checked_mul(self.fee_bps)
             .ok_or(SimulationError::Overflow)?
             / BPS_DENOMINATOR;
+
         let spot_price = reserve_out * PRICE_SCALE / reserve_in;
         let effective_price = amount_out * PRICE_SCALE / amount_in;
+
         let price_impact_bps = if spot_price > 0 {
             ((spot_price - effective_price) * BPS_DENOMINATOR / spot_price).max(0)
         } else {
@@ -162,37 +277,50 @@ impl PoolState {
         })
     }
 
-    pub fn quote_swap_exact_out(&self, token_out: &str, amount_out: i128) -> Result<SwapResult> {
+    pub fn quote_swap_exact_out(
+        &self,
+        token_out: &str,
+        amount_out: i128,
+    ) -> Result<SwapResult> {
         if amount_out <= 0 {
             return Err(SimulationError::ZeroAmount);
         }
+
         if self.fee_bps == BPS_DENOMINATOR {
             return Err(SimulationError::InvalidInput(
                 "exact-out swaps are impossible at a 100% fee".into(),
             ));
         }
+
         let (reserve_in, reserve_out, token_in) = self.reverse_pair(token_out)?;
+
         if reserve_in <= 0 || reserve_out <= 0 {
             return Err(SimulationError::EmptyPool);
         }
+
         if amount_out >= reserve_out {
             return Err(SimulationError::SlippageExceeded);
         }
+
         let numerator = reserve_in
             .checked_mul(amount_out)
             .ok_or(SimulationError::Overflow)?
             .checked_mul(BPS_DENOMINATOR)
             .ok_or(SimulationError::Overflow)?;
+
         let denominator = reserve_out
             .checked_sub(amount_out)
             .ok_or(SimulationError::Overflow)?
             .checked_mul(BPS_DENOMINATOR - self.fee_bps)
             .ok_or(SimulationError::Overflow)?;
+
         let required_in = numerator / denominator + 1;
+
         let fee_amount = required_in
             .checked_mul(self.fee_bps)
             .ok_or(SimulationError::Overflow)?
             / BPS_DENOMINATOR;
+
         Ok(SwapResult {
             token_in,
             token_out: token_out.to_string(),
@@ -202,26 +330,51 @@ impl PoolState {
         })
     }
 
-    pub fn quote_add_liquidity(&self, amount_a: i128, amount_b: i128) -> Result<LiquidityQuote> {
+    pub fn quote_add_liquidity(
+        &self,
+        amount_a: i128,
+        amount_b: i128,
+    ) -> Result<LiquidityQuote> {
         if amount_a <= 0 || amount_b <= 0 {
             return Err(SimulationError::ZeroAmount);
         }
+
         if self.total_shares > 0 && (self.reserve_a <= 0 || self.reserve_b <= 0) {
             return Err(SimulationError::EmptyPool);
         }
-        let shares = if self.total_shares == 0 {
-            isqrt(amount_a.checked_mul(amount_b).ok_or(SimulationError::Overflow)?)
+
+        let raw_shares = if self.total_shares == 0 {
+            isqrt(
+                amount_a
+                    .checked_mul(amount_b)
+                    .ok_or(SimulationError::Overflow)?,
+            )
         } else {
             let shares_a = amount_a
                 .checked_mul(self.total_shares)
                 .ok_or(SimulationError::Overflow)?
                 / self.reserve_a;
+
             let shares_b = amount_b
                 .checked_mul(self.total_shares)
                 .ok_or(SimulationError::Overflow)?
                 / self.reserve_b;
+
             shares_a.min(shares_b)
         };
+
+        let shares = if self.total_shares == 0 && !self.min_liquidity_locked {
+            if raw_shares <= MINIMUM_LIQUIDITY {
+                return Err(SimulationError::InsufficientShares);
+            }
+
+            raw_shares
+                .checked_sub(MINIMUM_LIQUIDITY)
+                .ok_or(SimulationError::Overflow)?
+        } else {
+            raw_shares
+        };
+
         Ok(LiquidityQuote {
             amount_a,
             amount_b,
@@ -234,16 +387,39 @@ impl PoolState {
         })
     }
 
-    pub fn quote_remove_liquidity(&self, shares: i128) -> Result<LiquidityQuote> {
+    pub fn quote_remove_liquidity(
+        &self,
+        shares: i128,
+    ) -> Result<LiquidityQuote> {
         if shares <= 0 {
             return Err(SimulationError::ZeroAmount);
         }
+
         if self.total_shares <= 0 {
             return Err(SimulationError::EmptyPool);
         }
+
+        // The permanently locked minimum liquidity is included in
+        // total_shares but is not provider-owned and therefore cannot be
+        // withdrawn through the simulator's provider-facing share amount.
+        let withdrawable_shares = self
+            .total_shares
+            .checked_sub(self.locked_liquidity)
+            .ok_or(SimulationError::Overflow)?;
+
+        if shares > withdrawable_shares {
+            return Err(SimulationError::SlippageExceeded);
+        }
+
         Ok(LiquidityQuote {
-            amount_a: shares * self.reserve_a / self.total_shares,
-            amount_b: shares * self.reserve_b / self.total_shares,
+            amount_a: shares
+                .checked_mul(self.reserve_a)
+                .ok_or(SimulationError::Overflow)?
+                / self.total_shares,
+            amount_b: shares
+                .checked_mul(self.reserve_b)
+                .ok_or(SimulationError::Overflow)?
+                / self.total_shares,
             shares,
             pool_ratio: if self.reserve_a > 0 {
                 self.reserve_b * PRICE_SCALE / self.reserve_a
@@ -262,22 +438,59 @@ impl PoolState {
         if self.paused {
             return Err(SimulationError::Paused);
         }
+
         let quote = self.quote_swap_exact_in(token_in, amount_in)?;
+
         if quote.amount_out < min_out {
             return Err(SimulationError::SlippageExceeded);
         }
+
         self.apply_checkpoint()?;
+
         let protocol_fee = self.protocol_fee(amount_in)?;
+        let lp_rebate = self.lp_rebate(protocol_fee)?;
+        let net_protocol_fee = protocol_fee
+            .checked_sub(lp_rebate)
+            .ok_or(SimulationError::Overflow)?;
 
         if token_in == self.token_a {
-            self.reserve_a = self.reserve_a + amount_in - protocol_fee;
-            self.reserve_b = self.reserve_b - quote.amount_out;
-            self.accrued_fee_a = self.accrued_fee_a + protocol_fee;
+            // Only the net protocol fee leaves the LP reserves.
+            // The rebate remains in the reserve for LPs.
+            self.reserve_a = self
+                .reserve_a
+                .checked_add(amount_in)
+                .ok_or(SimulationError::Overflow)?
+                .checked_sub(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.reserve_b = self
+                .reserve_b
+                .checked_sub(quote.amount_out)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.accrued_fee_a = self
+                .accrued_fee_a
+                .checked_add(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
         } else {
-            self.reserve_b = self.reserve_b + amount_in - protocol_fee;
-            self.reserve_a = self.reserve_a - quote.amount_out;
-            self.accrued_fee_b = self.accrued_fee_b + protocol_fee;
+            self.reserve_b = self
+                .reserve_b
+                .checked_add(amount_in)
+                .ok_or(SimulationError::Overflow)?
+                .checked_sub(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.reserve_a = self
+                .reserve_a
+                .checked_sub(quote.amount_out)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.accrued_fee_b = self
+                .accrued_fee_b
+                .checked_add(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
         }
+
         Ok(quote)
     }
 
@@ -290,22 +503,57 @@ impl PoolState {
         if self.paused {
             return Err(SimulationError::Paused);
         }
+
         let quote = self.quote_swap_exact_out(token_out, amount_out)?;
+
         if quote.amount_in > max_in {
             return Err(SimulationError::SlippageExceeded);
         }
+
         self.apply_checkpoint()?;
+
         let protocol_fee = self.protocol_fee(quote.amount_in)?;
+        let lp_rebate = self.lp_rebate(protocol_fee)?;
+        let net_protocol_fee = protocol_fee
+            .checked_sub(lp_rebate)
+            .ok_or(SimulationError::Overflow)?;
 
         if token_out == self.token_a {
-            self.reserve_b = self.reserve_b + quote.amount_in - protocol_fee;
-            self.reserve_a = self.reserve_a - amount_out;
-            self.accrued_fee_b = self.accrued_fee_b + protocol_fee;
+            self.reserve_b = self
+                .reserve_b
+                .checked_add(quote.amount_in)
+                .ok_or(SimulationError::Overflow)?
+                .checked_sub(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.reserve_a = self
+                .reserve_a
+                .checked_sub(amount_out)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.accrued_fee_b = self
+                .accrued_fee_b
+                .checked_add(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
         } else {
-            self.reserve_a = self.reserve_a + quote.amount_in - protocol_fee;
-            self.reserve_b = self.reserve_b - amount_out;
-            self.accrued_fee_a = self.accrued_fee_a + protocol_fee;
+            self.reserve_a = self
+                .reserve_a
+                .checked_add(quote.amount_in)
+                .ok_or(SimulationError::Overflow)?
+                .checked_sub(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.reserve_b = self
+                .reserve_b
+                .checked_sub(amount_out)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.accrued_fee_a = self
+                .accrued_fee_a
+                .checked_add(net_protocol_fee)
+                .ok_or(SimulationError::Overflow)?;
         }
+
         Ok(quote)
     }
 
@@ -318,14 +566,43 @@ impl PoolState {
         if self.paused {
             return Err(SimulationError::Paused);
         }
+
+        let first_deposit = self.total_shares == 0 && !self.min_liquidity_locked;
         let quote = self.quote_add_liquidity(amount_a, amount_b)?;
+
         if quote.shares < min_shares {
             return Err(SimulationError::SlippageExceeded);
         }
+
         self.apply_checkpoint()?;
-        self.reserve_a = self.reserve_a + amount_a;
-        self.reserve_b = self.reserve_b + amount_b;
-        self.total_shares = self.total_shares + quote.shares;
+
+        self.reserve_a = self
+            .reserve_a
+            .checked_add(amount_a)
+            .ok_or(SimulationError::Overflow)?;
+
+        self.reserve_b = self
+            .reserve_b
+            .checked_add(amount_b)
+            .ok_or(SimulationError::Overflow)?;
+
+        if first_deposit {
+            // The contract mints `raw_shares - MINIMUM_LIQUIDITY` to the
+            // provider and permanently locks MINIMUM_LIQUIDITY.
+            self.total_shares = quote
+                .shares
+                .checked_add(MINIMUM_LIQUIDITY)
+                .ok_or(SimulationError::Overflow)?;
+
+            self.locked_liquidity = MINIMUM_LIQUIDITY;
+            self.min_liquidity_locked = true;
+        } else {
+            self.total_shares = self
+                .total_shares
+                .checked_add(quote.shares)
+                .ok_or(SimulationError::Overflow)?;
+        }
+
         Ok(quote)
     }
 
@@ -338,14 +615,30 @@ impl PoolState {
         if self.paused {
             return Err(SimulationError::Paused);
         }
+
         let quote = self.quote_remove_liquidity(shares)?;
+
         if quote.amount_a < min_a || quote.amount_b < min_b {
             return Err(SimulationError::SlippageExceeded);
         }
+
         self.apply_checkpoint()?;
-        self.reserve_a = self.reserve_a - quote.amount_a;
-        self.reserve_b = self.reserve_b - quote.amount_b;
-        self.total_shares = self.total_shares - shares;
+
+        self.reserve_a = self
+            .reserve_a
+            .checked_sub(quote.amount_a)
+            .ok_or(SimulationError::Overflow)?;
+
+        self.reserve_b = self
+            .reserve_b
+            .checked_sub(quote.amount_b)
+            .ok_or(SimulationError::Overflow)?;
+
+        self.total_shares = self
+            .total_shares
+            .checked_sub(shares)
+            .ok_or(SimulationError::Overflow)?;
+
         Ok(quote)
     }
 
@@ -359,17 +652,37 @@ impl PoolState {
         if self.protocol_fee_bps <= 0 {
             return Ok(0);
         }
-        Ok(amount
+
+        amount
             .checked_mul(self.protocol_fee_bps)
-            .ok_or(SimulationError::Overflow)?
-            / BPS_DENOMINATOR)
+            .ok_or(SimulationError::Overflow)
+            .map(|value| value / BPS_DENOMINATOR)
+    }
+
+    fn lp_rebate(&self, protocol_fee: i128) -> Result<i128> {
+        if protocol_fee <= 0 || self.lp_rebate_bps <= 0 {
+            return Ok(0);
+        }
+
+        protocol_fee
+            .checked_mul(self.lp_rebate_bps)
+            .ok_or(SimulationError::Overflow)
+            .map(|value| value / BPS_DENOMINATOR)
     }
 
     fn token_pair(&self, token_in: &str) -> Result<(i128, i128, String)> {
         if token_in == self.token_a {
-            Ok((self.reserve_a, self.reserve_b, self.token_b.clone()))
+            Ok((
+                self.reserve_a,
+                self.reserve_b,
+                self.token_b.clone(),
+            ))
         } else if token_in == self.token_b {
-            Ok((self.reserve_b, self.reserve_a, self.token_a.clone()))
+            Ok((
+                self.reserve_b,
+                self.reserve_a,
+                self.token_a.clone(),
+            ))
         } else {
             Err(SimulationError::InvalidToken {
                 token: token_in.to_string(),
@@ -379,9 +692,17 @@ impl PoolState {
 
     fn reverse_pair(&self, token_out: &str) -> Result<(i128, i128, String)> {
         if token_out == self.token_a {
-            Ok((self.reserve_b, self.reserve_a, self.token_b.clone()))
+            Ok((
+                self.reserve_b,
+                self.reserve_a,
+                self.token_b.clone(),
+            ))
         } else if token_out == self.token_b {
-            Ok((self.reserve_a, self.reserve_b, self.token_a.clone()))
+            Ok((
+                self.reserve_a,
+                self.reserve_b,
+                self.token_a.clone(),
+            ))
         } else {
             Err(SimulationError::InvalidToken {
                 token: token_out.to_string(),
@@ -424,11 +745,252 @@ fn isqrt(n: i128) -> i128 {
     if n <= 0 {
         return 0;
     }
+
     let mut x = n;
     let mut y = (x + 1) / 2;
+
     while y < x {
         x = y;
         y = (x + n / x) / 2;
     }
+
     x
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool_with_liquidity() -> PoolState {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.execute_add_liquidity(100_000, 100_000, 0)
+            .expect("initial liquidity should succeed");
+
+        pool
+    }
+
+    #[test]
+    fn first_deposit_below_minimum_liquidity_returns_insufficient_shares() {
+        let pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        let result = pool.quote_add_liquidity(1_000, 1_000);
+
+        assert_eq!(
+            result,
+            Err(SimulationError::InsufficientShares)
+        );
+    }
+
+    #[test]
+    fn first_deposit_mints_sqrt_product_minus_minimum_liquidity() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        let quote = pool
+            .execute_add_liquidity(2_000, 2_000, 1_000)
+            .expect("first deposit should succeed");
+
+        // sqrt(2,000 * 2,000) = 2,000.
+        // Provider receives 2,000 - 1,000 = 1,000 shares.
+        assert_eq!(quote.shares, 1_000);
+        assert_eq!(pool.total_shares, 2_000);
+        assert_eq!(pool.locked_liquidity, MINIMUM_LIQUIDITY);
+        assert!(pool.min_liquidity_locked);
+
+        let mut second_pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        let second_quote = second_pool
+            .execute_add_liquidity(5_000, 5_000, 4_000)
+            .expect("first deposit should succeed");
+
+        // sqrt(5,000 * 5,000) = 5,000.
+        // Provider receives 5,000 - 1,000 = 4,000 shares.
+        assert_eq!(second_quote.shares, 4_000);
+        assert_eq!(second_pool.total_shares, 5_000);
+        assert_eq!(second_pool.locked_liquidity, MINIMUM_LIQUIDITY);
+    }
+
+    #[test]
+    fn second_deposit_is_unaffected_by_minimum_liquidity_lock() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.execute_add_liquidity(2_000, 2_000, 1_000)
+            .expect("first deposit should succeed");
+
+        let quote = pool
+            .quote_add_liquidity(1_000, 1_000)
+            .expect("second deposit should succeed");
+
+        // The pool has 2,000 total shares: 1,000 provider shares and
+        // 1,000 permanently locked shares. The second provider receives:
+        // 1,000 * 2,000 / 2,000 = 1,000 shares.
+        assert_eq!(quote.shares, 1_000);
+
+        pool.execute_add_liquidity(1_000, 1_000, 1_000)
+            .expect("second deposit should execute");
+
+        assert_eq!(pool.total_shares, 3_000);
+        assert_eq!(pool.locked_liquidity, MINIMUM_LIQUIDITY);
+        assert!(pool.min_liquidity_locked);
+    }
+
+    #[test]
+    fn swap_exact_in_credits_net_protocol_fee_after_lp_rebate() {
+        let mut pool = pool_with_liquidity();
+
+        pool.protocol_fee_bps = 30;
+        pool.lp_rebate_bps = 5_000;
+
+        let initial_reserve_a = pool.reserve_a;
+
+        let quote = pool
+            .execute_swap_exact_in("TOKEN_A", 10_000, 0)
+            .expect("swap should succeed");
+
+        // protocol fee = 10,000 * 30 / 10,000 = 30
+        // LP rebate = 30 * 5,000 / 10,000 = 15
+        // net protocol fee = 30 - 15 = 15
+        assert_eq!(pool.accrued_fee_a, 15);
+
+        // The 15-token LP rebate remains in the reserve, so the reserve
+        // increases by amount_in - net_protocol_fee.
+        assert_eq!(
+            pool.reserve_a,
+            initial_reserve_a + 10_000 - 15
+        );
+
+        assert!(quote.amount_out > 0);
+    }
+
+    #[test]
+    fn swap_with_zero_lp_rebate_preserves_previous_protocol_fee_accounting() {
+        let mut pool = pool_with_liquidity();
+
+        pool.protocol_fee_bps = 30;
+        pool.lp_rebate_bps = 0;
+
+        let initial_reserve_a = pool.reserve_a;
+
+        pool.execute_swap_exact_in("TOKEN_A", 10_000, 0)
+            .expect("swap should succeed");
+
+        // With no LP rebate, the entire protocol fee is accrued.
+        assert_eq!(pool.accrued_fee_a, 30);
+
+        assert_eq!(
+            pool.reserve_a,
+            initial_reserve_a + 10_000 - 30
+        );
+    }
+
+    #[test]
+    fn swap_exact_out_credits_net_protocol_fee_after_lp_rebate() {
+        let mut pool = pool_with_liquidity();
+
+        pool.protocol_fee_bps = 30;
+        pool.lp_rebate_bps = 5_000;
+
+        let quote = pool
+            .quote_swap_exact_out("TOKEN_B", 1_000)
+            .expect("exact-out quote should succeed");
+
+        let protocol_fee =
+            quote.amount_in * pool.protocol_fee_bps / BPS_DENOMINATOR;
+
+        let expected_rebate =
+            protocol_fee * pool.lp_rebate_bps / BPS_DENOMINATOR;
+
+        let expected_net_fee = protocol_fee - expected_rebate;
+
+        pool.execute_swap_exact_out("TOKEN_B", 1_000, quote.amount_in)
+            .expect("exact-out swap should succeed");
+
+        assert_eq!(pool.accrued_fee_a, expected_net_fee);
+    }
+
+    #[test]
+    fn validate_rejects_invalid_lp_rebate_bps() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.lp_rebate_bps = BPS_DENOMINATOR + 1;
+
+        assert_eq!(
+            pool.validate(),
+            Err(SimulationError::InvalidFeeBps {
+                fee_bps: BPS_DENOMINATOR + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_accepts_valid_lp_rebate_bps_and_locked_state() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.lp_rebate_bps = 5_000;
+        pool.total_shares = 2_000;
+        pool.locked_liquidity = MINIMUM_LIQUIDITY;
+        pool.min_liquidity_locked = true;
+
+        assert!(pool.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_populated_pool_without_minimum_liquidity_lock() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.total_shares = MINIMUM_LIQUIDITY + 1;
+
+        assert!(matches!(
+            pool.validate(),
+            Err(SimulationError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn first_deposit_exactly_at_minimum_liquidity_is_rejected() {
+        let pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        // sqrt(1,000 * 1,000) = 1,000, so the provider would receive
+        // zero shares after the mandatory 1,000-share lock.
+        let result = pool.quote_add_liquidity(1_000, 1_000);
+
+        assert_eq!(
+            result,
+            Err(SimulationError::InsufficientShares)
+        );
+    }
+
+    #[test]
+    fn provider_cannot_withdraw_permanently_locked_liquidity() {
+        let mut pool =
+            PoolState::new("TOKEN_A", "TOKEN_B", 30).expect("pool should be valid");
+
+        pool.execute_add_liquidity(2_000, 2_000, 1_000)
+            .expect("first deposit should succeed");
+
+        // total_shares = 2,000, of which 1,000 is permanently locked.
+        // Only the provider's 1,000 shares can be withdrawn.
+        let result = pool.quote_remove_liquidity(1_001);
+
+        assert_eq!(
+            result,
+            Err(SimulationError::SlippageExceeded)
+        );
+
+        let quote = pool
+            .quote_remove_liquidity(1_000)
+            .expect("provider shares should be withdrawable");
+
+        assert_eq!(quote.amount_a, 1_000);
+        assert_eq!(quote.amount_b, 1_000);
+    }
 }


### PR DESCRIPTION
## Summary

This PR resolves four related correctness and test-coverage issues across the AMM simulator and UI components.

### Changes

* **#834 — AMM simulator accounting**

  * Added `MINIMUM_LIQUIDITY` first-deposit locking.
  * Added pool-level `locked_liquidity` tracking.
  * Added `lp_rebate_bps` to `PoolState` with serde defaults.
  * Updated exact-in and exact-out swaps to account for LP rebates correctly.
  * Only the net protocol fee is added to accrued protocol fees.
  * Added validation for invalid rebate and inconsistent minimum-liquidity state.

* **#835 — AMM simulator test coverage**

  * Added liquidity-removal success and error-path tests.
  * Added CSV parsing tests for all four trade actions.
  * Added unknown trade-kind and optional-column regression tests.
  * Added JSON array, wrapper, and malformed-input tests.
  * Added Monte Carlo deterministic-seed and all-paths-failed tests.
  * Added percentile/max invariant coverage.
  * Added `shock_amount` lower-bound coverage.

* **#833 — RiskIndicator**

  * Added trading-volume/TVL risk assessment.
  * Added high-fee/narrow-range risk assessment.
  * Documented the new thresholds and scoring rationale.
  * Preserved the existing risk factors, score clamping, and risk-level boundaries.
  * Added direct unit coverage for baseline, volume, fee, regression, and worst-case scenarios.

* **#832 — RangeSelector**

  * Replaced the stale React-state drag dependency with a synchronous `useRef`.
  * Added latest-value refs for controlled range updates.
  * Added unmount cleanup for global mouse listeners.
  * Preserved lower/upper clamping and keyboard interactions.
  * Added regression tests for lower/upper dragging, mouseup cleanup, unmount cleanup, and keyboard adjustment.

### Testing

```bash
cargo test -p amm-simulator
pnpm --filter @soroban-amm/ui-components test
pnpm --filter @soroban-amm/ui-components build
```

The changes are intentionally scoped to the simulator accounting/test paths and the affected UI components without modifying the deployed AMM contract or unrelated UI rendering.

Closes #832
Closes #833
Closes #834
Closes #835
