### PR TITLE
feat(sdk): harden Go SDK validation and errors and make Android SDK buildable

### DIFF
--- a/packages/go-sdk/signer.go
+++ b/packages/go-sdk/signer.go
@@ -3,7 +3,6 @@ package gosdk
 import (
 	"context"
 	"errors"
-	"strings"
 )
 
 // Signer signs transaction envelopes. It is an interface so callers can back it
@@ -18,7 +17,7 @@ type Signer interface {
 }
 
 // ErrSignerAddress is returned when a Signer reports an address that is not a
-// plausible Stellar account.
+// valid Stellar account strkey.
 var ErrSignerAddress = errors.New("signer address is not a valid account address")
 
 // SignerFunc adapts a function to the Signer interface, pairing it with a fixed
@@ -41,7 +40,7 @@ func (s SignerFunc) SignEnvelope(ctx context.Context, envelopeXDR string, networ
 	return s.Sign(ctx, envelopeXDR, networkPassphrase)
 }
 
-// ValidateSigner checks that a Signer reports a well-formed account address.
+// ValidateSigner checks that a Signer reports a valid Stellar account address.
 func ValidateSigner(s Signer) error {
 	if s == nil {
 		return ErrNoSigner
@@ -52,26 +51,20 @@ func ValidateSigner(s Signer) error {
 	return nil
 }
 
-// IsAccountAddress reports whether addr looks like a Stellar account strkey:
-// 56 characters beginning with G.
+// IsAccountAddress reports whether addr is a valid Stellar account strkey.
+//
+// Validation is delegated to DecodeStrkey so the helper verifies the version
+// byte, base32 encoding, payload length, and CRC16-XModem checksum.
 func IsAccountAddress(addr string) bool {
-	return len(addr) == 56 && strings.HasPrefix(addr, "G") && isBase32Upper(addr)
+	_, kind, err := DecodeStrkey(addr)
+	return err == nil && kind == StrkeyAccount
 }
 
-// IsContractAddress reports whether addr looks like a Soroban contract strkey:
-// 56 characters beginning with C.
+// IsContractAddress reports whether addr is a valid Soroban contract strkey.
+//
+// Validation is delegated to DecodeStrkey so the helper verifies the version
+// byte, base32 encoding, payload length, and CRC16-XModem checksum.
 func IsContractAddress(addr string) bool {
-	return len(addr) == 56 && strings.HasPrefix(addr, "C") && isBase32Upper(addr)
-}
-
-func isBase32Upper(s string) bool {
-	for _, r := range s {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= '2' && r <= '7':
-		default:
-			return false
-		}
-	}
-	return true
+	_, kind, err := DecodeStrkey(addr)
+	return err == nil && kind == StrkeyContract
 }

--- a/packages/go-sdk/signer_test.go
+++ b/packages/go-sdk/signer_test.go
@@ -1,0 +1,115 @@
+package gosdk
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func corruptStrkey(addr string) string {
+	corrupt := []byte(addr)
+	if corrupt[10] == 'A' {
+		corrupt[10] = 'B'
+	} else {
+		corrupt[10] = 'A'
+	}
+	return string(corrupt)
+}
+
+func TestIsAccountAddressRejectsCorruptedChecksum(t *testing.T) {
+	corrupt := corruptStrkey(zeroAccount)
+
+	if IsAccountAddress(corrupt) {
+		t.Fatalf("checksum-corrupted account address %q must be rejected", corrupt)
+	}
+}
+
+func TestIsContractAddressRejectsCorruptedChecksum(t *testing.T) {
+	corrupt := corruptStrkey(zeroContract)
+
+	if IsContractAddress(corrupt) {
+		t.Fatalf("checksum-corrupted contract address %q must be rejected", corrupt)
+	}
+}
+
+func TestAddressHelpersAcceptValidAddresses(t *testing.T) {
+	if !IsAccountAddress(zeroAccount) {
+		t.Fatalf("zeroAccount should be accepted as a valid account address")
+	}
+
+	if IsContractAddress(zeroAccount) {
+		t.Fatalf("zeroAccount must not be accepted as a contract address")
+	}
+
+	if !IsContractAddress(zeroContract) {
+		t.Fatalf("zeroContract should be accepted as a valid contract address")
+	}
+
+	if IsAccountAddress(zeroContract) {
+		t.Fatalf("zeroContract must not be accepted as an account address")
+	}
+}
+
+func TestNewClientRejectsChecksumCorruptedSourceAccount(t *testing.T) {
+	corrupt := corruptStrkey(zeroAccount)
+
+	client, err := NewClient(Config{
+		RPCURL:            "http://localhost:8000",
+		NetworkPassphrase: NetworkTestnet,
+		SourceAccount:     corrupt,
+	})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig, got %v", err)
+	}
+	if client != nil {
+		t.Fatal("NewClient must not return a client for a checksum-corrupted source account")
+	}
+}
+
+func TestValidateSignerRejectsChecksumCorruptedAddress(t *testing.T) {
+	corrupt := corruptStrkey(zeroAccount)
+
+	signer := SignerFunc{
+		Addr: corrupt,
+		Sign: func(ctx context.Context, envelopeXDR string, networkPassphrase string) (string, error) {
+			return envelopeXDR, nil
+		},
+	}
+
+	err := ValidateSigner(signer)
+	if !errors.Is(err, ErrSignerAddress) {
+		t.Fatalf("expected ErrSignerAddress, got %v", err)
+	}
+}
+
+func TestSharesOfRejectsChecksumCorruptedProviderBeforeRPC(t *testing.T) {
+	corrupt := corruptStrkey(zeroAccount)
+
+	client, err := NewClient(Config{
+		RPCURL:            "http://localhost:8000",
+		NetworkPassphrase: NetworkTestnet,
+		SourceAccount:     zeroAccount,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	client.WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("SharesOf must reject the provider before making an HTTP request")
+			return nil, nil
+		}),
+	})
+
+	_, err = client.SharesOf(context.Background(), zeroContract, corrupt)
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig, got %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
# feat(sdk): harden Go SDK validation and errors and make Android SDK buildable

