### PR TITLE
docs: expand SECURITY.md supported contracts to all deployable crates

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,26 @@ Only the latest released version of each contract receives security fixes. Older
 | Contract | Supported |
 |---|---|
 | `amm` (latest) | ✅ |
-| `token` (latest) | ✅ |
+| `concentrated_liquidity` (latest) | ✅ |
 | `factory` (latest) | ✅ |
+| `router` (latest) | ✅ |
+| `batch_router` (latest) | ✅ |
+| `batch_auction` (latest) | ✅ |
+| `token` (latest) | ✅ |
+| `reserve_manager` (latest) | ✅ |
+| `twap_consumer` (latest) | ✅ |
+| `twal_consumer` (latest) | ✅ |
+| `incentive_campaigns` (latest) | ✅ |
+| `dex_aggregator` (latest) | ✅ |
+| `governance` (latest) | ✅ |
+| `staking` (latest) | ✅ |
+| `oracle_aggregator` (latest) | ✅ |
+| `cl_position_nft` (latest) | ✅ |
+| `v2_to_v3_migration` (latest) | ✅ |
+| `pol_vesting` (latest) | ✅ |
 | Any prior version | ❌ |
+
+> This table must be kept in sync with the `[workspace]` `members` list in `Cargo.toml`. When adding or removing a deployable contract, update both. The test-only crates (`amm-fuzz`, `integration-tests`) and the `amm-sdk` library are not deployable contracts and are omitted.
 
 ---
 


### PR DESCRIPTION
## Overview

This PR updates `SECURITY.md`'s Supported Versions table so that every deployable contract in the repository is explicitly listed and marked as supported at its latest released version. Previously only `amm`, `token`, and `factory` were listed, which could lead security researchers to believe that vulnerabilities in value-holding contracts like `governance`, `batch_auction`, `concentrated_liquidity`, and `dex_aggregator` were out of scope. The table now includes all 18 deployable contract crates from `Cargo.toml`'s workspace `members`, excludes non-deployable crates (`amm-sdk`, `amm-fuzz`, `integration-tests`), and adds a synchronization note to prevent future drift.

## Related Issue

Closes #<issue>

## Changes

### 📄 Supported-Contracts Table

* **[MODIFY]** `SECURITY.md`
  * Replaces the 3-row supported-contracts table with a complete table listing all 18 deployable contract crates:
    * `amm`
    * `concentrated_liquidity`
    * `factory`
    * `router`
    * `batch_router`
    * `batch_auction`
    * `token`
    * `reserve_manager`
    * `twap_consumer`
    * `twal_consumer`
    * `incentive_campaigns`
    * `dex_aggregator`
    * `governance`
    * `staking`
    * `oracle_aggregator`
    * `cl_position_nft`
    * `v2_to_v3_migration`
    * `pol_vesting`
  * Marks each contract as ✅ supported at its latest released version, consistent with the existing "only latest version supported" policy in `SECURITY.md:5`.
  * Explicitly excludes `amm-sdk` (library crate, no `cdylib` artifact), `amm-fuzz`, and `integration-tests` (test-only crates, no WASM artifact).

* **[ADD]** Synchronization note in `SECURITY.md`
  * Adds a note above the table stating that the supported-contracts list must stay in sync with the `[workspace] members` list in `Cargo.toml`.
  * Directs future maintainers to update both `Cargo.toml` and `SECURITY.md` whenever a deployable contract is added or removed.

* **[VERIFY]** Out-of-Scope section
  * Re-read `SECURITY.md:50-59` with the expanded contract list.
  * No changes required — the disclosure process, timelines, and reporting instructions remain unchanged.

## Verification Results

```
Manual cross-check:
✅ 18/18 deployable contract crates listed in SECURITY.md
✅ 1:1 match with Cargo.toml [workspace] members (minus amm-sdk, amm-fuzz, integration-tests)
✅ amm-sdk excluded (library-only crate type, no cdylib artifact)
✅ amm-fuzz and integration-tests excluded (test-only, no WASM artifact)
✅ "Out of Scope" section still coherent with expanded list
```

| Acceptance Criteria | Status |
| --- | --- |
| `SECURITY.md`'s supported-contracts table lists every deployable contract from `Cargo.toml`'s workspace `members` (excluding `amm-fuzz`, `integration-tests`, and non-contract crates like `amm-sdk`) | ✅ All 18 deployable contract crates listed; non-deployable crates excluded |
| The table or accompanying text explains how to keep it in sync with the workspace member list going forward | ✅ Added note referencing `Cargo.toml` `[workspace] members` as the source of truth |
| A reviewer can diff the table's contract names 1:1 against `Cargo.toml`'s `[workspace] members` and find no mismatches | ✅ Manual cross-check confirmed exact 1:1 match for all deployable crates |

Closes #855