## Summary

This PR consolidates fixes across the Go and Android SDKs in `soroban-amm`.

It:

* strengthens Stellar/Soroban address validation by using the existing checksum-verifying `DecodeStrkey` implementation;
* adds typed Go SDK error sentinels for all 20 deployed `AmmError` discriminants;
* adds regression coverage for checksum validation and contract error decoding;
* makes the Android SDK a standalone buildable Gradle library;
* adds the missing Android manifest and build configuration;
* documents the Android SDK API, build requirements, usage, and current stub status.

## Issues addressed

* Closes #839 — `go-sdk`: make `IsAccountAddress` / `IsContractAddress` validate strkey checksums
* Closes #838 — `go-sdk`: decode all 20 deployed `AmmError` variants
* Closes #836 — `android-sdk`: add the missing Gradle/Android module configuration
* Closes #837 — `android-sdk`: add SDK usage documentation and examples

## Changes

### Go SDK — address validation

Updated `packages/go-sdk/signer.go` so:

* `IsAccountAddress` delegates to `DecodeStrkey`;
* `IsContractAddress` delegates to `DecodeStrkey`;
* the expected `StrkeyKind` is checked;
* malformed and checksum-corrupted addresses now return `false`;
* the duplicate checksum-free `isBase32Upper` validation path has been removed.

This causes invalid addresses to fail earlier through existing `NewClient`, `ValidateSigner`, and `SharesOf` validation paths.

### Go SDK — contract errors

Updated `packages/go-sdk/errors.go` with the five missing AMM error sentinels:

* `ErrFotSlippage` — discriminant `16`
* `ErrOracleDeviationExceeded` — discriminant `17`
* `ErrFlashLoanRepaymentFailed` — discriminant `18`
* `ErrAlreadyExecuted` — discriminant `19`
* `ErrProposalExpired` — discriminant `20`

`ammErrorsByCode` now covers all 20 `AmmError` discriminants.

### Go SDK — tests

Added:

* checksum-corruption tests for account and contract addresses;
* valid-address regression coverage;
* `NewClient` source-account validation coverage;
* `ValidateSigner` checksum validation coverage;
* `SharesOf` validation coverage proving no HTTP request is made for a malformed provider;
* table-driven coverage for all 20 contract error discriminants;
* explicit tests for the five newly supported error codes;
* unknown error-code coverage;
* malformed/non-contract RPC error coverage;
* AMM error-map completeness coverage.

### Android SDK — build configuration

Converted `packages/android-sdk` into a standalone Gradle Android library.

Added:

* `settings.gradle.kts`;
* applied Android Library and Kotlin Android plugins;
* Android namespace;
* compile/min SDK configuration;
* Java/Kotlin 17 compatibility;
* library group/version metadata;
* coroutine dependency required by the suspend API;
* minimal Android library manifest.

The module can now be built independently with:

```bash
cd packages/android-sdk
gradle assembleDebug
```

### Android SDK — documentation

Expanded the README with:

* build prerequisites;
* standalone Gradle build instructions;
* `AmClient` construction example;
* swap transaction example;
* coroutine-based submission example;
* constructor and method parameter documentation;
* `TxResult.txHash` documentation;
* explicit disclosure that transaction building/submission are currently stubs;
* reference to #726 for the implementation work;
* local module dependency guidance.

## Testing

### Go SDK

```bash
cd packages/go-sdk
go test ./...
```

### Android SDK

```bash
cd packages/android-sdk
gradle assembleDebug
```

The Android build verification covers the module's Gradle configuration and confirms that `AmClient.kt` remains compilable without implementing the transaction-building or submission stubs tracked by #726.

## Scope

This PR intentionally does not:

* modify `DecodeStrkey`, `EncodeStrkey`, or `crc16XModem`;
* introduce an external Stellar strkey dependency;
* implement `AmClient.buildSwapTransaction`;
* implement `AmClient.submitSignedTransaction`;
* add the Android SDK to GitHub Actions CI;
* configure Maven Central publishing credentials or signing.

Those remain separate concerns and can be addressed independently.

## Result

The Go SDK now performs checksum-aware address validation and provides typed handling for every deployed AMM contract error.

The Android SDK now has a complete standalone Gradle module structure and documentation without making claims about transaction functionality that has not yet been implemented.

Closes #836
Closes #837
Closes #838
Closes #839




